### PR TITLE
feat: CPA multi-pool integration & stability fixes

### DIFF
--- a/services/api.py
+++ b/services/api.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, Field
 from services.account_service import account_service
 from services.config import config
 from services.backend_service import BackendService
+from services.cpa_service import cpa_service, cpa_config, fetch_tokens_for_pool, fetch_pool_status
 from services.image_service import ImageGenerationError
 from services.version import get_app_version
 
@@ -46,6 +47,25 @@ class AccountUpdateRequest(BaseModel):
     type: str | None = None
     status: str | None = None
     quota: int | None = None
+
+
+class CPAConfigUpdateRequest(BaseModel):
+    base_url: str | None = None
+    secret_key: str | None = None
+
+
+class CPAPoolCreateRequest(BaseModel):
+    name: str = ""
+    base_url: str = ""
+    secret_key: str = ""
+    enabled: bool = True
+
+
+class CPAPoolUpdateRequest(BaseModel):
+    name: str | None = None
+    base_url: str | None = None
+    secret_key: str | None = None
+    enabled: bool | None = None
 
 
 def build_model_item(model_id: str) -> dict[str, object]:
@@ -245,6 +265,98 @@ def create_app() -> FastAPI:
         except ImageGenerationError as exc:
             raise HTTPException(status_code=502, detail={"error": str(exc)}) from exc
 
+    # ── CPA multi-pool endpoints ────────────────────────────────────
+
+    @router.get("/api/cpa/pools")
+    async def list_cpa_pools(authorization: str | None = Header(default=None)):
+        require_auth_key(authorization)
+        return {"pools": cpa_config.list_pools()}
+
+    @router.post("/api/cpa/pools")
+    async def create_cpa_pool(
+            body: CPAPoolCreateRequest,
+            authorization: str | None = Header(default=None),
+    ):
+        require_auth_key(authorization)
+        if not body.base_url.strip():
+            raise HTTPException(status_code=400, detail={"error": "base_url is required"})
+        if not body.secret_key.strip():
+            raise HTTPException(status_code=400, detail={"error": "secret_key is required"})
+        pool = cpa_config.add_pool(
+            name=body.name,
+            base_url=body.base_url,
+            secret_key=body.secret_key,
+            enabled=body.enabled,
+        )
+        cpa_service.invalidate_cache()
+        return {"pool": pool, "pools": cpa_config.list_pools()}
+
+    @router.post("/api/cpa/pools/{pool_id}")
+    async def update_cpa_pool(
+            pool_id: str,
+            body: CPAPoolUpdateRequest,
+            authorization: str | None = Header(default=None),
+    ):
+        require_auth_key(authorization)
+        pool = cpa_config.update_pool(pool_id, body.model_dump(exclude_none=True))
+        if pool is None:
+            raise HTTPException(status_code=404, detail={"error": "pool not found"})
+        cpa_service.invalidate_cache()
+        return {"pool": pool, "pools": cpa_config.list_pools()}
+
+    @router.delete("/api/cpa/pools/{pool_id}")
+    async def delete_cpa_pool(
+            pool_id: str,
+            authorization: str | None = Header(default=None),
+    ):
+        require_auth_key(authorization)
+        if not cpa_config.delete_pool(pool_id):
+            raise HTTPException(status_code=404, detail={"error": "pool not found"})
+        cpa_service.invalidate_cache()
+        return {"pools": cpa_config.list_pools()}
+
+    @router.get("/api/cpa/pools/{pool_id}/status")
+    async def cpa_pool_status(
+            pool_id: str,
+            authorization: str | None = Header(default=None),
+    ):
+        require_auth_key(authorization)
+        pool = cpa_config.get_pool(pool_id)
+        if pool is None:
+            raise HTTPException(status_code=404, detail={"error": "pool not found"})
+        result = await run_in_threadpool(fetch_pool_status, pool)
+        return result
+
+    @router.post("/api/cpa/pools/{pool_id}/sync")
+    async def cpa_pool_sync(
+            pool_id: str,
+            authorization: str | None = Header(default=None),
+    ):
+        """Pull tokens from a specific CPA pool and import into local account pool."""
+        require_auth_key(authorization)
+        pool = cpa_config.get_pool(pool_id)
+        if pool is None:
+            raise HTTPException(status_code=404, detail={"error": "pool not found"})
+        tokens = await run_in_threadpool(fetch_tokens_for_pool, pool)
+        if not tokens:
+            raise HTTPException(status_code=502, detail={"error": "No tokens returned from CPA"})
+        result = account_service.add_accounts(tokens)
+        refresh_result = account_service.refresh_accounts(tokens)
+        return {
+            **result,
+            "refreshed": refresh_result.get("refreshed", 0),
+            "errors": refresh_result.get("errors", []),
+            "items": refresh_result.get("items", result.get("items", [])),
+        }
+
+    @router.get("/api/cpa/status")
+    async def cpa_global_status(authorization: str | None = Header(default=None)):
+        require_auth_key(authorization)
+        if not cpa_config.has_usable:
+            return {"enabled": False, "pools": 0, "tokens": 0}
+        tokens = await run_in_threadpool(cpa_service.fetch_all_tokens)
+        return {"enabled": True, "pools": len(cpa_config.usable_pools()), "tokens": len(tokens)}
+
     app.include_router(router)
 
     @app.get("/{full_path:path}", include_in_schema=False)
@@ -252,6 +364,10 @@ def create_app() -> FastAPI:
         asset = resolve_web_asset(full_path)
         if asset is not None:
             return FileResponse(asset)
+
+        # Static assets (_next/*) must not fallback to HTML — return 404
+        if full_path.strip("/").startswith("_next/"):
+            raise HTTPException(status_code=404, detail="Not Found")
 
         fallback = resolve_web_asset("")
         if fallback is None:

--- a/services/backend_service.py
+++ b/services/backend_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from fastapi import HTTPException
 
 from services.account_service import AccountService
+from services.cpa_service import cpa_service
 from services.image_service import ImageGenerationError, generate_image_result, is_token_invalid_error
 
 
@@ -42,6 +43,45 @@ class BackendService:
             raise HTTPException(status_code=503, detail={"error": str(exc)}) from exc
 
     def generate_with_pool(self, prompt: str, model: str, n: int):
+        if cpa_service.enabled:
+            return self._generate_with_cpa(prompt, model, n)
+        return self._generate_with_local_pool(prompt, model, n)
+
+    def _generate_with_cpa(self, prompt: str, model: str, n: int):
+        """Fetch token from CLIProxyAPI on-the-fly and generate images."""
+        attempted_tokens: set[str] = set()
+        max_attempts = 5
+
+        for attempt in range(max_attempts):
+            request_token = cpa_service.get_token(excluded_tokens=attempted_tokens)
+            if not request_token:
+                if attempt == 0:
+                    raise HTTPException(
+                        status_code=503,
+                        detail={"error": "No access_token available from CPA"},
+                    )
+                break
+            attempted_tokens.add(request_token)
+            print(f"[image-generate] cpa token={request_token[:12]}... model={model} n={n}")
+
+            try:
+                result = generate_image_result(request_token, prompt, model, n)
+                print(f"[image-generate] cpa success token={request_token[:12]}...")
+                return result
+            except ImageGenerationError as exc:
+                print(f"[image-generate] cpa fail token={request_token[:12]}... error={exc}")
+                if is_token_invalid_error(str(exc)):
+                    cpa_service.invalidate_cache()
+                    continue
+                raise
+
+        raise HTTPException(
+            status_code=503,
+            detail={"error": "All CPA tokens exhausted or failed"},
+        )
+
+    def _generate_with_local_pool(self, prompt: str, model: str, n: int):
+        """Original local account pool logic."""
         attempted_tokens: set[str] = set()
 
         while True:

--- a/services/cpa_service.py
+++ b/services/cpa_service.py
@@ -1,0 +1,341 @@
+"""CLIProxyAPI integration — fetch access_tokens from multiple remote CPA instances."""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from threading import Lock
+from typing import Any
+
+from curl_cffi.requests import Session
+
+from services.config import config, DATA_DIR
+
+
+CPA_CONFIG_FILE = DATA_DIR / "cpa_config.json"
+
+
+# ── Pool entry type ──────────────────────────────────────────────────
+
+def _new_pool_id() -> str:
+    return uuid.uuid4().hex[:12]
+
+
+def _normalize_pool(raw: dict) -> dict:
+    return {
+        "id": str(raw.get("id") or _new_pool_id()).strip(),
+        "name": str(raw.get("name") or "").strip(),
+        "base_url": str(raw.get("base_url") or "").strip(),
+        "secret_key": str(raw.get("secret_key") or "").strip(),
+        "enabled": bool(raw.get("enabled", True)),
+    }
+
+
+def _is_pool_usable(pool: dict) -> bool:
+    return bool(pool.get("enabled") and pool.get("base_url") and pool.get("secret_key"))
+
+
+# ── Persisted multi-pool config ─────────────────────────────────────
+
+class CPAConfig:
+    """Manages a list of CPA pool entries persisted to ``cpa_config.json``."""
+
+    def __init__(self, store_file: Path):
+        self._store_file = store_file
+        self._lock = Lock()
+        self._pools: list[dict] = self._load()
+
+    # -- persistence ---------------------------------------------------
+
+    def _load(self) -> list[dict]:
+        if not self._store_file.exists():
+            return []
+        try:
+            raw = json.loads(self._store_file.read_text(encoding="utf-8"))
+            # Migrate from old single-pool format
+            if isinstance(raw, dict) and "base_url" in raw:
+                pool = _normalize_pool(raw)
+                if pool["base_url"]:
+                    return [pool]
+                return []
+            if isinstance(raw, list):
+                return [_normalize_pool(item) for item in raw if isinstance(item, dict)]
+        except Exception:
+            pass
+        return []
+
+    def _save(self) -> None:
+        self._store_file.parent.mkdir(parents=True, exist_ok=True)
+        self._store_file.write_text(
+            json.dumps(self._pools, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+    # -- public API ----------------------------------------------------
+
+    def list_pools(self) -> list[dict]:
+        with self._lock:
+            return [dict(p) for p in self._pools]
+
+    def get_pool(self, pool_id: str) -> dict | None:
+        with self._lock:
+            for p in self._pools:
+                if p["id"] == pool_id:
+                    return dict(p)
+        return None
+
+    def add_pool(self, name: str, base_url: str, secret_key: str, enabled: bool = True) -> dict:
+        pool = _normalize_pool({
+            "id": _new_pool_id(),
+            "name": name,
+            "base_url": base_url,
+            "secret_key": secret_key,
+            "enabled": enabled,
+        })
+        with self._lock:
+            self._pools.append(pool)
+            self._save()
+        return dict(pool)
+
+    def update_pool(self, pool_id: str, updates: dict) -> dict | None:
+        with self._lock:
+            for i, p in enumerate(self._pools):
+                if p["id"] == pool_id:
+                    merged = {**p, **{k: v for k, v in updates.items() if v is not None}, "id": pool_id}
+                    self._pools[i] = _normalize_pool(merged)
+                    self._save()
+                    return dict(self._pools[i])
+        return None
+
+    def delete_pool(self, pool_id: str) -> bool:
+        with self._lock:
+            before = len(self._pools)
+            self._pools = [p for p in self._pools if p["id"] != pool_id]
+            if len(self._pools) < before:
+                self._save()
+                return True
+        return False
+
+    def usable_pools(self) -> list[dict]:
+        with self._lock:
+            return [dict(p) for p in self._pools if _is_pool_usable(p)]
+
+    @property
+    def has_usable(self) -> bool:
+        with self._lock:
+            return any(_is_pool_usable(p) for p in self._pools)
+
+
+# ── CPA fetcher (per-pool) ──────────────────────────────────────────
+
+def _management_headers(secret_key: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {secret_key}",
+        "Accept": "application/json",
+    }
+
+
+def _extract_access_token(auth_file: dict[str, Any]) -> str | None:
+    for key in ("access_token", "token", "accessToken", "access-token"):
+        value = str(auth_file.get(key) or "").strip()
+        if value:
+            return value
+    for wrapper_key in ("data", "content", "credential", "auth", "credentials"):
+        nested = auth_file.get(wrapper_key)
+        if isinstance(nested, dict):
+            for key in ("access_token", "token", "accessToken", "access-token"):
+                value = str(nested.get(key) or "").strip()
+                if value:
+                    return value
+    for value in auth_file.values():
+        if isinstance(value, str) and value.strip().startswith("eyJ") and len(value.strip()) > 100:
+            return value.strip()
+    return None
+
+
+def _resolve_file_list(payload: Any) -> list[dict]:
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)]
+    if isinstance(payload, dict):
+        for key in ("files", "auth_files", "auth-files", "data", "items"):
+            candidate = payload.get(key)
+            if isinstance(candidate, list):
+                return [item for item in candidate if isinstance(item, dict)]
+        return [payload]
+    return []
+
+
+def _fetch_file_detail(session: Session, base_url: str, secret_key: str, file_name: str) -> dict | None:
+    url = f"{base_url.rstrip('/')}/v0/management/auth-files/download"
+    try:
+        response = session.get(url, headers=_management_headers(secret_key), params={"name": file_name}, timeout=15)
+        if not response.ok:
+            return None
+        data = response.json()
+        return data if isinstance(data, dict) else None
+    except Exception:
+        return None
+
+
+def fetch_tokens_for_pool(pool: dict) -> list[str]:
+    """Fetch all access_tokens from a single CPA pool."""
+    base_url = pool.get("base_url") or ""
+    secret_key = pool.get("secret_key") or ""
+    if not base_url or not secret_key:
+        return []
+
+    pool_name = pool.get("name") or pool.get("id") or "?"
+    url = f"{base_url.rstrip('/')}/v0/management/auth-files"
+    print(f"[cpa-service] [{pool_name}] fetching from {url}")
+
+    session = Session(verify=config.tls_verify)
+    try:
+        response = session.get(url, headers=_management_headers(secret_key), timeout=30)
+        if not response.ok:
+            print(f"[cpa-service] [{pool_name}] HTTP {response.status_code}")
+            return []
+        payload = response.json()
+    except Exception as exc:
+        print(f"[cpa-service] [{pool_name}] error: {exc}")
+        return []
+
+    file_entries = _resolve_file_list(payload)
+    active_entries = [
+        e for e in file_entries
+        if not e.get("disabled") and not e.get("unavailable")
+        and e.get("status") in (None, "", "active")
+        and e.get("type") in (None, "", "codex")
+    ]
+    print(f"[cpa-service] [{pool_name}] {len(active_entries)} active codex entries")
+
+    tokens: list[str] = []
+    seen: set[str] = set()
+    need_download: list[dict] = []
+
+    for entry in active_entries:
+        token = _extract_access_token(entry)
+        if token and token not in seen:
+            seen.add(token)
+            tokens.append(token)
+        else:
+            need_download.append(entry)
+
+    if need_download:
+        max_workers = min(10, len(need_download))
+        try:
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                future_map = {}
+                for entry in need_download:
+                    file_name = str(entry.get("name") or entry.get("id") or "").strip()
+                    if not file_name:
+                        continue
+                    future = executor.submit(_fetch_file_detail, session, base_url, secret_key, file_name)
+                    future_map[future] = file_name
+
+                for future in as_completed(future_map):
+                    detail = future.result()
+                    if detail is None:
+                        continue
+                    content = detail.get("content")
+                    if isinstance(content, str):
+                        try:
+                            parsed = json.loads(content)
+                            if isinstance(parsed, dict):
+                                detail = {**detail, **parsed}
+                        except Exception:
+                            pass
+                    token = _extract_access_token(detail)
+                    if token and token not in seen:
+                        seen.add(token)
+                        tokens.append(token)
+        except Exception as exc:
+            print(f"[cpa-service] [{pool_name}] concurrent fetch error: {exc}")
+
+    session.close()
+    print(f"[cpa-service] [{pool_name}] extracted {len(tokens)} token(s)")
+    return tokens
+
+
+def fetch_pool_status(pool: dict) -> dict:
+    """Test a single pool and return status info."""
+    tokens = fetch_tokens_for_pool(pool)
+    return {"pool_id": pool["id"], "tokens": len(tokens)}
+
+
+# ── Aggregated CPA service ──────────────────────────────────────────
+
+class CPAService:
+    """Aggregates tokens from all usable CPA pools with caching."""
+
+    def __init__(self, cpa_config: CPAConfig):
+        self._config = cpa_config
+        self._lock = Lock()
+        self._tokens: list[str] = []
+        self._index = 0
+        self._last_refresh: float = 0
+        self._cache_ttl = 300
+
+    @property
+    def enabled(self) -> bool:
+        return self._config.has_usable
+
+    def fetch_all_tokens(self) -> list[str]:
+        """Fetch tokens from all usable pools concurrently."""
+        pools = self._config.usable_pools()
+        if not pools:
+            return []
+
+        all_tokens: list[str] = []
+        seen: set[str] = set()
+
+        max_workers = min(5, len(pools))
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            future_map = {executor.submit(fetch_tokens_for_pool, pool): pool for pool in pools}
+            for future in as_completed(future_map):
+                try:
+                    tokens = future.result()
+                    for token in tokens:
+                        if token not in seen:
+                            seen.add(token)
+                            all_tokens.append(token)
+                except Exception as exc:
+                    pool = future_map[future]
+                    print(f"[cpa-service] pool {pool.get('name', pool.get('id'))} error: {exc}")
+
+        print(f"[cpa-service] total {len(all_tokens)} token(s) from {len(pools)} pool(s)")
+        return all_tokens
+
+    def get_token(self, excluded_tokens: set[str] | None = None) -> str | None:
+        with self._lock:
+            now = time.time()
+            if not self._tokens or (now - self._last_refresh) > self._cache_ttl:
+                self._tokens = self.fetch_all_tokens()
+                self._last_refresh = now
+                if self._tokens:
+                    self._index = 0
+
+            excluded = {t for t in (excluded_tokens or set()) if t}
+            available = [t for t in self._tokens if t not in excluded]
+            if not available:
+                return None
+
+            token = available[self._index % len(available)]
+            self._index += 1
+            return token
+
+    def invalidate_cache(self) -> None:
+        with self._lock:
+            self._last_refresh = 0
+
+
+# ── Singletons ──────────────────────────────────────────────────────
+
+cpa_config = CPAConfig(CPA_CONFIG_FILE)
+cpa_service = CPAService(cpa_config)
+
+if cpa_config.has_usable:
+    pools = cpa_config.usable_pools()
+    print(f"[cpa-service] {len(pools)} usable pool(s) configured")

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
     output: 'export',
+    trailingSlash: true,
     images: {
         unoptimized: true,
     },

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -1,0 +1,467 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  CheckCircle2,
+  Eye,
+  EyeOff,
+  Link2,
+  LoaderCircle,
+  Pencil,
+  Plus,
+  Power,
+  PowerOff,
+  RefreshCw,
+  Save,
+  ServerCog,
+  Trash2,
+  Unplug,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+  createCPAPool,
+  deleteCPAPool,
+  fetchCPAPoolStatus,
+  fetchCPAPools,
+  syncCPAPool,
+  updateCPAPool,
+  type CPAPool,
+} from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+type PoolStatus = { pool_id: string; tokens: number };
+
+export default function SettingsPage() {
+  const didLoadRef = useRef(false);
+  const [pools, setPools] = useState<CPAPool[]>([]);
+  const [poolStatuses, setPoolStatuses] = useState<Record<string, PoolStatus>>({});
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Dialog state
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingPool, setEditingPool] = useState<CPAPool | null>(null);
+  const [formName, setFormName] = useState("");
+  const [formBaseUrl, setFormBaseUrl] = useState("");
+  const [formSecretKey, setFormSecretKey] = useState("");
+  const [showSecret, setShowSecret] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  // Per-pool loading states
+  const [testingId, setTestingId] = useState<string | null>(null);
+  const [syncingId, setSyncingId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [togglingId, setTogglingId] = useState<string | null>(null);
+
+  const loadPools = async () => {
+    setIsLoading(true);
+    try {
+      const data = await fetchCPAPools();
+      setPools(data.pools);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "加载 CPA 配置失败");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (didLoadRef.current) return;
+    didLoadRef.current = true;
+    void loadPools();
+  }, []);
+
+  const openAddDialog = () => {
+    setEditingPool(null);
+    setFormName("");
+    setFormBaseUrl("");
+    setFormSecretKey("");
+    setShowSecret(false);
+    setDialogOpen(true);
+  };
+
+  const openEditDialog = (pool: CPAPool) => {
+    setEditingPool(pool);
+    setFormName(pool.name);
+    setFormBaseUrl(pool.base_url);
+    setFormSecretKey(pool.secret_key);
+    setShowSecret(false);
+    setDialogOpen(true);
+  };
+
+  const handleSave = async () => {
+    if (!formBaseUrl.trim()) {
+      toast.error("请输入 CPA 地址");
+      return;
+    }
+    if (!formSecretKey.trim()) {
+      toast.error("请输入 Secret Key");
+      return;
+    }
+    setIsSaving(true);
+    try {
+      if (editingPool) {
+        const data = await updateCPAPool(editingPool.id, {
+          name: formName.trim(),
+          base_url: formBaseUrl.trim(),
+          secret_key: formSecretKey.trim(),
+        });
+        setPools(data.pools);
+        toast.success("号池已更新");
+      } else {
+        const data = await createCPAPool({
+          name: formName.trim(),
+          base_url: formBaseUrl.trim(),
+          secret_key: formSecretKey.trim(),
+        });
+        setPools(data.pools);
+        toast.success("号池已添加");
+      }
+      setDialogOpen(false);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "保存失败");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleToggle = async (pool: CPAPool) => {
+    setTogglingId(pool.id);
+    try {
+      const data = await updateCPAPool(pool.id, { enabled: !pool.enabled });
+      setPools(data.pools);
+      toast.success(pool.enabled ? "已禁用" : "已启用");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "操作失败");
+    } finally {
+      setTogglingId(null);
+    }
+  };
+
+  const handleDelete = async (pool: CPAPool) => {
+    setDeletingId(pool.id);
+    try {
+      const data = await deleteCPAPool(pool.id);
+      setPools(data.pools);
+      toast.success("号池已删除");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "删除失败");
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const handleTest = async (pool: CPAPool) => {
+    setTestingId(pool.id);
+    try {
+      const result = await fetchCPAPoolStatus(pool.id);
+      setPoolStatuses((prev) => ({ ...prev, [pool.id]: result }));
+      if (result.tokens > 0) {
+        toast.success(`连接成功，获取到 ${result.tokens} 个 token`);
+      } else {
+        toast.warning("连接成功，但未获取到 token");
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "连接测试失败");
+    } finally {
+      setTestingId(null);
+    }
+  };
+
+  const handleSync = async (pool: CPAPool) => {
+    setSyncingId(pool.id);
+    try {
+      const result = await syncCPAPool(pool.id);
+      if ((result.errors?.length ?? 0) > 0) {
+        toast.warning(
+          `同步完成：新增 ${result.added}，刷新 ${result.refreshed}，失败 ${result.errors.length}`,
+        );
+      } else {
+        toast.success(`同步完成：新增 ${result.added}，跳过 ${result.skipped}，刷新 ${result.refreshed}`);
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "同步失败");
+    } finally {
+      setSyncingId(null);
+    }
+  };
+
+  const enabledCount = pools.filter((p) => p.enabled).length;
+
+  return (
+    <>
+      <section className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="space-y-1">
+          <div className="text-xs font-semibold tracking-[0.18em] text-stone-500 uppercase">Settings</div>
+          <h1 className="text-2xl font-semibold tracking-tight">设置</h1>
+        </div>
+      </section>
+
+      <section className="space-y-6">
+        <Card className="rounded-2xl border-white/80 bg-white/90 shadow-sm">
+          <CardContent className="space-y-6 p-6">
+            <div className="flex items-start justify-between">
+              <div className="flex items-center gap-3">
+                <div className="flex size-10 items-center justify-center rounded-xl bg-stone-100">
+                  <ServerCog className="size-5 text-stone-600" />
+                </div>
+                <div>
+                  <h2 className="text-lg font-semibold tracking-tight">CPA 号池管理</h2>
+                  <p className="text-sm text-stone-500">
+                    连接多个 CLIProxyAPI 实例，自动获取 access_token 用于生图
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                {pools.length > 0 && (
+                  <Badge
+                    variant={enabledCount > 0 ? "success" : "secondary"}
+                    className="rounded-md px-2.5 py-1"
+                  >
+                    {enabledCount}/{pools.length} 启用
+                  </Badge>
+                )}
+                <Button
+                  className="h-9 rounded-xl bg-stone-950 px-4 text-white hover:bg-stone-800"
+                  onClick={openAddDialog}
+                >
+                  <Plus className="size-4" />
+                  添加号池
+                </Button>
+              </div>
+            </div>
+
+            {isLoading ? (
+              <div className="flex items-center justify-center py-10">
+                <LoaderCircle className="size-5 animate-spin text-stone-400" />
+              </div>
+            ) : pools.length === 0 ? (
+              <div className="flex flex-col items-center justify-center gap-3 rounded-xl bg-stone-50 px-6 py-10 text-center">
+                <ServerCog className="size-8 text-stone-300" />
+                <div className="space-y-1">
+                  <p className="text-sm font-medium text-stone-600">暂无 CPA 号池</p>
+                  <p className="text-sm text-stone-400">点击「添加号池」连接你的 CLIProxyAPI 实例</p>
+                </div>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {pools.map((pool) => {
+                  const status = poolStatuses[pool.id];
+                  const isBusy =
+                    testingId === pool.id ||
+                    syncingId === pool.id ||
+                    deletingId === pool.id ||
+                    togglingId === pool.id;
+
+                  return (
+                    <div
+                      key={pool.id}
+                      className={cn(
+                        "flex flex-col gap-3 rounded-xl border px-4 py-3 transition",
+                        pool.enabled
+                          ? "border-stone-200 bg-white"
+                          : "border-stone-100 bg-stone-50 opacity-60",
+                      )}
+                    >
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-3">
+                          <div
+                            className={cn(
+                              "size-2.5 rounded-full",
+                              pool.enabled ? "bg-emerald-500" : "bg-stone-300",
+                            )}
+                          />
+                          <div>
+                            <div className="text-sm font-medium text-stone-800">
+                              {pool.name || pool.base_url}
+                            </div>
+                            {pool.name && (
+                              <div className="text-xs text-stone-400">{pool.base_url}</div>
+                            )}
+                          </div>
+                        </div>
+                        <div className="flex items-center gap-1">
+                          <button
+                            type="button"
+                            className="rounded-lg p-2 text-stone-400 transition hover:bg-stone-100 hover:text-stone-700"
+                            onClick={() => void handleToggle(pool)}
+                            disabled={isBusy}
+                            title={pool.enabled ? "禁用" : "启用"}
+                          >
+                            {togglingId === pool.id ? (
+                              <LoaderCircle className="size-4 animate-spin" />
+                            ) : pool.enabled ? (
+                              <Power className="size-4" />
+                            ) : (
+                              <PowerOff className="size-4" />
+                            )}
+                          </button>
+                          <button
+                            type="button"
+                            className="rounded-lg p-2 text-stone-400 transition hover:bg-stone-100 hover:text-stone-700"
+                            onClick={() => openEditDialog(pool)}
+                            disabled={isBusy}
+                            title="编辑"
+                          >
+                            <Pencil className="size-4" />
+                          </button>
+                          <button
+                            type="button"
+                            className="rounded-lg p-2 text-stone-400 transition hover:bg-rose-50 hover:text-rose-500"
+                            onClick={() => void handleDelete(pool)}
+                            disabled={isBusy}
+                            title="删除"
+                          >
+                            {deletingId === pool.id ? (
+                              <LoaderCircle className="size-4 animate-spin" />
+                            ) : (
+                              <Trash2 className="size-4" />
+                            )}
+                          </button>
+                        </div>
+                      </div>
+
+                      {pool.enabled && (
+                        <div className="flex items-center gap-2">
+                          <Button
+                            variant="outline"
+                            className="h-8 rounded-lg border-stone-200 bg-white px-3 text-xs text-stone-600"
+                            onClick={() => void handleTest(pool)}
+                            disabled={isBusy}
+                          >
+                            {testingId === pool.id ? (
+                              <LoaderCircle className="size-3.5 animate-spin" />
+                            ) : (
+                              <RefreshCw className="size-3.5" />
+                            )}
+                            测试连接
+                          </Button>
+                          <Button
+                            variant="outline"
+                            className="h-8 rounded-lg border-stone-200 bg-white px-3 text-xs text-stone-600"
+                            onClick={() => void handleSync(pool)}
+                            disabled={isBusy}
+                          >
+                            {syncingId === pool.id ? (
+                              <LoaderCircle className="size-3.5 animate-spin" />
+                            ) : (
+                              <RefreshCw className="size-3.5" />
+                            )}
+                            同步到号池
+                          </Button>
+                          {status && (
+                            <span className="text-xs text-stone-400">
+                              可用 Token: {status.tokens}
+                            </span>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+
+            <div className="rounded-xl bg-stone-50 px-4 py-3 text-sm leading-6 text-stone-500">
+              <p className="font-medium text-stone-600">使用说明</p>
+              <ul className="mt-1 list-inside list-disc space-y-0.5">
+                <li>添加多个 CPA 号池后，生图请求会自动从所有启用的号池获取 token</li>
+                <li>也可以点击「同步到号池」将某个 CPA 的 token 导入本地号池管理</li>
+                <li>CPA 需要开启 remote-management 并设置 allow-remote: true</li>
+                <li>同步 token 不会影响 CPA 原有的登录态</li>
+                <li>禁用或删除号池即可停止从该 CPA 获取 token</li>
+              </ul>
+            </div>
+          </CardContent>
+        </Card>
+      </section>
+
+      {/* Add / Edit Dialog */}
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent showCloseButton={false} className="rounded-2xl p-6">
+          <DialogHeader className="gap-2">
+            <DialogTitle>{editingPool ? "编辑号池" : "添加号池"}</DialogTitle>
+            <DialogDescription className="text-sm leading-6">
+              {editingPool ? "修改 CPA 号池的连接信息" : "添加一个新的 CLIProxyAPI 号池"}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-stone-700">名称（可选）</label>
+              <Input
+                value={formName}
+                onChange={(e) => setFormName(e.target.value)}
+                placeholder="例如：主号池、备用池"
+                className="h-11 rounded-xl border-stone-200 bg-white"
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="flex items-center gap-1.5 text-sm font-medium text-stone-700">
+                <Link2 className="size-3.5" />
+                CPA 地址
+              </label>
+              <Input
+                value={formBaseUrl}
+                onChange={(e) => setFormBaseUrl(e.target.value)}
+                placeholder="http://your-cpa-host:8317"
+                className="h-11 rounded-xl border-stone-200 bg-white"
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="flex items-center gap-1.5 text-sm font-medium text-stone-700">
+                <Unplug className="size-3.5" />
+                Management Secret Key
+              </label>
+              <div className="relative">
+                <Input
+                  type={showSecret ? "text" : "password"}
+                  value={formSecretKey}
+                  onChange={(e) => setFormSecretKey(e.target.value)}
+                  placeholder="CPA 管理密钥"
+                  className="h-11 rounded-xl border-stone-200 bg-white pr-10"
+                />
+                <button
+                  type="button"
+                  className="absolute top-1/2 right-3 -translate-y-1/2 text-stone-400 transition hover:text-stone-600"
+                  onClick={() => setShowSecret(!showSecret)}
+                >
+                  {showSecret ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+                </button>
+              </div>
+            </div>
+          </div>
+          <DialogFooter className="pt-2">
+            <Button
+              variant="secondary"
+              className="h-10 rounded-xl bg-stone-100 px-5 text-stone-700 hover:bg-stone-200"
+              onClick={() => setDialogOpen(false)}
+              disabled={isSaving}
+            >
+              取消
+            </Button>
+            <Button
+              className="h-10 rounded-xl bg-stone-950 px-5 text-white hover:bg-stone-800"
+              onClick={() => void handleSave()}
+              disabled={isSaving}
+            >
+              {isSaving ? <LoaderCircle className="size-4 animate-spin" /> : <Save className="size-4" />}
+              {editingPool ? "保存修改" : "添加"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/web/src/components/top-nav.tsx
+++ b/web/src/components/top-nav.tsx
@@ -11,6 +11,7 @@ import { cn } from "@/lib/utils";
 const navItems = [
   { href: "/image", label: "画图" },
   { href: "/accounts", label: "号池管理" },
+  { href: "/settings", label: "设置" },
 ];
 
 export function TopNav() {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -116,3 +116,64 @@ export async function generateImage(prompt: string, model: ImageModel = "gpt-ima
     },
   );
 }
+
+// ── CPA (CLIProxyAPI) ──────────────────────────────────────────────
+
+export type CPAPool = {
+  id: string;
+  name: string;
+  base_url: string;
+  secret_key: string;
+  enabled: boolean;
+};
+
+export type CPAStatus = {
+  enabled: boolean;
+  pools: number;
+  tokens: number;
+};
+
+export async function fetchCPAPools() {
+  return httpRequest<{ pools: CPAPool[] }>("/api/cpa/pools");
+}
+
+export async function createCPAPool(pool: { name: string; base_url: string; secret_key: string; enabled?: boolean }) {
+  return httpRequest<{ pool: CPAPool; pools: CPAPool[] }>("/api/cpa/pools", {
+    method: "POST",
+    body: pool,
+  });
+}
+
+export async function updateCPAPool(
+  poolId: string,
+  updates: { name?: string; base_url?: string; secret_key?: string; enabled?: boolean },
+) {
+  return httpRequest<{ pool: CPAPool; pools: CPAPool[] }>(`/api/cpa/pools/${poolId}`, {
+    method: "POST",
+    body: updates,
+  });
+}
+
+export async function deleteCPAPool(poolId: string) {
+  return httpRequest<{ pools: CPAPool[] }>(`/api/cpa/pools/${poolId}`, {
+    method: "DELETE",
+  });
+}
+
+export async function fetchCPAPoolStatus(poolId: string) {
+  return httpRequest<{ pool_id: string; tokens: number }>(`/api/cpa/pools/${poolId}/status`);
+}
+
+export async function syncCPAPool(poolId: string) {
+  return httpRequest<{
+    added: number;
+    skipped: number;
+    refreshed: number;
+    errors: Array<{ access_token: string; error: string }>;
+    items: Account[];
+  }>(`/api/cpa/pools/${poolId}/sync`, { method: "POST" });
+}
+
+export async function fetchCPAGlobalStatus() {
+  return httpRequest<CPAStatus>("/api/cpa/status");
+}

--- a/web/src/lib/request.ts
+++ b/web/src/lib/request.ts
@@ -30,8 +30,14 @@ request.interceptors.response.use(
         const status = error.response?.status;
         const shouldRedirect = (error.config as RequestConfig | undefined)?.redirectOnUnauthorized !== false;
         if (status === 401 && shouldRedirect && typeof window !== "undefined") {
-            await clearStoredAuthKey();
-            window.location.href = "/login";
+            // Avoid redirect loop — only redirect if not already on /login
+            if (!window.location.pathname.startsWith("/login")) {
+                await clearStoredAuthKey();
+                window.location.replace("/login");
+                // Return a never-resolving promise to prevent further error handling
+                // while the browser navigates away
+                return new Promise(() => {});
+            }
         }
 
         const payload = error.response?.data;


### PR DESCRIPTION
## 功能：CLIProxyAPI (CPA) 多号池集成

支持从外部 CLIProxyAPI 实例自动获取 access_token 用于生图，无需手动维护本地号池。

### 新增功能

- **多号池管理**：支持配置多个 CPA 实例，通过 Web 设置页面添加/编辑/删除/启用/禁用
- **自动获取 Token**：生图时自动从所有启用的 CPA 号池获取 access_token，5 分钟缓存 + 轮询
- **按需同步**：可选将 CPA 的 token 同步到本地号池管理（不影响 CPA 原有登录态）
- **零侵入**：未配置 CPA 时行为与原版完全一致，自动 fallback 到本地号池

### 稳定性修复

- `web/next.config.ts`：添加 `trailingSlash: true`，修复直接访问页面 URL 偶尔 404 的问题
- `services/api.py`：`_next/` 静态资源请求不再 fallback 到 HTML，避免 JS chunk 加载失败导致白屏
- `web/src/lib/request.ts`：修复未登录时 401 跳转导致页面崩溃（"This page couldn't load"）

### 改动文件

| 文件 | 说明 |
|------|------|
| `services/cpa_service.py` | 新增：CPA 多号池配置管理 + Token 获取服务 |
| `services/api.py` | 新增 CPA CRUD API + _next/ 404 保护 |
| `services/backend_service.py` | 生图时优先从 CPA 获取 token |
| `web/src/app/settings/page.tsx` | 新增：设置页面（号池管理 UI） |
| `web/src/components/top-nav.tsx` | 导航栏增加「设置」入口 |
| `web/src/lib/api.ts` | 新增 CPA 相关 API 调用 |
| `web/src/lib/request.ts` | 修复 401 跳转崩溃 |
| `web/next.config.ts` | 添加 trailingSlash 配置 |

### CPA 接口

通过 CLIProxyAPI 的管理 API 获取 token：
1. `GET /v0/management/auth-files` → 获取 auth-file 列表
2. `GET /v0/management/auth-files/download?name={filename}` → 获取文件内容中的 access_token

### 使用方式

登录 Web 面板 → 设置 → 添加号池 → 填入 CPA 地址和 Management Secret Key → 生图自动从 CPA 获取 token
