### PR TITLE
fix(image): 恢复 /v1/images/edits 对 image[] 的兼容

### DIFF
--- a/services/api.py
+++ b/services/api.py
@@ -282,7 +282,8 @@ def create_app() -> FastAPI:
     @router.post("/v1/images/edits")
     async def edit_images(
             authorization: str | None = Header(default=None),
-            image: list[UploadFile] = File(...),
+            image: list[UploadFile] | None = File(default=None),
+            image_list: list[UploadFile] | None = File(default=None, alias="image[]"),
             prompt: str = Form(...),
             model: str = Form(default="gpt-image-1"),
             n: int = Form(default=1),
@@ -291,8 +292,12 @@ def create_app() -> FastAPI:
         if n < 1 or n > 4:
             raise HTTPException(status_code=400, detail={"error": "n must be between 1 and 4"})
 
+        uploads = [*(image or []), *(image_list or [])]
+        if not uploads:
+            raise HTTPException(status_code=400, detail={"error": "image file is required"})
+
         images: list[tuple[bytes, str, str]] = []
-        for upload in image:
+        for upload in uploads:
             image_data = await upload.read()
             if not image_data:
                 raise HTTPException(status_code=400, detail={"error": "image file is empty"})

--- a/test/test_image_edits_api.py
+++ b/test/test_image_edits_api.py
@@ -1,0 +1,98 @@
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from fastapi.testclient import TestClient
+
+from services import api as api_module
+
+
+class _FakeThread:
+    def join(self, timeout: float | None = None) -> None:
+        return None
+
+
+class _FakeChatGPTService:
+    last_call: dict[str, object] | None = None
+
+    def __init__(self, _account_service) -> None:
+        return None
+
+    def edit_with_pool(self, prompt: str, images, model: str, n: int):
+        normalized_images = list(images)
+        type(self).last_call = {
+            "prompt": prompt,
+            "images": normalized_images,
+            "model": model,
+            "n": n,
+        }
+        return {
+            "created": 123,
+            "data": [{"b64_json": "ZmFrZQ==", "revised_prompt": prompt}],
+        }
+
+
+class ImageEditsApiTests(unittest.TestCase):
+    def setUp(self) -> None:
+        _FakeChatGPTService.last_call = None
+        self.auth_header = {"Authorization": "Bearer test-auth"}
+        self.patches = [
+            mock.patch.object(api_module, "ChatGPTService", _FakeChatGPTService),
+            mock.patch.object(
+                api_module,
+                "config",
+                SimpleNamespace(auth_key="test-auth", refresh_account_interval_minute=60),
+            ),
+            mock.patch.object(api_module, "start_limited_account_watcher", lambda _stop_event: _FakeThread()),
+        ]
+        for patcher in self.patches:
+            patcher.start()
+        self.addCleanup(self._cleanup_patches)
+        self.client = TestClient(api_module.create_app())
+        self.addCleanup(self.client.close)
+
+    def _cleanup_patches(self) -> None:
+        for patcher in reversed(self.patches):
+            patcher.stop()
+
+    def test_accepts_repeated_image_field(self) -> None:
+        response = self.client.post(
+            "/v1/images/edits",
+            headers=self.auth_header,
+            data={"prompt": "test prompt", "model": "gpt-image-1", "n": "1"},
+            files=[
+                ("image", ("first.png", b"first", "image/png")),
+                ("image", ("second.png", b"second", "image/png")),
+            ],
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(_FakeChatGPTService.last_call)
+        self.assertEqual(len(_FakeChatGPTService.last_call["images"]), 2)
+        self.assertEqual(
+            [item[1] for item in _FakeChatGPTService.last_call["images"]],
+            ["first.png", "second.png"],
+        )
+
+    def test_accepts_repeated_image_bracket_field(self) -> None:
+        response = self.client.post(
+            "/v1/images/edits",
+            headers=self.auth_header,
+            data={"prompt": "test prompt", "model": "gpt-image-1", "n": "1"},
+            files=[
+                ("image[]", ("first.png", b"first", "image/png")),
+                ("image[]", ("second.png", b"second", "image/png")),
+            ],
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(_FakeChatGPTService.last_call)
+        self.assertEqual(len(_FakeChatGPTService.last_call["images"]), 2)
+        self.assertEqual(
+            [item[1] for item in _FakeChatGPTService.last_call["images"]],
+            ["first.png", "second.png"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 变更说明

- 为 `/v1/images/edits` 恢复对 multipart 字段 `image[]` 的兼容
- 保持当前基于重复 `image` 字段的实现不变
- 新增聚焦测试，覆盖 `image` 和 `image[]` 两种上传方式

## 背景

上游后续调整后，`/v1/images/edits` 只接受名为 `image` 的 multipart 字段。

但兼容性上仍然存在现实需求：
- OpenAI 官方示例中仍然能看到 `image[]`
- OpenWebUI 的图片编辑接口实际发送的就是 `image[]`

因此当前实现会让这类调用方直接在 FastAPI 参数校验阶段失败，返回 `422 Unprocessable Content`。

## 修改思路

这次改动保持作者当前的实现方向不变，只在接口入口增加一层最小兼容：

- 继续支持当前的 `image`
- 同时兼容 `image[]`
- 进入业务逻辑前将两者合并为同一组上传文件

也就是说，这不是回退当前设计，而是在不影响现有前端和内部处理流程的前提下，补回对旧调用方式和外部调用方的兼容性。

## 范围

本 PR 只处理 multipart 上传字段名兼容问题：

- `image`
- `image[]`

不包含以下能力扩展：

- JSON `images`
- `mask`
- 流式图片编辑响应
- 其他尚未端到端实现的图片编辑参数

## 测试

新增接口测试，验证以下两种请求都可以正常进入编辑流程：

- 重复 `image`
- 重复 `image[]`