### PR TITLE
为网页版增加连续图像对话 session 句柄接口

### DIFF
--- a/services/api.py
+++ b/services/api.py
@@ -14,6 +14,11 @@ from services.account_service import account_service
 from services.chatgpt_service import ChatGPTService
 from services.config import config
 from services.cpa_service import cpa_config, cpa_import_service, list_remote_files
+from services.image_session_service import (
+    ImageSessionExpiredError,
+    ImageSessionService,
+    serialize_image_session_response,
+)
 from services.proxy_service import test_proxy
 from services.sub2api_service import (
     list_remote_accounts as sub2api_list_remote_accounts,
@@ -182,6 +187,19 @@ def resolve_image_base_url(request: Request) -> str:
     return config.base_url or f"{request.url.scheme}://{request.headers.get('host', request.url.netloc)}"
 
 
+async def read_uploaded_images(uploads: list[UploadFile]) -> list[tuple[bytes, str, str]]:
+    images: list[tuple[bytes, str, str]] = []
+    for upload in uploads:
+        image_data = await upload.read()
+        if not image_data:
+            raise HTTPException(status_code=400, detail={"error": "image file is empty"})
+
+        file_name = upload.filename or "image.png"
+        mime_type = upload.content_type or "image/png"
+        images.append((image_data, file_name, mime_type))
+    return images
+
+
 def start_limited_account_watcher(stop_event: Event) -> Thread:
     interval_seconds = config.refresh_account_interval_minute * 60
 
@@ -229,6 +247,7 @@ def resolve_web_asset(requested_path: str) -> Path | None:
 
 def create_app() -> FastAPI:
     chatgpt_service = ChatGPTService(account_service)
+    image_session_service = ImageSessionService(account_service)
     app_version = get_app_version()
 
     @asynccontextmanager
@@ -380,16 +399,7 @@ def create_app() -> FastAPI:
             raise HTTPException(status_code=400, detail={"error": "image file is required"})
 
         base_url = resolve_image_base_url(request)
-
-        images: list[tuple[bytes, str, str]] = []
-        for upload in uploads:
-            image_data = await upload.read()
-            if not image_data:
-                raise HTTPException(status_code=400, detail={"error": "image file is empty"})
-
-            file_name = upload.filename or "image.png"
-            mime_type = upload.content_type or "image/png"
-            images.append((image_data, file_name, mime_type))
+        images = await read_uploaded_images(uploads)
 
         try:
             return await run_in_threadpool(
@@ -397,6 +407,54 @@ def create_app() -> FastAPI:
             )
         except ImageGenerationError as exc:
             raise HTTPException(status_code=502, detail={"error": str(exc)}) from exc
+
+    @router.post("/api/image/sessions")
+    async def create_image_session(
+            authorization: str | None = Header(default=None),
+            image: list[UploadFile] | None = File(default=None),
+            image_list: list[UploadFile] | None = File(default=None, alias="image[]"),
+            prompt: str = Form(...),
+            model: str = Form(default="gpt-image-1"),
+    ):
+        require_auth_key(authorization)
+        uploads = [*(image or []), *(image_list or [])]
+        images = await read_uploaded_images(uploads) if uploads else None
+        try:
+            session, result = await run_in_threadpool(
+                image_session_service.create_session,
+                prompt,
+                model,
+                images,
+            )
+        except ImageGenerationError as exc:
+            raise HTTPException(status_code=502, detail={"error": str(exc)}) from exc
+        return serialize_image_session_response(session, result)
+
+    @router.post("/api/image/sessions/{session_id}/turns")
+    async def create_image_session_turn(
+            session_id: str,
+            authorization: str | None = Header(default=None),
+            image: list[UploadFile] | None = File(default=None),
+            image_list: list[UploadFile] | None = File(default=None, alias="image[]"),
+            prompt: str = Form(...),
+            model: str = Form(default="gpt-image-1"),
+    ):
+        require_auth_key(authorization)
+        uploads = [*(image or []), *(image_list or [])]
+        images = await read_uploaded_images(uploads) if uploads else None
+        try:
+            session, result = await run_in_threadpool(
+                image_session_service.create_turn,
+                session_id,
+                prompt,
+                model,
+                images,
+            )
+        except ImageSessionExpiredError as exc:
+            raise HTTPException(status_code=410, detail={"error": str(exc)}) from exc
+        except ImageGenerationError as exc:
+            raise HTTPException(status_code=502, detail={"error": str(exc)}) from exc
+        return serialize_image_session_response(session, result)
 
     @router.post("/v1/chat/completions")
     async def create_chat_completion(body: ChatCompletionRequest, authorization: str | None = Header(default=None)):

--- a/services/config.py
+++ b/services/config.py
@@ -44,9 +44,9 @@ def _load_settings() -> LoadedSettings:
         )
 
     try:
-        refresh_interval = int(raw_config.get("refresh_account_interval_minute", 5))
+        refresh_interval = int(raw_config.get("refresh_account_interval_minute", 60))
     except (TypeError, ValueError):
-        refresh_interval = 5
+        refresh_interval = 60
 
     return LoadedSettings(
         auth_key=auth_key,
@@ -77,7 +77,7 @@ class ConfigStore:
 
     @property
     def auth_key(self) -> str:
-        return str(os.getenv("CHATGPT2API_AUTH_KEY") or self.data.get("auth-key") or "").strip()
+        return _load_settings().auth_key
 
     @property
     def accounts_file(self) -> Path:
@@ -85,10 +85,7 @@ class ConfigStore:
 
     @property
     def refresh_account_interval_minute(self) -> int:
-        try:
-            return int(self.data.get("refresh_account_interval_minute", 5))
-        except (TypeError, ValueError):
-            return 5
+        return _load_settings().refresh_account_interval_minute
 
     @property
     def images_dir(self) -> Path:

--- a/services/config.py
+++ b/services/config.py
@@ -33,9 +33,10 @@ def _read_json_object(path: Path, *, name: str) -> dict[str, object]:
     return data if isinstance(data, dict) else {}
 
 
-def _load_settings() -> LoadedSettings:
+def _load_settings(path: Path | None = None) -> LoadedSettings:
     DATA_DIR.mkdir(parents=True, exist_ok=True)
-    raw_config = _read_json_object(CONFIG_FILE, name="config.json")
+    resolved_path = path or CONFIG_FILE
+    raw_config = _read_json_object(resolved_path, name=resolved_path.name)
     auth_key = str(os.getenv("CHATGPT2API_AUTH_KEY") or raw_config.get("auth-key") or "").strip()
     if not auth_key:
         raise ValueError(
@@ -59,6 +60,7 @@ class ConfigStore:
         self.path = path
         DATA_DIR.mkdir(parents=True, exist_ok=True)
         self.data = self._load()
+        self._settings = _load_settings(self.path)
         if not self.auth_key:
             raise ValueError(
                 "❌ auth-key 未设置！\n"
@@ -77,7 +79,7 @@ class ConfigStore:
 
     @property
     def auth_key(self) -> str:
-        return _load_settings().auth_key
+        return self._settings.auth_key
 
     @property
     def accounts_file(self) -> Path:
@@ -85,7 +87,7 @@ class ConfigStore:
 
     @property
     def refresh_account_interval_minute(self) -> int:
-        return _load_settings().refresh_account_interval_minute
+        return self._settings.refresh_account_interval_minute
 
     @property
     def images_dir(self) -> Path:
@@ -110,6 +112,7 @@ class ConfigStore:
     def update(self, data: dict[str, object]) -> dict[str, object]:
         self.data = dict(data or {})
         self._save()
+        self._settings = _load_settings(self.path)
         return self.get()
 
 

--- a/services/image_service.py
+++ b/services/image_service.py
@@ -297,6 +297,7 @@ def _send_edit_conversation(
     device_id: str,
     chat_token: str,
     proof_token: Optional[str],
+    conversation_id: str | None,
     parent_message_id: str,
     prompt: str,
     model: str,
@@ -346,6 +347,7 @@ def _send_edit_conversation(
             headers=headers,
             json={
                 "action": "next",
+                "conversation_id": conversation_id,
                 "messages": [
                     {
                         "id": str(uuid.uuid4()),
@@ -402,6 +404,7 @@ def _send_conversation(
     device_id: str,
     chat_token: str,
     proof_token: Optional[str],
+    conversation_id: str | None,
     parent_message_id: str,
     prompt: str,
     model: str,
@@ -427,6 +430,7 @@ def _send_conversation(
             headers=headers,
             json={
                 "action": "next",
+                "conversation_id": conversation_id,
                 "messages": [
                     {
                         "id": str(uuid.uuid4()),
@@ -557,35 +561,68 @@ def _extract_image_ids(mapping: dict) -> list[str]:
     return file_ids
 
 
-def _poll_image_ids(session: Session, access_token: str, device_id: str, conversation_id: str) -> list[str]:
+def _fetch_conversation_payload(session: Session, access_token: str, device_id: str, conversation_id: str) -> dict | None:
+    response = _retry(
+        lambda: session.get(
+            f"{BASE_URL}/backend-api/conversation/{conversation_id}",
+            headers={
+                "Authorization": f"Bearer {access_token}",
+                "oai-device-id": device_id,
+                "accept": "*/*",
+            },
+            timeout=30,
+        ),
+        retries=2,
+        retry_on_status=(429, 502, 503, 504),
+    )
+    if response.status_code != 200:
+        return None
+    try:
+        payload = response.json()
+    except Exception:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _resolve_conversation_state(
+    session: Session,
+    access_token: str,
+    device_id: str,
+    conversation_id: str,
+    require_file_ids: bool,
+) -> dict[str, object]:
     started = time.time()
+    last_current_node = ""
+    last_file_ids: list[str] = []
     while time.time() - started < 180:
-        response = _retry(
-            lambda: session.get(
-                f"{BASE_URL}/backend-api/conversation/{conversation_id}",
-                headers={
-                    "Authorization": f"Bearer {access_token}",
-                    "oai-device-id": device_id,
-                    "accept": "*/*",
-                },
-                timeout=30,
-            ),
-            retries=2,
-            retry_on_status=(429, 502, 503, 504),
-        )
-        if response.status_code != 200:
+        payload = _fetch_conversation_payload(session, access_token, device_id, conversation_id)
+        if not payload:
             time.sleep(3)
             continue
-        try:
-            payload = response.json()
-        except Exception:
-            time.sleep(3)
-            continue
+        current_node = str(payload.get("current_node") or "")
+        if current_node:
+            last_current_node = current_node
         file_ids = _extract_image_ids(payload.get("mapping") or {})
         if file_ids:
-            return file_ids
+            last_file_ids = file_ids
+        if last_file_ids:
+            return {"current_node": last_current_node, "file_ids": last_file_ids}
+        if last_current_node and not require_file_ids:
+            return {"current_node": last_current_node, "file_ids": last_file_ids}
         time.sleep(3)
-    return []
+    return {"current_node": last_current_node, "file_ids": last_file_ids}
+
+
+def _poll_image_ids(session: Session, access_token: str, device_id: str, conversation_id: str) -> list[str]:
+    state = _resolve_conversation_state(
+        session,
+        access_token,
+        device_id,
+        conversation_id,
+        require_file_ids=True,
+    )
+    file_ids = state.get("file_ids")
+    return file_ids if isinstance(file_ids, list) else []
 
 
 def _canonicalize_file_id(file_id: str) -> str:
@@ -658,7 +695,15 @@ def _resolve_upstream_model(access_token: str, requested_model: str) -> str:
     return str(requested_model or DEFAULT_MODEL).strip() or DEFAULT_MODEL
 
 
-def generate_image_result(access_token: str, prompt: str, model: str = DEFAULT_MODEL, response_format: str = "b64_json", base_url: str = None) -> dict:
+def generate_image_result(
+    access_token: str,
+    prompt: str,
+    model: str = DEFAULT_MODEL,
+    response_format: str = "b64_json",
+    base_url: str | None = None,
+    conversation_id: str | None = None,
+    parent_message_id: str | None = None,
+) -> dict:
     prompt = str(prompt or "").strip()
     access_token = str(access_token or "").strip()
     if not prompt:
@@ -683,14 +728,16 @@ def generate_image_result(access_token: str, prompt: str, model: str = DEFAULT_M
                 user_agent=USER_AGENT,
                 proof_config=_pow_config(USER_AGENT),
             )
-        parent_message_id = str(uuid.uuid4())
+        request_parent_message_id = str(parent_message_id or "").strip() or str(uuid.uuid4())
+        request_conversation_id = str(conversation_id or "").strip() or None
         response = _send_conversation(
             session,
             access_token,
             device_id,
             chat_token,
             proof_token,
-            parent_message_id,
+            request_conversation_id,
+            request_parent_message_id,
             prompt,
             upstream_model,
         )
@@ -698,8 +745,21 @@ def generate_image_result(access_token: str, prompt: str, model: str = DEFAULT_M
         actual_conversation_id = parsed.get("conversation_id") or ""
         file_ids = parsed.get("file_ids") or []
         response_text = str(parsed.get("text") or "").strip()
-        if actual_conversation_id and not file_ids:
-            file_ids = _poll_image_ids(session, access_token, device_id, actual_conversation_id)
+        next_parent_message_id = request_parent_message_id
+        if actual_conversation_id:
+            state = _resolve_conversation_state(
+                session,
+                access_token,
+                device_id,
+                actual_conversation_id,
+                require_file_ids=not bool(file_ids),
+            )
+            current_node = str(state.get("current_node") or "").strip()
+            if current_node:
+                next_parent_message_id = current_node
+            if not file_ids:
+                state_file_ids = state.get("file_ids")
+                file_ids = state_file_ids if isinstance(state_file_ids, list) else []
         if not file_ids:
             if response_text:
                 raise ImageGenerationError(response_text)
@@ -719,6 +779,8 @@ def generate_image_result(access_token: str, prompt: str, model: str = DEFAULT_M
         return {
             "created": time.time_ns() // 1_000_000_000,
             "data": [result_data],
+            "upstream_conversation_id": actual_conversation_id or None,
+            "upstream_parent_message_id": next_parent_message_id or None,
         }
     except Exception as exc:
         print(f"[image-upstream] fail token={access_token[:12]}... error={exc}")
@@ -768,7 +830,9 @@ def edit_image_result(
     images: list[tuple[bytes, str, str]],
     model: str = DEFAULT_MODEL,
     response_format: str = "b64_json",
-    base_url: str = None,
+    base_url: str | None = None,
+    conversation_id: str | None = None,
+    parent_message_id: str | None = None,
 ) -> dict:
     prompt = str(prompt or "").strip()
     access_token = str(access_token or "").strip()
@@ -816,14 +880,16 @@ def edit_image_result(
                 user_agent=USER_AGENT,
                 proof_config=_pow_config(USER_AGENT),
             )
-        parent_message_id = str(uuid.uuid4())
+        request_parent_message_id = str(parent_message_id or "").strip() or str(uuid.uuid4())
+        request_conversation_id = str(conversation_id or "").strip() or None
         response = _send_edit_conversation(
             session,
             access_token,
             device_id,
             chat_token,
             proof_token,
-            parent_message_id,
+            request_conversation_id,
+            request_parent_message_id,
             prompt,
             upstream_model,
             uploaded_images,
@@ -833,11 +899,24 @@ def edit_image_result(
         input_file_ids = {image.file_id for image in uploaded_images}
         file_ids = _filter_output_file_ids(parsed.get("file_ids") or [], input_file_ids)
         response_text = str(parsed.get("text") or "").strip()
-        if actual_conversation_id and not file_ids:
-            file_ids = _filter_output_file_ids(
-                _poll_image_ids(session, access_token, device_id, actual_conversation_id),
-                input_file_ids,
+        next_parent_message_id = request_parent_message_id
+        if actual_conversation_id:
+            state = _resolve_conversation_state(
+                session,
+                access_token,
+                device_id,
+                actual_conversation_id,
+                require_file_ids=not bool(file_ids),
             )
+            current_node = str(state.get("current_node") or "").strip()
+            if current_node:
+                next_parent_message_id = current_node
+            if not file_ids:
+                state_file_ids = state.get("file_ids")
+                file_ids = _filter_output_file_ids(
+                    state_file_ids if isinstance(state_file_ids, list) else [],
+                    input_file_ids,
+                )
         if not file_ids:
             if response_text:
                 raise ImageGenerationError(response_text)
@@ -857,6 +936,8 @@ def edit_image_result(
         return {
             "created": time.time_ns() // 1_000_000_000,
             "data": [result_data],
+            "upstream_conversation_id": actual_conversation_id or None,
+            "upstream_parent_message_id": next_parent_message_id or None,
         }
     except Exception as exc:
         print(f"[image-edit-upstream] fail token={access_token[:12]}... error={exc}")

--- a/services/image_session_service.py
+++ b/services/image_session_service.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from threading import Lock
+import time
+import uuid
+from typing import Any
+
+from services.account_service import AccountService
+from services.image_service import (
+    ImageGenerationError,
+    edit_image_result,
+    generate_image_result,
+    is_token_invalid_error,
+)
+
+SESSION_TTL_SECONDS = 2 * 60 * 60
+SESSION_EXPIRED_MESSAGE = "连续对话会话已失效，请从当前结果图重新开始编辑"
+
+
+class ImageSessionExpiredError(Exception):
+    pass
+
+
+@dataclass
+class ImageSessionState:
+    session_id: str
+    access_token: str
+    upstream_conversation_id: str | None = None
+    upstream_parent_message_id: str | None = None
+    updated_at: float = 0.0
+    turn_lock: Any = field(default_factory=Lock, repr=False, compare=False)
+
+    def touch(self) -> None:
+        self.updated_at = time.time()
+
+
+class ImageSessionService:
+    """Process-local web session handles for continuous image conversations."""
+
+    def __init__(self, account_service: AccountService):
+        self.account_service = account_service
+        self._lock = Lock()
+        self._sessions: dict[str, ImageSessionState] = {}
+
+    def _prune_expired_locked(self, now: float) -> None:
+        expired_session_ids = [
+            session_id
+            for session_id, session in self._sessions.items()
+            if now - session.updated_at >= SESSION_TTL_SECONDS
+        ]
+        for session_id in expired_session_ids:
+            self._sessions.pop(session_id, None)
+
+    def _get_session_locked(self, session_id: str, now: float) -> ImageSessionState:
+        self._prune_expired_locked(now)
+        session = self._sessions.get(session_id)
+        if session is None:
+            raise ImageSessionExpiredError(SESSION_EXPIRED_MESSAGE)
+        return session
+
+    def _invalidate_session(self, session_id: str) -> None:
+        with self._lock:
+            self._sessions.pop(session_id, None)
+
+    def _run_turn(
+        self,
+        session: ImageSessionState,
+        prompt: str,
+        model: str,
+        images: list[tuple[bytes, str, str]] | None,
+    ) -> dict:
+        if images:
+            result = edit_image_result(
+                session.access_token,
+                prompt,
+                images,
+                model,
+                conversation_id=session.upstream_conversation_id,
+                parent_message_id=session.upstream_parent_message_id,
+            )
+        else:
+            result = generate_image_result(
+                session.access_token,
+                prompt,
+                model,
+                conversation_id=session.upstream_conversation_id,
+                parent_message_id=session.upstream_parent_message_id,
+            )
+        self.account_service.mark_image_result(session.access_token, success=True)
+        session.upstream_conversation_id = str(result.get("upstream_conversation_id") or "").strip() or None
+        session.upstream_parent_message_id = str(result.get("upstream_parent_message_id") or "").strip() or None
+        session.touch()
+        return result
+
+    def create_session(
+        self,
+        prompt: str,
+        model: str,
+        images: list[tuple[bytes, str, str]] | None = None,
+    ) -> tuple[ImageSessionState, dict]:
+        access_token = self.account_service.get_available_access_token()
+        session = ImageSessionState(
+            session_id=str(uuid.uuid4()),
+            access_token=access_token,
+            updated_at=time.time(),
+        )
+        try:
+            result = self._run_turn(session, prompt, model, images)
+        except ImageGenerationError:
+            self.account_service.mark_image_result(access_token, success=False)
+            raise
+
+        with self._lock:
+            self._prune_expired_locked(time.time())
+            self._sessions[session.session_id] = session
+        return session, result
+
+    def create_turn(
+        self,
+        session_id: str,
+        prompt: str,
+        model: str,
+        images: list[tuple[bytes, str, str]] | None = None,
+    ) -> tuple[ImageSessionState, dict]:
+        normalized_session_id = str(session_id or "").strip()
+        if not normalized_session_id:
+            raise ImageSessionExpiredError(SESSION_EXPIRED_MESSAGE)
+
+        with self._lock:
+            session = self._get_session_locked(normalized_session_id, time.time())
+
+        with session.turn_lock:
+            with self._lock:
+                self._get_session_locked(normalized_session_id, time.time())
+            try:
+                result = self._run_turn(session, prompt, model, images)
+            except ImageGenerationError as exc:
+                self.account_service.mark_image_result(session.access_token, success=False)
+                if is_token_invalid_error(str(exc)):
+                    self.account_service.remove_token(session.access_token)
+                    self._invalidate_session(normalized_session_id)
+                    raise ImageSessionExpiredError(SESSION_EXPIRED_MESSAGE) from exc
+                raise
+
+            with self._lock:
+                self._sessions[session.session_id] = session
+            return session, result
+
+
+def serialize_image_session_response(session: ImageSessionState, result: dict) -> dict[str, object]:
+    expires_at = datetime.fromtimestamp(session.updated_at + SESSION_TTL_SECONDS, tz=UTC)
+    updated_at = datetime.fromtimestamp(session.updated_at, tz=UTC)
+    return {
+        "session_id": session.session_id,
+        "created": int(result.get("created") or 0),
+        "data": result.get("data") if isinstance(result.get("data"), list) else [],
+        "updated_at": updated_at.isoformat().replace("+00:00", "Z"),
+        "expires_at": expires_at.isoformat().replace("+00:00", "Z"),
+    }

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -48,7 +48,7 @@ class ConfigLoadingTests(unittest.TestCase):
                 settings = module._load_settings()
 
                 self.assertEqual(settings.auth_key, os_auth_key)
-                self.assertEqual(settings.refresh_account_interval_minute, 5)
+                self.assertEqual(settings.refresh_account_interval_minute, 60)
             finally:
                 module.BASE_DIR = old_base_dir
                 module.DATA_DIR = old_data_dir

--- a/test/test_image_edits_api.py
+++ b/test/test_image_edits_api.py
@@ -1,4 +1,5 @@
 import unittest
+from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
@@ -18,13 +19,23 @@ class _FakeChatGPTService:
     def __init__(self, _account_service) -> None:
         return None
 
-    def edit_with_pool(self, prompt: str, images, model: str, n: int):
+    def edit_with_pool(
+        self,
+        prompt: str,
+        images,
+        model: str,
+        n: int,
+        response_format: str = "b64_json",
+        base_url: str | None = None,
+    ):
         normalized_images = list(images)
         type(self).last_call = {
             "prompt": prompt,
             "images": normalized_images,
             "model": model,
             "n": n,
+            "response_format": response_format,
+            "base_url": base_url,
         }
         return {
             "created": 123,
@@ -41,7 +52,12 @@ class ImageEditsApiTests(unittest.TestCase):
             mock.patch.object(
                 api_module,
                 "config",
-                SimpleNamespace(auth_key="test-auth", refresh_account_interval_minute=60),
+                SimpleNamespace(
+                    auth_key="test-auth",
+                    refresh_account_interval_minute=60,
+                    images_dir=Path("test-images"),
+                    base_url="http://localhost:8000",
+                ),
             ),
             mock.patch.object(api_module, "start_limited_account_watcher", lambda _stop_event: _FakeThread()),
         ]

--- a/test/test_image_session_service.py
+++ b/test/test_image_session_service.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import os
+import threading
+import time
+import unittest
+from unittest.mock import Mock, patch
+
+os.environ.setdefault("CHATGPT2API_AUTH_KEY", "test-auth")
+
+from services.image_session_service import (  # noqa: E402
+    ImageSessionExpiredError,
+    ImageSessionState,
+    ImageSessionService,
+    serialize_image_session_response,
+)
+
+
+class ImageSessionServiceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.account_service = Mock()
+        self.account_service.get_available_access_token.return_value = "token-1"
+        self.service = ImageSessionService(self.account_service)
+
+    @patch("services.image_session_service.generate_image_result")
+    def test_create_session_persists_upstream_handles(self, generate_image_result: Mock) -> None:
+        generate_image_result.return_value = {
+            "created": 123,
+            "data": [{"b64_json": "ZmFrZQ==", "revised_prompt": "prompt"}],
+            "upstream_conversation_id": "conversation-1",
+            "upstream_parent_message_id": "message-1",
+        }
+
+        session, result = self.service.create_session("prompt", "gpt-image-1")
+
+        self.assertEqual(result["created"], 123)
+        self.assertEqual(session.upstream_conversation_id, "conversation-1")
+        self.assertEqual(session.upstream_parent_message_id, "message-1")
+        self.account_service.mark_image_result.assert_called_once_with("token-1", success=True)
+
+    @patch("services.image_session_service.generate_image_result")
+    def test_create_turn_uses_existing_upstream_handles(self, generate_image_result: Mock) -> None:
+        generate_image_result.side_effect = [
+            {
+                "created": 1,
+                "data": [{"b64_json": "ZmFrZQ=="}],
+                "upstream_conversation_id": "conversation-1",
+                "upstream_parent_message_id": "message-1",
+            },
+            {
+                "created": 2,
+                "data": [{"b64_json": "YmFy"}],
+                "upstream_conversation_id": "conversation-1",
+                "upstream_parent_message_id": "message-2",
+            },
+        ]
+
+        session, _ = self.service.create_session("first", "gpt-image-1")
+        next_session, next_result = self.service.create_turn(session.session_id, "second", "gpt-image-1")
+
+        self.assertEqual(next_result["created"], 2)
+        self.assertEqual(next_session.upstream_parent_message_id, "message-2")
+        self.assertEqual(generate_image_result.call_args_list[1].kwargs["conversation_id"], "conversation-1")
+        self.assertEqual(generate_image_result.call_args_list[1].kwargs["parent_message_id"], "message-1")
+
+    def test_expired_session_raises_consistent_error(self) -> None:
+        self.service._sessions["expired"] = Mock(
+            session_id="expired",
+            access_token="token-1",
+            upstream_conversation_id=None,
+            upstream_parent_message_id=None,
+            updated_at=0.0,
+        )
+
+        with patch("services.image_session_service.time.time", return_value=9999999999.0):
+            with self.assertRaises(ImageSessionExpiredError):
+                self.service.create_turn("expired", "prompt", "gpt-image-1")
+
+    @patch("services.image_session_service.generate_image_result")
+    def test_create_session_prunes_expired_sessions_before_insert(self, generate_image_result: Mock) -> None:
+        generate_image_result.return_value = {
+            "created": 123,
+            "data": [{"b64_json": "ZmFrZQ=="}],
+        }
+        self.service._sessions["expired"] = ImageSessionState(
+            session_id="expired",
+            access_token="token-expired",
+            updated_at=0.0,
+        )
+
+        with patch("services.image_session_service.time.time", return_value=9999999999.0):
+            session, _ = self.service.create_session("prompt", "gpt-image-1")
+
+        self.assertNotIn("expired", self.service._sessions)
+        self.assertIn(session.session_id, self.service._sessions)
+
+    def test_create_turn_serializes_requests_per_session(self) -> None:
+        session = ImageSessionState(
+            session_id="session-1",
+            access_token="token-1",
+            updated_at=time.time(),
+        )
+        self.service._sessions[session.session_id] = session
+
+        entered_prompts: list[str] = []
+        results: list[tuple[str, int]] = []
+        failures: list[BaseException] = []
+        first_started = threading.Event()
+        allow_first_to_finish = threading.Event()
+
+        def fake_run_turn(current_session: ImageSessionState, prompt: str, model: str, images: object) -> dict:
+            entered_prompts.append(prompt)
+            if prompt == "first":
+                first_started.set()
+                self.assertTrue(allow_first_to_finish.wait(timeout=1))
+            current_session.upstream_parent_message_id = prompt
+            current_session.touch()
+            return {
+                "created": len(entered_prompts),
+                "data": [{"b64_json": prompt}],
+            }
+
+        def run_turn(prompt: str) -> None:
+            try:
+                _, result = self.service.create_turn(session.session_id, prompt, "gpt-image-1")
+                results.append((prompt, int(result["created"])))
+            except BaseException as exc:  # pragma: no cover - surfaced by assertions below
+                failures.append(exc)
+
+        with patch.object(self.service, "_run_turn", side_effect=fake_run_turn):
+            first_thread = threading.Thread(target=run_turn, args=("first",))
+            second_thread = threading.Thread(target=run_turn, args=("second",))
+
+            first_thread.start()
+            self.assertTrue(first_started.wait(timeout=1))
+
+            second_thread.start()
+            time.sleep(0.1)
+            self.assertEqual(entered_prompts, ["first"])
+
+            allow_first_to_finish.set()
+            first_thread.join(timeout=1)
+            second_thread.join(timeout=1)
+
+        self.assertFalse(failures)
+        self.assertEqual(entered_prompts, ["first", "second"])
+        self.assertEqual(sorted(results), [("first", 1), ("second", 2)])
+
+
+class ImageSessionResponseTests(unittest.TestCase):
+    def test_serialize_response_hides_upstream_handles(self) -> None:
+        session = Mock(session_id="session-1", updated_at=1000.0)
+        payload = serialize_image_session_response(
+            session,
+            {
+                "created": 1000,
+                "data": [{"b64_json": "ZmFrZQ=="}],
+                "upstream_conversation_id": "conversation-1",
+                "upstream_parent_message_id": "message-1",
+            },
+        )
+
+        self.assertEqual(payload["session_id"], "session-1")
+        self.assertNotIn("upstream_conversation_id", payload)
+        self.assertNotIn("upstream_parent_message_id", payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_image_sessions_api.py
+++ b/test/test_image_sessions_api.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import time
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from fastapi.testclient import TestClient
+
+from services import api as api_module
+
+
+class _FakeThread:
+    def join(self, timeout: float | None = None) -> None:
+        return None
+
+
+class _FakeChatGPTService:
+    def __init__(self, _account_service) -> None:
+        return None
+
+
+class _FakeImageSessionService:
+    last_create_session_call: dict[str, object] | None = None
+    last_create_turn_call: dict[str, object] | None = None
+
+    def __init__(self, _account_service) -> None:
+        return None
+
+    def create_session(self, prompt: str, model: str, images=None):
+        normalized_images = list(images) if images else None
+        type(self).last_create_session_call = {
+            "prompt": prompt,
+            "model": model,
+            "images": normalized_images,
+        }
+        session = SimpleNamespace(session_id="session-1", updated_at=time.time())
+        result = {
+            "created": 123,
+            "data": [{"b64_json": "ZmFrZQ==", "revised_prompt": prompt}],
+            "upstream_conversation_id": "conversation-1",
+            "upstream_parent_message_id": "message-1",
+        }
+        return session, result
+
+    def create_turn(self, session_id: str, prompt: str, model: str, images=None):
+        if session_id == "expired":
+            raise api_module.ImageSessionExpiredError("连续对话会话已失效，请从当前结果图重新开始编辑")
+
+        normalized_images = list(images) if images else None
+        type(self).last_create_turn_call = {
+            "session_id": session_id,
+            "prompt": prompt,
+            "model": model,
+            "images": normalized_images,
+        }
+        session = SimpleNamespace(session_id=session_id, updated_at=time.time())
+        result = {
+            "created": 124,
+            "data": [{"b64_json": "YmFy", "revised_prompt": prompt}],
+            "upstream_conversation_id": "conversation-1",
+            "upstream_parent_message_id": "message-2",
+        }
+        return session, result
+
+
+class ImageSessionApiTests(unittest.TestCase):
+    def setUp(self) -> None:
+        _FakeImageSessionService.last_create_session_call = None
+        _FakeImageSessionService.last_create_turn_call = None
+        self.auth_header = {"Authorization": "Bearer test-auth"}
+        self.patches = [
+            mock.patch.object(api_module, "ChatGPTService", _FakeChatGPTService),
+            mock.patch.object(api_module, "ImageSessionService", _FakeImageSessionService),
+            mock.patch.object(
+                api_module,
+                "config",
+                SimpleNamespace(
+                    auth_key="test-auth",
+                    refresh_account_interval_minute=60,
+                    base_url="http://localhost:8000",
+                    images_dir=Path("test-images"),
+                ),
+            ),
+            mock.patch.object(api_module, "start_limited_account_watcher", lambda _stop_event: _FakeThread()),
+        ]
+        for patcher in self.patches:
+            patcher.start()
+        self.addCleanup(self._cleanup_patches)
+        self.client = TestClient(api_module.create_app())
+        self.addCleanup(self.client.close)
+
+    def _cleanup_patches(self) -> None:
+        for patcher in reversed(self.patches):
+            patcher.stop()
+
+    def test_requires_auth_for_session_creation(self) -> None:
+        response = self.client.post("/api/image/sessions", data={"prompt": "test prompt"})
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_create_session_accepts_repeated_image_field(self) -> None:
+        response = self.client.post(
+            "/api/image/sessions",
+            headers=self.auth_header,
+            data={"prompt": "test prompt", "model": "gpt-image-1"},
+            files=[
+                ("image", ("first.png", b"first", "image/png")),
+                ("image", ("second.png", b"second", "image/png")),
+            ],
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(_FakeImageSessionService.last_create_session_call)
+        self.assertEqual(len(_FakeImageSessionService.last_create_session_call["images"]), 2)
+        self.assertEqual(
+            [item[1] for item in _FakeImageSessionService.last_create_session_call["images"]],
+            ["first.png", "second.png"],
+        )
+        payload = response.json()
+        self.assertEqual(payload["session_id"], "session-1")
+        self.assertIn("expires_at", payload)
+        self.assertNotIn("upstream_conversation_id", payload)
+
+    def test_create_turn_accepts_repeated_image_bracket_field(self) -> None:
+        response = self.client.post(
+            "/api/image/sessions/session-1/turns",
+            headers=self.auth_header,
+            data={"prompt": "test prompt", "model": "gpt-image-1"},
+            files=[
+                ("image[]", ("first.png", b"first", "image/png")),
+                ("image[]", ("second.png", b"second", "image/png")),
+            ],
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(_FakeImageSessionService.last_create_turn_call)
+        self.assertEqual(_FakeImageSessionService.last_create_turn_call["session_id"], "session-1")
+        self.assertEqual(len(_FakeImageSessionService.last_create_turn_call["images"]), 2)
+
+    def test_create_turn_returns_410_for_expired_session(self) -> None:
+        response = self.client.post(
+            "/api/image/sessions/expired/turns",
+            headers=self.auth_header,
+            data={"prompt": "test prompt", "model": "gpt-image-1"},
+        )
+
+        self.assertEqual(response.status_code, 410)
+        self.assertEqual(response.json()["detail"]["error"], "连续对话会话已失效，请从当前结果图重新开始编辑")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/src/app/image/components/image-composer.tsx
+++ b/web/src/app/image/components/image-composer.tsx
@@ -23,8 +23,9 @@ type ImageComposerProps = {
   model: ImageModel;
   imageCount: string;
   availableQuota: string;
-  hasAnyGenerating: boolean;
-  generatingCount: number;
+  activeTaskCount: number;
+  selectedConversationTitle: string | null;
+  selectedConversationStats: { queued: number; running: number } | null;
   referenceImages: Array<{ name: string; dataUrl: string }>;
   textareaRef: RefObject<HTMLTextAreaElement | null>;
   fileInputRef: RefObject<HTMLInputElement | null>;
@@ -45,8 +46,9 @@ export function ImageComposer({
   model,
   imageCount,
   availableQuota,
-  hasAnyGenerating,
-  generatingCount,
+  activeTaskCount,
+  selectedConversationTitle,
+  selectedConversationStats,
   referenceImages,
   textareaRef,
   fileInputRef,
@@ -176,10 +178,10 @@ export function ImageComposer({
                     </Button>
                   )}
                   <div className="rounded-full bg-stone-100 px-3 py-2 text-xs font-medium text-stone-600">剩余额度 {availableQuota}</div>
-                  {hasAnyGenerating && (
+                  {activeTaskCount > 0 && (
                     <div className="flex items-center gap-1.5 rounded-full bg-amber-50 px-3 py-2 text-xs font-medium text-amber-700">
                       <LoaderCircle className="size-3 animate-spin" />
-                      {generatingCount} 个任务进行中
+                      {activeTaskCount} 个任务处理中或排队中
                     </div>
                   )}
                   <Select value={model} onValueChange={(value) => onModelChange(value as ImageModel)}>
@@ -214,6 +216,17 @@ export function ImageComposer({
                       编辑图
                     </ModeButton>
                   </div>
+                  {selectedConversationTitle ? (
+                    <div className="rounded-full bg-stone-100 px-3 py-2 text-xs font-medium text-stone-600">
+                      当前对话：{selectedConversationTitle}
+                      {selectedConversationStats?.running ? ` · 处理中 ${selectedConversationStats.running}` : ""}
+                      {selectedConversationStats?.queued ? ` · 排队 ${selectedConversationStats.queued}` : ""}
+                    </div>
+                  ) : (
+                    <div className="rounded-full bg-stone-100 px-3 py-2 text-xs font-medium text-stone-600">
+                      当前对话：发送后自动创建
+                    </div>
+                  )}
                 </div>
 
                 <button

--- a/web/src/app/image/components/image-results.tsx
+++ b/web/src/app/image/components/image-results.tsx
@@ -1,35 +1,28 @@
 "use client";
-import { LoaderCircle } from "lucide-react";
-import { useMemo, useState } from "react";
 
-import { ImageLightbox } from "@/components/image-lightbox";
-import type { ImageConversation, StoredImage } from "@/store/image-conversations";
+import { Clock3, LoaderCircle, Sparkles } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import type { ImageConversation, ImageTurnStatus, StoredImage } from "@/store/image-conversations";
+
+export type ImageLightboxItem = {
+  id: string;
+  src: string;
+};
 
 type ImageResultsProps = {
   selectedConversation: ImageConversation | null;
-  isSelectedGenerating: boolean;
-  openLightbox: (imageId: string) => void;
+  onOpenLightbox: (images: ImageLightboxItem[], index: number) => void;
+  onContinueEdit: (conversationId: string, image: StoredImage) => void;
   formatConversationTime: (value: string) => string;
 };
 
 export function ImageResults({
   selectedConversation,
-  isSelectedGenerating,
-  openLightbox,
+  onOpenLightbox,
+  onContinueEdit,
   formatConversationTime,
 }: ImageResultsProps) {
-  const [referenceLightboxOpen, setReferenceLightboxOpen] = useState(false);
-  const [referenceLightboxIndex, setReferenceLightboxIndex] = useState(0);
-
-  const referenceLightboxImages = useMemo(
-    () =>
-      (selectedConversation?.referenceImages ?? []).map((image, index) => ({
-        id: `${image.name}-${index}`,
-        src: image.dataUrl,
-      })),
-    [selectedConversation?.referenceImages],
-  );
-
   if (!selectedConversation) {
     return (
       <div className="flex h-full min-h-[420px] items-center justify-center text-center">
@@ -48,7 +41,7 @@ export function ImageResults({
               fontFamily: '"Palatino Linotype","Book Antiqua","URW Palladio L","Times New Roman",serif',
             }}
           >
-            Describe a scene, a mood, or a character, and let the next image start here.
+            在同一窗口里保留本地历史与任务状态，并从已有结果图继续发起新的无状态编辑。
           </p>
         </div>
       </div>
@@ -56,128 +49,166 @@ export function ImageResults({
   }
 
   return (
-    <div className="mx-auto flex w-full max-w-[980px] flex-col gap-4">
-      <ImageLightbox
-        images={referenceLightboxImages}
-        currentIndex={referenceLightboxIndex}
-        open={referenceLightboxOpen}
-        onOpenChange={setReferenceLightboxOpen}
-        onIndexChange={setReferenceLightboxIndex}
-      />
+    <div className="mx-auto flex w-full max-w-[980px] flex-col gap-8">
+      {selectedConversation.turns.map((turn, turnIndex) => {
+        const referenceLightboxImages = turn.referenceImages.map((image, index) => ({
+          id: `${turn.id}-reference-${index}`,
+          src: image.dataUrl,
+        }));
+        const successfulTurnImages = turn.images.flatMap((image) =>
+          image.status === "success" && image.b64_json
+            ? [{ id: image.id, src: `data:image/png;base64,${image.b64_json}` }]
+            : [],
+        );
 
-      <div className="flex justify-end">
-        <div className="w-full max-w-[min(820px,92%)] px-1 pt-1">
-          <div className="ml-auto flex max-w-full flex-col items-end gap-2.5 text-right">
-            <div className="w-fit max-w-[min(32rem,100%)] whitespace-pre-wrap break-words text-[15px] leading-6 text-stone-700 sm:leading-7">
-              {selectedConversation.prompt}
-            </div>
-            {selectedConversation.referenceImages?.length ? (
-              <div
-                className="grid w-fit auto-rows-fr gap-3"
-                style={{
-                  gridTemplateColumns: `repeat(${Math.min(selectedConversation.referenceImages.length, 3)}, minmax(0, 1fr))`,
-                }}
-              >
-                {selectedConversation.referenceImages.map((image, index) => (
-                  <button
-                    key={`${image.name}-${index}`}
-                    type="button"
-                    onClick={() => {
-                      setReferenceLightboxIndex(index);
-                      setReferenceLightboxOpen(true);
-                    }}
-                    className="group relative aspect-square min-h-[112px] overflow-hidden rounded-[18px] border border-stone-200/80 bg-stone-100/60 text-left transition hover:border-stone-300 sm:min-h-[136px]"
-                    aria-label={`预览参考图 ${image.name || index + 1}`}
-                  >
-                    <img
-                      src={image.dataUrl}
-                      alt={image.name || `参考图 ${index + 1}`}
-                      className="absolute inset-0 h-full w-full object-cover transition duration-200 group-hover:scale-[1.02]"
-                    />
-                  </button>
-                ))}
-              </div>
-            ) : null}
-          </div>
-        </div>
-      </div>
-
-      <div className="flex justify-start">
-        <div className="w-full p-1">
-          <div className="mb-4 flex flex-wrap items-center gap-2 text-xs text-stone-500">
-            <span className="rounded-full bg-stone-100 px-3 py-1">{selectedConversation.mode === "edit" ? "编辑图" : "文生图"}</span>
-            <span className="rounded-full bg-stone-100 px-3 py-1">{selectedConversation.model}</span>
-            <span className="rounded-full bg-stone-100 px-3 py-1">{selectedConversation.count} 张</span>
-            <span className="rounded-full bg-stone-100 px-3 py-1">
-              {formatConversationTime(selectedConversation.createdAt)}
-            </span>
-            {isSelectedGenerating && (
-              <span className="rounded-full bg-amber-50 px-3 py-1 text-amber-700">处理中</span>
-            )}
-          </div>
-
-          {selectedConversation.status === "error" && selectedConversation.images.length === 0 ? (
-            <div className="border-l-2 border-rose-300 bg-rose-50/70 px-4 py-4 text-sm leading-6 text-rose-600">
-              {selectedConversation.error || "生成失败"}
-            </div>
-          ) : null}
-
-          {selectedConversation.images.length > 0 ? (
-            <div className="columns-1 gap-4 space-y-4 sm:columns-2 xl:columns-3">
-              {selectedConversation.images.map((image, index) => (
-                <div key={image.id} className="break-inside-avoid overflow-hidden rounded-[22px]">
-                  <ImageResultCard image={image} index={index} onOpen={openLightbox} />
+        return (
+          <div key={turn.id} className="flex flex-col gap-4">
+            <div className="flex justify-end">
+              <div className="max-w-[82%] rounded-[28px] bg-stone-950 px-5 py-4 text-[15px] leading-7 text-white shadow-sm">
+                <div className="mb-2 flex flex-wrap items-center gap-2 text-[11px] text-white/70">
+                  <span className="rounded-full bg-white/10 px-2.5 py-1">第 {turnIndex + 1} 轮</span>
+                  <span className="rounded-full bg-white/10 px-2.5 py-1">
+                    {turn.mode === "edit" ? "编辑图" : "文生图"}
+                  </span>
+                  <span className="rounded-full bg-white/10 px-2.5 py-1">{turn.model}</span>
+                  <span className="rounded-full bg-white/10 px-2.5 py-1">{getTurnStatusLabel(turn.status)}</span>
+                  <span className="rounded-full bg-white/10 px-2.5 py-1">{formatConversationTime(turn.createdAt)}</span>
                 </div>
-              ))}
+                <div>{turn.prompt}</div>
+              </div>
             </div>
-          ) : null}
 
-          {selectedConversation.status === "error" && selectedConversation.images.length > 0 ? (
-            <div className="mt-4 border-l-2 border-amber-300 bg-amber-50/70 px-4 py-3 text-sm leading-6 text-amber-700">
-              {selectedConversation.error}
+            <div className="flex justify-start">
+              <div className="w-full rounded-[28px] border border-stone-200/80 bg-white/85 p-4 shadow-[0_14px_40px_rgba(28,25,23,0.05)]">
+                {turn.referenceImages.length > 0 ? (
+                  <div className="mb-5 rounded-[22px] border border-stone-200/80 bg-stone-50/80 p-3">
+                    <div className="mb-3 text-xs font-medium text-stone-500">本轮参考图</div>
+                    <div
+                      className="grid gap-3"
+                      style={{
+                        gridTemplateColumns: `repeat(${Math.min(turn.referenceImages.length, 3)}, minmax(0, 1fr))`,
+                      }}
+                    >
+                      {turn.referenceImages.map((image, index) => (
+                        <button
+                          key={`${turn.id}-${image.name}-${index}`}
+                          type="button"
+                          onClick={() => onOpenLightbox(referenceLightboxImages, index)}
+                          className="group relative aspect-square overflow-hidden rounded-[18px] border border-stone-200/80 bg-stone-100/60 text-left transition hover:border-stone-300"
+                          aria-label={`预览参考图 ${image.name || index + 1}`}
+                        >
+                          <img
+                            src={image.dataUrl}
+                            alt={image.name || `参考图 ${index + 1}`}
+                            className="absolute inset-0 h-full w-full object-cover transition duration-200 group-hover:scale-[1.02]"
+                          />
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
+
+                <div className="mb-4 flex flex-wrap items-center gap-2 text-xs text-stone-500">
+                  <span className="rounded-full bg-stone-100 px-3 py-1">{turn.count} 张</span>
+                  <span className="rounded-full bg-stone-100 px-3 py-1">{getTurnStatusLabel(turn.status)}</span>
+                  {turn.status === "queued" ? (
+                    <span className="rounded-full bg-amber-50 px-3 py-1 text-amber-700">等待当前对话中的前序任务完成</span>
+                  ) : null}
+                </div>
+
+                <div className="columns-1 gap-4 space-y-4 sm:columns-2 xl:columns-3">
+                  {turn.images.map((image, index) => {
+                    if (image.status === "success" && image.b64_json) {
+                      const currentIndex = successfulTurnImages.findIndex((item) => item.id === image.id);
+
+                      return (
+                        <div
+                          key={image.id}
+                          className="break-inside-avoid overflow-hidden rounded-[22px] border border-stone-200/80 bg-stone-50/60"
+                        >
+                          <button
+                            type="button"
+                            onClick={() => onOpenLightbox(successfulTurnImages, currentIndex)}
+                            className="group block w-full cursor-zoom-in"
+                          >
+                            <img
+                              src={`data:image/png;base64,${image.b64_json}`}
+                              alt={`Generated result ${index + 1}`}
+                              className="block h-auto w-full transition duration-200 group-hover:brightness-90"
+                            />
+                          </button>
+                          <div className="flex items-center justify-between gap-2 px-3 py-3">
+                            <div className="text-xs text-stone-500">结果 {index + 1}</div>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              className="rounded-full border-stone-200 bg-white text-stone-700 hover:bg-stone-50"
+                              onClick={() => onContinueEdit(selectedConversation.id, image)}
+                            >
+                              <Sparkles className="size-4" />
+                              继续编辑
+                            </Button>
+                          </div>
+                        </div>
+                      );
+                    }
+
+                    if (image.status === "error") {
+                      return (
+                        <div
+                          key={image.id}
+                          className="break-inside-avoid overflow-hidden rounded-[22px] border border-rose-200 bg-rose-50"
+                        >
+                          <div className="flex min-h-[320px] items-center justify-center px-6 py-8 text-center text-sm leading-6 text-rose-600">
+                            {image.error || "生成失败"}
+                          </div>
+                        </div>
+                      );
+                    }
+
+                    return (
+                      <div
+                        key={image.id}
+                        className="break-inside-avoid overflow-hidden rounded-[22px] border border-stone-200/80 bg-stone-100/80"
+                      >
+                        <div className="flex min-h-[320px] flex-col items-center justify-center gap-3 px-6 py-8 text-center text-stone-500">
+                          <div className="rounded-full bg-white p-3 shadow-sm">
+                            {turn.status === "queued" ? (
+                              <Clock3 className="size-5" />
+                            ) : (
+                              <LoaderCircle className="size-5 animate-spin" />
+                            )}
+                          </div>
+                          <p className="text-sm">{turn.status === "queued" ? "已加入当前对话队列..." : "正在处理图片..."}</p>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+
+                {turn.status === "error" && turn.error ? (
+                  <div className="mt-4 border-l-2 border-amber-300 bg-amber-50/70 px-4 py-3 text-sm leading-6 text-amber-700">
+                    {turn.error}
+                  </div>
+                ) : null}
+              </div>
             </div>
-          ) : null}
-        </div>
-      </div>
+          </div>
+        );
+      })}
     </div>
   );
 }
 
-function ImageResultCard({
-  image,
-  index,
-  onOpen,
-}: {
-  image: StoredImage;
-  index: number;
-  onOpen: (imageId: string) => void;
-}) {
-  if (image.status === "success" && image.b64_json) {
-    return (
-      <button type="button" onClick={() => onOpen(image.id)} className="group block w-full cursor-zoom-in">
-        <img
-          src={`data:image/png;base64,${image.b64_json}`}
-          alt={`Generated result ${index + 1}`}
-          className="block h-auto w-full transition duration-200 group-hover:brightness-90"
-        />
-      </button>
-    );
+function getTurnStatusLabel(status: ImageTurnStatus) {
+  if (status === "queued") {
+    return "排队中";
   }
-
-  if (image.status === "error") {
-    return (
-      <div className="flex min-h-[320px] items-center justify-center bg-rose-50 px-6 py-8 text-center text-sm leading-6 text-rose-600">
-        {image.error || "生成失败"}
-      </div>
-    );
+  if (status === "generating") {
+    return "处理中";
   }
-
-  return (
-    <div className="flex min-h-[320px] flex-col items-center justify-center gap-3 bg-stone-100/80 px-6 py-8 text-center text-stone-500">
-      <div className="rounded-full bg-white p-3 shadow-sm">
-        <LoaderCircle className="size-5 animate-spin" />
-      </div>
-      <p className="text-sm">正在生成图片...</p>
-    </div>
-  );
+  if (status === "success") {
+    return "已完成";
+  }
+  return "失败";
 }

--- a/web/src/app/image/components/image-sidebar.tsx
+++ b/web/src/app/image/components/image-sidebar.tsx
@@ -4,7 +4,7 @@ import { LoaderCircle, MessageSquarePlus, Trash2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import type { ImageConversation } from "@/store/image-conversations";
+import { getImageConversationStats, type ImageConversation } from "@/store/image-conversations";
 
 type ImageSidebarProps = {
   conversations: ImageConversation[];
@@ -56,7 +56,7 @@ export function ImageSidebar({
           ) : (
             conversations.map((conversation) => {
               const active = conversation.id === selectedConversationId;
-              const stats = getConversationStats(conversation);
+              const stats = getImageConversationStats(conversation);
               return (
                 <div
                   key={conversation.id}
@@ -104,19 +104,5 @@ export function ImageSidebar({
         </div>
       </div>
     </aside>
-  );
-}
-
-function getConversationStats(conversation: ImageConversation) {
-  return conversation.turns.reduce(
-    (acc, turn) => {
-      if (turn.status === "queued") {
-        acc.queued += 1;
-      } else if (turn.status === "generating") {
-        acc.running += 1;
-      }
-      return acc;
-    },
-    { queued: 0, running: 0 },
   );
 }

--- a/web/src/app/image/components/image-sidebar.tsx
+++ b/web/src/app/image/components/image-sidebar.tsx
@@ -9,7 +9,6 @@ import type { ImageConversation } from "@/store/image-conversations";
 type ImageSidebarProps = {
   conversations: ImageConversation[];
   isLoadingHistory: boolean;
-  generatingIds: Set<string>;
   selectedConversationId: string | null;
   onCreateDraft: () => void;
   onClearHistory: () => void | Promise<void>;
@@ -21,7 +20,6 @@ type ImageSidebarProps = {
 export function ImageSidebar({
   conversations,
   isLoadingHistory,
-  generatingIds,
   selectedConversationId,
   onCreateDraft,
   onClearHistory,
@@ -58,7 +56,7 @@ export function ImageSidebar({
           ) : (
             conversations.map((conversation) => {
               const active = conversation.id === selectedConversationId;
-              const generating = generatingIds.has(conversation.id);
+              const stats = getConversationStats(conversation);
               return (
                 <div
                   key={conversation.id}
@@ -74,13 +72,22 @@ export function ImageSidebar({
                     onClick={() => onSelectConversation(conversation.id)}
                     className="block w-full pr-8 text-left"
                   >
-                    <div className="flex items-center gap-1.5 truncate text-sm font-semibold">
-                      {generating && <LoaderCircle className="size-3.5 shrink-0 animate-spin text-stone-400" />}
+                    <div className="truncate text-sm font-semibold">
                       <span className="truncate">{conversation.title}</span>
                     </div>
                     <div className={cn("mt-1 text-xs", active ? "text-stone-500" : "text-stone-400")}>
-                      {formatConversationTime(conversation.createdAt)}
+                      {conversation.turns.length} 轮 · {formatConversationTime(conversation.updatedAt)}
                     </div>
+                    {stats.running > 0 || stats.queued > 0 ? (
+                      <div className="mt-2 flex flex-wrap items-center gap-2 text-[11px]">
+                        {stats.running > 0 ? (
+                          <span className="rounded-full bg-blue-50 px-2 py-1 text-blue-600">处理中 {stats.running}</span>
+                        ) : null}
+                        {stats.queued > 0 ? (
+                          <span className="rounded-full bg-amber-50 px-2 py-1 text-amber-700">排队 {stats.queued}</span>
+                        ) : null}
+                      </div>
+                    ) : null}
                   </button>
                   <button
                     type="button"
@@ -97,5 +104,19 @@ export function ImageSidebar({
         </div>
       </div>
     </aside>
+  );
+}
+
+function getConversationStats(conversation: ImageConversation) {
+  return conversation.turns.reduce(
+    (acc, turn) => {
+      if (turn.status === "queued") {
+        acc.queued += 1;
+      } else if (turn.status === "generating") {
+        acc.running += 1;
+      }
+      return acc;
+    },
+    { queued: 0, running: 0 },
   );
 }

--- a/web/src/app/image/page.tsx
+++ b/web/src/app/image/page.tsx
@@ -11,6 +11,7 @@ import { editImage, fetchAccounts, generateImage, type Account, type ImageModel 
 import {
   clearImageConversations,
   deleteImageConversation,
+  getImageConversationStats,
   listImageConversations,
   saveImageConversation,
   type ImageConversation,
@@ -92,24 +93,6 @@ function buildReferenceImageFromResult(image: StoredImage, fileName: string): St
     type: "image/png",
     dataUrl: `data:image/png;base64,${image.b64_json}`,
   };
-}
-
-function getConversationStats(conversation: ImageConversation | null) {
-  if (!conversation) {
-    return { queued: 0, running: 0 };
-  }
-
-  return conversation.turns.reduce(
-    (acc, turn) => {
-      if (turn.status === "queued") {
-        acc.queued += 1;
-      } else if (turn.status === "generating") {
-        acc.running += 1;
-      }
-      return acc;
-    },
-    { queued: 0, running: 0 },
-  );
 }
 
 function pickFallbackConversationId(conversations: ImageConversation[]) {
@@ -207,13 +190,13 @@ export default function ImagePage() {
     [conversations, selectedConversationId],
   );
   const selectedConversationStats = useMemo(
-    () => getConversationStats(selectedConversation),
+    () => getImageConversationStats(selectedConversation),
     [selectedConversation],
   );
   const activeTaskCount = useMemo(
     () =>
       conversations.reduce((sum, conversation) => {
-        const stats = getConversationStats(conversation);
+        const stats = getImageConversationStats(conversation);
         return sum + stats.queued + stats.running;
       }, 0),
     [conversations],
@@ -725,7 +708,7 @@ export default function ImagePage() {
     await persistConversation(baseConversation);
     void runConversationQueue(conversationId);
 
-    const targetStats = getConversationStats(baseConversation);
+    const targetStats = getImageConversationStats(baseConversation);
     if (targetStats.running > 0 || targetStats.queued > 1) {
       toast.success("已加入当前对话队列");
     } else if (!targetConversation) {

--- a/web/src/app/image/page.tsx
+++ b/web/src/app/image/page.tsx
@@ -7,7 +7,15 @@ import { ImageComposer } from "@/app/image/components/image-composer";
 import { ImageResults, type ImageLightboxItem } from "@/app/image/components/image-results";
 import { ImageSidebar } from "@/app/image/components/image-sidebar";
 import { ImageLightbox } from "@/components/image-lightbox";
-import { editImage, fetchAccounts, generateImage, type Account, type ImageModel } from "@/lib/api";
+import {
+  createImageSession,
+  createImageSessionTurn,
+  editImage,
+  fetchAccounts,
+  generateImage,
+  type Account,
+  type ImageModel,
+} from "@/lib/api";
 import {
   clearImageConversations,
   deleteImageConversation,
@@ -23,6 +31,7 @@ import {
 } from "@/store/image-conversations";
 
 const ACTIVE_CONVERSATION_STORAGE_KEY = "chatgpt2api:image_active_conversation_id";
+const SESSION_EXPIRED_MESSAGE = "连续对话会话已失效，请从当前结果图重新开始编辑";
 const activeConversationQueueIds = new Set<string>();
 
 const imageModelOptions: Array<{ label: string; value: ImageModel }> = [
@@ -93,6 +102,38 @@ function buildReferenceImageFromResult(image: StoredImage, fileName: string): St
     type: "image/png",
     dataUrl: `data:image/png;base64,${image.b64_json}`,
   };
+}
+
+function buildReferenceFiles(referenceImages: StoredReferenceImage[], turnId: string) {
+  return referenceImages.map((image, index) =>
+    dataUrlToFile(image.dataUrl, image.name || `${turnId}-${index + 1}.png`, image.type),
+  );
+}
+
+function isSessionExpiredError(message: string) {
+  return message.includes(SESSION_EXPIRED_MESSAGE);
+}
+
+function getLatestSuccessfulReferenceImage(conversation: ImageConversation | null): StoredReferenceImage | null {
+  if (!conversation) {
+    return null;
+  }
+
+  for (let turnIndex = conversation.turns.length - 1; turnIndex >= 0; turnIndex -= 1) {
+    const turn = conversation.turns[turnIndex];
+    for (let imageIndex = turn.images.length - 1; imageIndex >= 0; imageIndex -= 1) {
+      const image = turn.images[imageIndex];
+      const referenceImage = buildReferenceImageFromResult(
+        image,
+        `conversation-${conversation.id}-turn-${turn.id}-image-${imageIndex + 1}.png`,
+      );
+      if (referenceImage) {
+        return referenceImage;
+      }
+    }
+  }
+
+  return null;
 }
 
 function pickFallbackConversationId(conversations: ImageConversation[]) {
@@ -486,12 +527,11 @@ export default function ImagePage() {
       });
 
       try {
-        const referenceFiles = queuedTurn.referenceImages.map((image, index) =>
-          dataUrlToFile(image.dataUrl, image.name || `${queuedTurn.id}-${index + 1}.png`, image.type),
-        );
+        const referenceFiles = buildReferenceFiles(queuedTurn.referenceImages, queuedTurn.id);
         const pendingImages = queuedTurn.images.filter((image) => image.status === "loading");
+        const useSessionHandle = queuedTurn.count === 1;
 
-        if (queuedTurn.mode === "edit" && referenceFiles.length === 0) {
+        if (queuedTurn.mode === "edit" && referenceFiles.length === 0 && !snapshot.sessionId) {
           throw new Error("未找到可用于继续编辑的参考图");
         }
 
@@ -514,6 +554,90 @@ export default function ImagePage() {
               ),
             };
           });
+          return;
+        }
+
+        if (useSessionHandle) {
+          const pendingImage = pendingImages[0];
+          let sessionResponse;
+          let nextSessionId = snapshot.sessionId;
+
+          try {
+            if (snapshot.sessionId) {
+              sessionResponse = await createImageSessionTurn(
+                snapshot.sessionId,
+                referenceFiles.length > 0 ? referenceFiles : null,
+                queuedTurn.prompt,
+                queuedTurn.model,
+              );
+            } else {
+              sessionResponse = await createImageSession(
+                referenceFiles.length > 0 ? referenceFiles : null,
+                queuedTurn.prompt,
+                queuedTurn.model,
+              );
+            }
+          } catch (error) {
+            const message = error instanceof Error ? error.message : "生成图片失败";
+            if (!snapshot.sessionId || !isSessionExpiredError(message)) {
+              throw error;
+            }
+
+            await updateConversation(conversationId, (current) => ({
+              ...(current ?? snapshot),
+              sessionId: undefined,
+              updatedAt: new Date().toISOString(),
+            }));
+
+            const fallbackReferenceImage =
+              referenceFiles.length > 0 ? null : getLatestSuccessfulReferenceImage(snapshot);
+            const fallbackReferenceFiles = fallbackReferenceImage
+              ? [dataUrlToFile(fallbackReferenceImage.dataUrl, fallbackReferenceImage.name, fallbackReferenceImage.type)]
+              : referenceFiles;
+            if (fallbackReferenceFiles.length === 0) {
+              throw error;
+            }
+
+            toast.error(SESSION_EXPIRED_MESSAGE);
+            sessionResponse = await createImageSession(
+              fallbackReferenceFiles,
+              queuedTurn.prompt,
+              queuedTurn.model,
+            );
+          }
+
+          const first = sessionResponse.data?.[0];
+          if (!first?.b64_json) {
+            throw new Error("未返回图片数据");
+          }
+
+          nextSessionId = sessionResponse.session_id;
+          const nextImage: StoredImage = {
+            id: pendingImage.id,
+            status: "success",
+            b64_json: first.b64_json,
+          };
+
+          await updateConversation(conversationId, (current) => {
+            const conversation = current ?? snapshot;
+            return {
+              ...conversation,
+              sessionId: nextSessionId,
+              updatedAt: new Date().toISOString(),
+              turns: conversation.turns.map((turn) =>
+                turn.id === queuedTurn.id
+                  ? {
+                      ...turn,
+                      images: turn.images.map((image) => (image.id === nextImage.id ? nextImage : image)),
+                      status: "success",
+                      error: undefined,
+                    }
+                  : turn,
+              ),
+            };
+          });
+
+          await loadQuota();
           return;
         }
 
@@ -613,6 +737,7 @@ export default function ImagePage() {
           const conversation = current ?? snapshot;
           return {
             ...conversation,
+            sessionId: isSessionExpiredError(message) ? undefined : conversation.sessionId,
             updatedAt: new Date().toISOString(),
             turns: conversation.turns.map((turn) =>
               turn.id === queuedTurn.id
@@ -662,14 +787,17 @@ export default function ImagePage() {
       return;
     }
 
-    if (imageMode === "edit" && referenceImageFiles.length === 0) {
-      toast.error("请先上传参考图");
-      return;
-    }
-
     const targetConversation = selectedConversationId
       ? conversationsRef.current.find((conversation) => conversation.id === selectedConversationId) ?? null
       : null;
+    if (imageMode === "edit" && referenceImageFiles.length === 0 && !targetConversation?.sessionId) {
+      toast.error("请先上传参考图");
+      return;
+    }
+    if (targetConversation?.sessionId && parsedCount > 1) {
+      toast.error("连续对话暂只支持每轮 1 张图片");
+      return;
+    }
     const now = new Date().toISOString();
     const conversationId = targetConversation?.id ?? createId();
     const turnId = createId();

--- a/web/src/app/image/page.tsx
+++ b/web/src/app/image/page.tsx
@@ -3,11 +3,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
+import { ImageComposer } from "@/app/image/components/image-composer";
+import { ImageResults, type ImageLightboxItem } from "@/app/image/components/image-results";
+import { ImageSidebar } from "@/app/image/components/image-sidebar";
 import { ImageLightbox } from "@/components/image-lightbox";
 import { editImage, fetchAccounts, generateImage, type Account, type ImageModel } from "@/lib/api";
-import { ImageComposer } from "@/app/image/components/image-composer";
-import { ImageResults } from "@/app/image/components/image-results";
-import { ImageSidebar } from "@/app/image/components/image-sidebar";
 import {
   clearImageConversations,
   deleteImageConversation,
@@ -15,9 +15,14 @@ import {
   saveImageConversation,
   type ImageConversation,
   type ImageConversationMode,
+  type ImageTurn,
+  type ImageTurnStatus,
   type StoredImage,
   type StoredReferenceImage,
 } from "@/store/image-conversations";
+
+const ACTIVE_CONVERSATION_STORAGE_KEY = "chatgpt2api:image_active_conversation_id";
+const activeConversationQueueIds = new Set<string>();
 
 const imageModelOptions: Array<{ label: string; value: ImageModel }> = [
   { label: "gpt-image-1", value: "gpt-image-1" },
@@ -26,10 +31,10 @@ const imageModelOptions: Array<{ label: string; value: ImageModel }> = [
 
 function buildConversationTitle(prompt: string) {
   const trimmed = prompt.trim();
-  if (trimmed.length <= 5) {
+  if (trimmed.length <= 12) {
     return trimmed;
   }
-  return `${trimmed.slice(0, 5)}...`;
+  return `${trimmed.slice(0, 12)}...`;
 }
 
 function formatConversationTime(value: string) {
@@ -50,41 +55,11 @@ function formatAvailableQuota(accounts: Account[]) {
   return String(availableAccounts.reduce((sum, account) => sum + Math.max(0, account.quota), 0));
 }
 
-async function normalizeConversationHistory(items: ImageConversation[]) {
-  const normalized = items.map((item) =>
-    item.status === "generating"
-      ? {
-          ...item,
-          status: "error" as const,
-          error: item.images.some((image) => image.status === "success")
-            ? item.error || "生成已中断"
-            : "页面已刷新，生成已中断",
-          images: item.images.map((image) =>
-            image.status === "loading"
-              ? {
-                  ...image,
-                  status: "error" as const,
-                  error: "页面已刷新，生成已中断",
-                }
-              : image,
-          ),
-        }
-      : item,
-  );
-
-  await Promise.all(
-    normalized
-      .filter((item, index) => item !== items[index])
-      .map((item) => saveImageConversation(item)),
-  );
-
-  return normalized;
-}
-
 function createId() {
-  return typeof crypto !== "undefined" && "randomUUID" in crypto
-    ? crypto.randomUUID()
-    : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 }
 
 function readFileAsDataUrl(file: File) {
@@ -96,8 +71,118 @@ function readFileAsDataUrl(file: File) {
   });
 }
 
+function dataUrlToFile(dataUrl: string, fileName: string, mimeType?: string) {
+  const [header, content] = dataUrl.split(",", 2);
+  const matchedMimeType = header.match(/data:(.*?);base64/)?.[1];
+  const binary = atob(content || "");
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return new File([bytes], fileName, { type: mimeType || matchedMimeType || "image/png" });
+}
+
+function buildReferenceImageFromResult(image: StoredImage, fileName: string): StoredReferenceImage | null {
+  if (!image.b64_json) {
+    return null;
+  }
+
+  return {
+    name: fileName,
+    type: "image/png",
+    dataUrl: `data:image/png;base64,${image.b64_json}`,
+  };
+}
+
+function getConversationStats(conversation: ImageConversation | null) {
+  if (!conversation) {
+    return { queued: 0, running: 0 };
+  }
+
+  return conversation.turns.reduce(
+    (acc, turn) => {
+      if (turn.status === "queued") {
+        acc.queued += 1;
+      } else if (turn.status === "generating") {
+        acc.running += 1;
+      }
+      return acc;
+    },
+    { queued: 0, running: 0 },
+  );
+}
+
+function pickFallbackConversationId(conversations: ImageConversation[]) {
+  const activeConversation = conversations.find((conversation) =>
+    conversation.turns.some((turn) => turn.status === "queued" || turn.status === "generating"),
+  );
+  return activeConversation?.id ?? conversations[0]?.id ?? null;
+}
+
+async function recoverConversationHistory(items: ImageConversation[]) {
+  const normalized = items.map((conversation) => {
+    let changed = false;
+
+    const turns = conversation.turns.map((turn) => {
+      if (turn.status !== "queued" && turn.status !== "generating") {
+        return turn;
+      }
+
+      const loadingCount = turn.images.filter((image) => image.status === "loading").length;
+      if (loadingCount > 0 && turn.status === "generating") {
+        changed = true;
+        return {
+          ...turn,
+          status: "queued" as const,
+          error: undefined,
+        };
+      }
+
+      if (loadingCount > 0) {
+        return turn;
+      }
+
+      const failedCount = turn.images.filter((image) => image.status === "error").length;
+      const successCount = turn.images.filter((image) => image.status === "success").length;
+      const nextStatus: ImageTurnStatus =
+        failedCount > 0 ? "error" : successCount > 0 ? "success" : "queued";
+      const nextError = failedCount > 0 ? turn.error || `其中 ${failedCount} 张未成功生成` : undefined;
+      if (nextStatus === turn.status && nextError === turn.error) {
+        return turn;
+      }
+
+      changed = true;
+      return {
+        ...turn,
+        status: nextStatus,
+        error: nextError,
+      };
+    });
+
+    if (!changed) {
+      return conversation;
+    }
+
+    const lastTurn = turns.length > 0 ? turns[turns.length - 1] : null;
+    return {
+      ...conversation,
+      turns,
+      updatedAt: lastTurn?.createdAt || conversation.updatedAt,
+    };
+  });
+
+  await Promise.all(
+    normalized
+      .filter((conversation, index) => conversation !== items[index])
+      .map((conversation) => saveImageConversation(conversation)),
+  );
+
+  return normalized;
+}
+
 export default function ImagePage() {
   const didLoadQuotaRef = useRef(false);
+  const conversationsRef = useRef<ImageConversation[]>([]);
   const resultsViewportRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -111,49 +196,32 @@ export default function ImagePage() {
   const [conversations, setConversations] = useState<ImageConversation[]>([]);
   const [selectedConversationId, setSelectedConversationId] = useState<string | null>(null);
   const [isLoadingHistory, setIsLoadingHistory] = useState(true);
-  const [generatingIds, setGeneratingIds] = useState<Set<string>>(new Set());
-  const [availableQuota, setAvailableQuota] = useState("加载中");
+  const [availableQuota, setAvailableQuota] = useState("加载中...");
+  const [lightboxImages, setLightboxImages] = useState<ImageLightboxItem[]>([]);
   const [lightboxOpen, setLightboxOpen] = useState(false);
   const [lightboxIndex, setLightboxIndex] = useState(0);
 
+  const parsedCount = useMemo(() => Math.max(1, Math.min(10, Number(imageCount) || 1)), [imageCount]);
   const selectedConversation = useMemo(
     () => conversations.find((item) => item.id === selectedConversationId) ?? null,
     [conversations, selectedConversationId],
   );
-  const parsedCount = useMemo(() => Math.max(1, Math.min(10, Number(imageCount) || 1)), [imageCount]);
-  const isSelectedGenerating = selectedConversationId !== null && generatingIds.has(selectedConversationId);
-  const hasAnyGenerating = generatingIds.size > 0;
-
-  const addGeneratingId = useCallback((id: string) => {
-    setGeneratingIds((prev) => new Set(prev).add(id));
-  }, []);
-
-  const removeGeneratingId = useCallback((id: string) => {
-    setGeneratingIds((prev) => {
-      const next = new Set(prev);
-      next.delete(id);
-      return next;
-    });
-  }, []);
-
-  const lightboxImages = useMemo(
-    () =>
-      (selectedConversation?.images ?? [])
-        .filter((img): img is StoredImage & { b64_json: string } => img.status === "success" && !!img.b64_json)
-        .map((img) => ({ id: img.id, src: `data:image/png;base64,${img.b64_json}` })),
+  const selectedConversationStats = useMemo(
+    () => getConversationStats(selectedConversation),
     [selectedConversation],
   );
-
-  const openLightbox = useCallback(
-    (imageId: string) => {
-      const idx = lightboxImages.findIndex((img) => img.id === imageId);
-      if (idx >= 0) {
-        setLightboxIndex(idx);
-        setLightboxOpen(true);
-      }
-    },
-    [lightboxImages],
+  const activeTaskCount = useMemo(
+    () =>
+      conversations.reduce((sum, conversation) => {
+        const stats = getConversationStats(conversation);
+        return sum + stats.queued + stats.running;
+      }, 0),
+    [conversations],
   );
+
+  useEffect(() => {
+    conversationsRef.current = conversations;
+  }, [conversations]);
 
   useEffect(() => {
     let cancelled = false;
@@ -161,11 +229,19 @@ export default function ImagePage() {
     const loadHistory = async () => {
       try {
         const items = await listImageConversations();
-        const normalizedItems = await normalizeConversationHistory(items);
+        const normalizedItems = await recoverConversationHistory(items);
         if (cancelled) {
           return;
         }
+
         setConversations(normalizedItems);
+        const storedConversationId =
+          typeof window !== "undefined" ? window.localStorage.getItem(ACTIVE_CONVERSATION_STORAGE_KEY) : null;
+        const nextSelectedConversationId =
+          (storedConversationId && normalizedItems.some((conversation) => conversation.id === storedConversationId)
+            ? storedConversationId
+            : null) ?? pickFallbackConversationId(normalizedItems);
+        setSelectedConversationId(nextSelectedConversationId);
       } catch (error) {
         const message = error instanceof Error ? error.message : "读取会话记录失败";
         toast.error(message);
@@ -187,7 +263,7 @@ export default function ImagePage() {
       const data = await fetchAccounts();
       setAvailableQuota(formatAvailableQuota(data.items));
     } catch {
-      setAvailableQuota((prev) => (prev === "加载中" ? "—" : prev));
+      setAvailableQuota((prev) => (prev === "加载中..." ? "--" : prev));
     }
   }, []);
 
@@ -197,15 +273,11 @@ export default function ImagePage() {
     }
     didLoadQuotaRef.current = true;
 
-    const syncQuota = async () => {
-      await loadQuota();
-    };
-
     const handleFocus = () => {
-      void syncQuota();
+      void loadQuota();
     };
 
-    void syncQuota();
+    void loadQuota();
     window.addEventListener("focus", handleFocus);
     return () => {
       window.removeEventListener("focus", handleFocus);
@@ -213,7 +285,7 @@ export default function ImagePage() {
   }, [loadQuota]);
 
   useEffect(() => {
-    if (!selectedConversation && !isSelectedGenerating) {
+    if (!selectedConversation) {
       return;
     }
 
@@ -221,35 +293,53 @@ export default function ImagePage() {
       top: resultsViewportRef.current.scrollHeight,
       behavior: "smooth",
     });
-  }, [selectedConversation, isSelectedGenerating]);
+  }, [selectedConversation?.updatedAt, selectedConversation?.turns.length, selectedConversation]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    if (selectedConversationId) {
+      window.localStorage.setItem(ACTIVE_CONVERSATION_STORAGE_KEY, selectedConversationId);
+    } else {
+      window.localStorage.removeItem(ACTIVE_CONVERSATION_STORAGE_KEY);
+    }
+  }, [selectedConversationId]);
+
+  useEffect(() => {
+    if (selectedConversationId && !conversations.some((conversation) => conversation.id === selectedConversationId)) {
+      setSelectedConversationId(pickFallbackConversationId(conversations));
+    }
+  }, [conversations, selectedConversationId]);
 
   const persistConversation = async (conversation: ImageConversation) => {
     setConversations((prev) => {
       const next = [conversation, ...prev.filter((item) => item.id !== conversation.id)];
-      return next.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+      return next.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
     });
     await saveImageConversation(conversation);
   };
 
-  const updateConversation = async (
-    conversationId: string,
-    updater: (current: ImageConversation | null) => ImageConversation,
-  ) => {
-    let nextConversation: ImageConversation | null = null;
+  const updateConversation = useCallback(
+    async (conversationId: string, updater: (current: ImageConversation | null) => ImageConversation) => {
+      let nextConversation: ImageConversation | null = null;
 
-    setConversations((prev) => {
-      const current = prev.find((item) => item.id === conversationId) ?? null;
-      nextConversation = updater(current);
-      const next = [nextConversation, ...prev.filter((item) => item.id !== conversationId)];
-      return next.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
-    });
+      setConversations((prev) => {
+        const current = prev.find((item) => item.id === conversationId) ?? null;
+        nextConversation = updater(current);
+        const next = [nextConversation, ...prev.filter((item) => item.id !== conversationId)];
+        return next.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+      });
 
-    if (nextConversation) {
-      await saveImageConversation(nextConversation);
-    }
-  };
+      if (nextConversation) {
+        await saveImageConversation(nextConversation);
+      }
+    },
+    [],
+  );
 
-  const resetComposer = useCallback(() => {
+  const clearComposerInputs = useCallback(() => {
     setImagePrompt("");
     setImageCount("1");
     setReferenceImageFiles([]);
@@ -258,6 +348,11 @@ export default function ImagePage() {
       fileInputRef.current.value = "";
     }
   }, []);
+
+  const resetComposer = useCallback(() => {
+    setImageMode("generate");
+    clearComposerInputs();
+  }, [clearComposerInputs]);
 
   const handleCreateDraft = () => {
     setSelectedConversationId(null);
@@ -268,7 +363,10 @@ export default function ImagePage() {
   const handleDeleteConversation = async (id: string) => {
     const nextConversations = conversations.filter((item) => item.id !== id);
     setConversations(nextConversations);
-    setSelectedConversationId((prev) => (prev === id ? null : prev));
+    if (selectedConversationId === id) {
+      setSelectedConversationId(pickFallbackConversationId(nextConversations));
+      resetComposer();
+    }
 
     try {
       await deleteImageConversation(id);
@@ -285,6 +383,7 @@ export default function ImagePage() {
       await clearImageConversations();
       setConversations([]);
       setSelectedConversationId(null);
+      resetComposer();
       toast.success("已清空历史记录");
     } catch (error) {
       const message = error instanceof Error ? error.message : "清空历史记录失败";
@@ -305,8 +404,10 @@ export default function ImagePage() {
           dataUrl: await readFileAsDataUrl(file),
         })),
       );
+
       setReferenceImageFiles((prev) => [...prev, ...files]);
       setReferenceImages((prev) => [...prev, ...previews]);
+      setImageMode("edit");
       if (fileInputRef.current) {
         fileInputRef.current.value = "";
       }
@@ -316,15 +417,16 @@ export default function ImagePage() {
     }
   }, []);
 
-  const handleReferenceImageChange = useCallback(async (files: File[]) => {
-    if (files.length === 0) {
-      setReferenceImageFiles([]);
-      setReferenceImages([]);
-      return;
-    }
+  const handleReferenceImageChange = useCallback(
+    async (files: File[]) => {
+      if (files.length === 0) {
+        return;
+      }
 
-    await appendReferenceImages(files);
-  }, [appendReferenceImages]);
+      await appendReferenceImages(files);
+    },
+    [appendReferenceImages],
+  );
 
   const handleRemoveReferenceImage = useCallback((index: number) => {
     setReferenceImageFiles((prev) => {
@@ -337,7 +439,240 @@ export default function ImagePage() {
     setReferenceImages((prev) => prev.filter((_, currentIndex) => currentIndex !== index));
   }, []);
 
-  const handleGenerateImage = async () => {
+  const handleContinueEdit = useCallback(
+    (conversationId: string, image: StoredImage) => {
+      const nextReferenceImage = buildReferenceImageFromResult(
+        image,
+        `conversation-${conversationId}-${Date.now()}.png`,
+      );
+      if (!nextReferenceImage) {
+        return;
+      }
+
+      setSelectedConversationId(conversationId);
+      setImageMode("edit");
+      setReferenceImages([nextReferenceImage]);
+      setReferenceImageFiles([
+        dataUrlToFile(nextReferenceImage.dataUrl, nextReferenceImage.name, nextReferenceImage.type),
+      ]);
+      setImagePrompt("");
+      textareaRef.current?.focus();
+      toast.success("已把这张结果图设为当前参考图");
+    },
+    [],
+  );
+
+  const openLightbox = useCallback((images: ImageLightboxItem[], index: number) => {
+    if (images.length === 0) {
+      return;
+    }
+
+    setLightboxImages(images);
+    setLightboxIndex(Math.max(0, Math.min(index, images.length - 1)));
+    setLightboxOpen(true);
+  }, []);
+
+  const runConversationQueue = useCallback(
+    async (conversationId: string) => {
+      if (activeConversationQueueIds.has(conversationId)) {
+        return;
+      }
+
+      const snapshot = conversationsRef.current.find((conversation) => conversation.id === conversationId);
+      const queuedTurn = snapshot?.turns.find((turn) => turn.status === "queued");
+      if (!snapshot || !queuedTurn) {
+        return;
+      }
+
+      activeConversationQueueIds.add(conversationId);
+      await updateConversation(conversationId, (current) => {
+        const conversation = current ?? snapshot;
+        return {
+          ...conversation,
+          updatedAt: new Date().toISOString(),
+          turns: conversation.turns.map((turn) =>
+            turn.id === queuedTurn.id
+              ? {
+                  ...turn,
+                  status: "generating",
+                  error: undefined,
+                }
+              : turn,
+          ),
+        };
+      });
+
+      try {
+        const referenceFiles = queuedTurn.referenceImages.map((image, index) =>
+          dataUrlToFile(image.dataUrl, image.name || `${queuedTurn.id}-${index + 1}.png`, image.type),
+        );
+        const pendingImages = queuedTurn.images.filter((image) => image.status === "loading");
+
+        if (queuedTurn.mode === "edit" && referenceFiles.length === 0) {
+          throw new Error("未找到可用于继续编辑的参考图");
+        }
+
+        if (pendingImages.length === 0) {
+          const existingFailedCount = queuedTurn.images.filter((image) => image.status === "error").length;
+          const existingSuccessCount = queuedTurn.images.filter((image) => image.status === "success").length;
+          await updateConversation(conversationId, (current) => {
+            const conversation = current ?? snapshot;
+            return {
+              ...conversation,
+              updatedAt: new Date().toISOString(),
+              turns: conversation.turns.map((turn) =>
+                turn.id === queuedTurn.id
+                  ? {
+                      ...turn,
+                      status: existingFailedCount > 0 ? "error" : existingSuccessCount > 0 ? "success" : "queued",
+                      error: existingFailedCount > 0 ? `其中 ${existingFailedCount} 张未成功生成` : undefined,
+                    }
+                  : turn,
+              ),
+            };
+          });
+          return;
+        }
+
+        const tasks = pendingImages.map(async (pendingImage) => {
+          try {
+            const data =
+              queuedTurn.mode === "edit"
+                ? await editImage(referenceFiles, queuedTurn.prompt, queuedTurn.model)
+                : await generateImage(queuedTurn.prompt, queuedTurn.model);
+            const first = data.data?.[0];
+            if (!first?.b64_json) {
+              throw new Error("未返回图片数据");
+            }
+
+            const nextImage: StoredImage = {
+              id: pendingImage.id,
+              status: "success",
+              b64_json: first.b64_json,
+            };
+
+            await updateConversation(conversationId, (current) => {
+              const conversation = current ?? snapshot;
+              return {
+                ...conversation,
+                updatedAt: new Date().toISOString(),
+                turns: conversation.turns.map((turn) =>
+                  turn.id === queuedTurn.id
+                    ? {
+                        ...turn,
+                        images: turn.images.map((image) => (image.id === nextImage.id ? nextImage : image)),
+                      }
+                    : turn,
+                ),
+              };
+            });
+
+            return nextImage;
+          } catch (error) {
+            const message = error instanceof Error ? error.message : "生成失败";
+            const failedImage: StoredImage = {
+              id: pendingImage.id,
+              status: "error",
+              error: message,
+            };
+
+            await updateConversation(conversationId, (current) => {
+              const conversation = current ?? snapshot;
+              return {
+                ...conversation,
+                updatedAt: new Date().toISOString(),
+                turns: conversation.turns.map((turn) =>
+                  turn.id === queuedTurn.id
+                    ? {
+                        ...turn,
+                        images: turn.images.map((image) => (image.id === failedImage.id ? failedImage : image)),
+                      }
+                    : turn,
+                ),
+              };
+            });
+
+            throw error;
+          }
+        });
+
+        const settled = await Promise.allSettled(tasks);
+        const resumedSuccessCount = settled.filter(
+          (item): item is PromiseFulfilledResult<StoredImage> => item.status === "fulfilled",
+        ).length;
+        const resumedFailedCount = settled.length - resumedSuccessCount;
+        const existingSuccessCount = queuedTurn.images.filter((image) => image.status === "success").length;
+        const existingFailedCount = queuedTurn.images.filter((image) => image.status === "error").length;
+        const successCount = existingSuccessCount + resumedSuccessCount;
+        const failedCount = existingFailedCount + resumedFailedCount;
+
+        await updateConversation(conversationId, (current) => {
+          const conversation = current ?? snapshot;
+          return {
+            ...conversation,
+            updatedAt: new Date().toISOString(),
+            turns: conversation.turns.map((turn) =>
+              turn.id === queuedTurn.id
+                ? {
+                    ...turn,
+                    status: failedCount > 0 ? "error" : "success",
+                    error: failedCount > 0 ? `其中 ${failedCount} 张未成功生成` : undefined,
+                  }
+                : turn,
+            ),
+          };
+        });
+
+        await loadQuota();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "生成图片失败";
+        await updateConversation(conversationId, (current) => {
+          const conversation = current ?? snapshot;
+          return {
+            ...conversation,
+            updatedAt: new Date().toISOString(),
+            turns: conversation.turns.map((turn) =>
+              turn.id === queuedTurn.id
+                ? {
+                    ...turn,
+                    status: "error",
+                    error: message,
+                    images: turn.images.map((image) =>
+                      image.status === "loading" ? { ...image, status: "error", error: message } : image,
+                    ),
+                  }
+                : turn,
+            ),
+          };
+        });
+        toast.error(message);
+      } finally {
+        activeConversationQueueIds.delete(conversationId);
+        for (const conversation of conversationsRef.current) {
+          if (
+            !activeConversationQueueIds.has(conversation.id) &&
+            conversation.turns.some((turn) => turn.status === "queued")
+          ) {
+            void runConversationQueue(conversation.id);
+          }
+        }
+      }
+    },
+    [loadQuota, updateConversation],
+  );
+
+  useEffect(() => {
+    for (const conversation of conversations) {
+      if (
+        !activeConversationQueueIds.has(conversation.id) &&
+        conversation.turns.some((turn) => turn.status === "queued")
+      ) {
+        void runConversationQueue(conversation.id);
+      }
+    }
+  }, [conversations, runConversationQueue]);
+
+  const handleSubmit = async () => {
     const prompt = imagePrompt.trim();
     if (!prompt) {
       toast.error("请输入提示词");
@@ -349,118 +684,54 @@ export default function ImagePage() {
       return;
     }
 
+    const targetConversation = selectedConversationId
+      ? conversationsRef.current.find((conversation) => conversation.id === selectedConversationId) ?? null
+      : null;
     const now = new Date().toISOString();
-    const conversationId = createId();
-    const draftReferenceImages = imageMode === "edit" ? referenceImages : [];
-
-    const draftConversation: ImageConversation = {
-      id: conversationId,
-      title: buildConversationTitle(prompt),
+    const conversationId = targetConversation?.id ?? createId();
+    const turnId = createId();
+    const draftTurn: ImageTurn = {
+      id: turnId,
       prompt,
       model: imageModel,
       mode: imageMode,
-      referenceImages: draftReferenceImages,
+      referenceImages: imageMode === "edit" ? referenceImages : [],
       count: parsedCount,
       images: Array.from({ length: parsedCount }, (_, index) => ({
-        id: `${conversationId}-${index}`,
-        status: "loading",
+        id: `${turnId}-${index}`,
+        status: "loading" as const,
       })),
       createdAt: now,
-      status: "generating",
+      status: "queued",
     };
 
-    addGeneratingId(conversationId);
-    setSelectedConversationId(conversationId);
-    resetComposer();
-
-    try {
-      await persistConversation(draftConversation);
-
-      const tasks = Array.from({ length: parsedCount }, async (_, index) => {
-        try {
-          const data =
-            imageMode === "edit" && referenceImageFiles.length > 0
-              ? await editImage(referenceImageFiles, prompt, imageModel)
-              : await generateImage(prompt, imageModel);
-          const first = data.data?.[0];
-          if (!first?.b64_json) {
-            throw new Error(`第 ${index + 1} 张没有返回图片数据`);
-          }
-
-          const nextImage: StoredImage = {
-            id: `${conversationId}-${index}`,
-            status: "success",
-            b64_json: first.b64_json,
-          };
-
-          await updateConversation(conversationId, (current) => ({
-            ...(current ?? draftConversation),
-            images: (current?.images ?? draftConversation.images).map((image) =>
-              image.id === nextImage.id ? nextImage : image,
-            ),
-          }));
-
-          return nextImage;
-        } catch (error) {
-          const message = error instanceof Error ? error.message : `第 ${index + 1} 张生成失败`;
-          const failedImage: StoredImage = {
-            id: `${conversationId}-${index}`,
-            status: "error",
-            error: message,
-          };
-
-          await updateConversation(conversationId, (current) => ({
-            ...(current ?? draftConversation),
-            images: (current?.images ?? draftConversation.images).map((image) =>
-              image.id === failedImage.id ? failedImage : image,
-            ),
-          }));
-
-          throw error;
+    const baseConversation: ImageConversation = targetConversation
+      ? {
+          ...targetConversation,
+          updatedAt: now,
+          turns: [...targetConversation.turns, draftTurn],
         }
-      });
+      : {
+          id: conversationId,
+          title: buildConversationTitle(prompt),
+          createdAt: now,
+          updatedAt: now,
+          turns: [draftTurn],
+        };
 
-      const settled = await Promise.allSettled(tasks);
-      const successCount = settled.filter((item): item is PromiseFulfilledResult<StoredImage> => item.status === "fulfilled")
-        .length;
-      const failedCount = settled.length - successCount;
+    setSelectedConversationId(conversationId);
+    clearComposerInputs();
 
-      if (successCount === 0) {
-        const firstError = settled.find((item) => item.status === "rejected");
-        throw new Error(firstError?.status === "rejected" ? String(firstError.reason) : "生成图片失败");
-      }
+    await persistConversation(baseConversation);
+    void runConversationQueue(conversationId);
 
-      await updateConversation(conversationId, (current) => ({
-        ...(current ?? draftConversation),
-        status: failedCount > 0 ? "error" : "success",
-        error: failedCount > 0 ? `其中 ${failedCount} 张生成失败` : undefined,
-      }));
-      await loadQuota();
-
-      if (failedCount > 0) {
-        toast.error(`已完成 ${successCount} 张，另有 ${failedCount} 张未生成成功`);
-      } else {
-        toast.success(imageMode === "edit" ? `已完成 ${successCount} 张图片编辑` : `已生成 ${successCount} 张图片`);
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : imageMode === "edit" ? "编辑图片失败" : "生成图片失败";
-      await persistConversation({
-        ...draftConversation,
-        status: "error",
-        error: message,
-        images: draftConversation.images.map((image) =>
-          image.status === "loading"
-            ? {
-                ...image,
-                status: "error",
-                error: message,
-              }
-            : image,
-        ),
-      });
-      toast.error(message);
-    } finally {
-      removeGeneratingId(conversationId);
+    const targetStats = getConversationStats(baseConversation);
+    if (targetStats.running > 0 || targetStats.queued > 1) {
+      toast.success("已加入当前对话队列");
+    } else if (!targetConversation) {
+      toast.success("已创建新对话并开始处理");
+    } else {
+      toast.success("已发送到当前对话");
     }
   };
 
@@ -470,7 +741,6 @@ export default function ImagePage() {
         <ImageSidebar
           conversations={conversations}
           isLoadingHistory={isLoadingHistory}
-          generatingIds={generatingIds}
           selectedConversationId={selectedConversationId}
           onCreateDraft={handleCreateDraft}
           onClearHistory={handleClearHistory}
@@ -486,8 +756,8 @@ export default function ImagePage() {
           >
             <ImageResults
               selectedConversation={selectedConversation}
-              isSelectedGenerating={isSelectedGenerating}
-              openLightbox={openLightbox}
+              onOpenLightbox={openLightbox}
+              onContinueEdit={handleContinueEdit}
               formatConversationTime={formatConversationTime}
             />
           </div>
@@ -498,8 +768,9 @@ export default function ImagePage() {
             model={imageModel}
             imageCount={imageCount}
             availableQuota={availableQuota}
-            hasAnyGenerating={hasAnyGenerating}
-            generatingCount={generatingIds.size}
+            activeTaskCount={activeTaskCount}
+            selectedConversationTitle={selectedConversation?.title ?? null}
+            selectedConversationStats={selectedConversation ? selectedConversationStats : null}
             referenceImages={referenceImages}
             textareaRef={textareaRef}
             fileInputRef={fileInputRef}
@@ -508,7 +779,7 @@ export default function ImagePage() {
             onPromptChange={setImagePrompt}
             onModelChange={setImageModel}
             onImageCountChange={setImageCount}
-            onSubmit={handleGenerateImage}
+            onSubmit={handleSubmit}
             onPickReferenceImage={() => fileInputRef.current?.click()}
             onReferenceImageChange={handleReferenceImageChange}
             onRemoveReferenceImage={handleRemoveReferenceImage}

--- a/web/src/app/image/page.tsx
+++ b/web/src/app/image/page.tsx
@@ -352,7 +352,11 @@ export default function ImagePage() {
   };
 
   const updateConversation = useCallback(
-    async (conversationId: string, updater: (current: ImageConversation | null) => ImageConversation) => {
+    async (
+      conversationId: string,
+      updater: (current: ImageConversation | null) => ImageConversation,
+      options: { persist?: boolean } = {},
+    ) => {
       const current = conversationsRef.current.find((item) => item.id === conversationId) ?? null;
       const nextConversation = updater(current);
       const nextConversations = sortImageConversations([
@@ -361,7 +365,9 @@ export default function ImagePage() {
       ]);
       conversationsRef.current = nextConversations;
       setConversations(nextConversations);
-      await saveImageConversations(nextConversations);
+      if (options.persist !== false) {
+        await saveImageConversations(nextConversations);
+      }
     },
     [],
   );
@@ -664,21 +670,25 @@ export default function ImagePage() {
               b64_json: first.b64_json,
             };
 
-            await updateConversation(conversationId, (current) => {
-              const conversation = current ?? snapshot;
-              return {
-                ...conversation,
-                updatedAt: new Date().toISOString(),
-                turns: conversation.turns.map((turn) =>
-                  turn.id === queuedTurn.id
-                    ? {
-                        ...turn,
-                        images: turn.images.map((image) => (image.id === nextImage.id ? nextImage : image)),
-                      }
-                    : turn,
-                ),
-              };
-            });
+            await updateConversation(
+              conversationId,
+              (current) => {
+                const conversation = current ?? snapshot;
+                return {
+                  ...conversation,
+                  updatedAt: new Date().toISOString(),
+                  turns: conversation.turns.map((turn) =>
+                    turn.id === queuedTurn.id
+                      ? {
+                          ...turn,
+                          images: turn.images.map((image) => (image.id === nextImage.id ? nextImage : image)),
+                        }
+                      : turn,
+                  ),
+                };
+              },
+              { persist: false },
+            );
 
             return nextImage;
           } catch (error) {
@@ -689,21 +699,25 @@ export default function ImagePage() {
               error: message,
             };
 
-            await updateConversation(conversationId, (current) => {
-              const conversation = current ?? snapshot;
-              return {
-                ...conversation,
-                updatedAt: new Date().toISOString(),
-                turns: conversation.turns.map((turn) =>
-                  turn.id === queuedTurn.id
-                    ? {
-                        ...turn,
-                        images: turn.images.map((image) => (image.id === failedImage.id ? failedImage : image)),
-                      }
-                    : turn,
-                ),
-              };
-            });
+            await updateConversation(
+              conversationId,
+              (current) => {
+                const conversation = current ?? snapshot;
+                return {
+                  ...conversation,
+                  updatedAt: new Date().toISOString(),
+                  turns: conversation.turns.map((turn) =>
+                    turn.id === queuedTurn.id
+                      ? {
+                          ...turn,
+                          images: turn.images.map((image) => (image.id === failedImage.id ? failedImage : image)),
+                        }
+                      : turn,
+                  ),
+                };
+              },
+              { persist: false },
+            );
 
             throw error;
           }

--- a/web/src/app/image/page.tsx
+++ b/web/src/app/image/page.tsx
@@ -21,7 +21,7 @@ import {
   deleteImageConversation,
   getImageConversationStats,
   listImageConversations,
-  saveImageConversation,
+  saveImageConversations,
   type ImageConversation,
   type ImageConversationMode,
   type ImageTurn,
@@ -143,6 +143,10 @@ function pickFallbackConversationId(conversations: ImageConversation[]) {
   return activeConversation?.id ?? conversations[0]?.id ?? null;
 }
 
+function sortImageConversations(conversations: ImageConversation[]) {
+  return [...conversations].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+}
+
 async function recoverConversationHistory(items: ImageConversation[]) {
   const normalized = items.map((conversation) => {
     let changed = false;
@@ -195,11 +199,10 @@ async function recoverConversationHistory(items: ImageConversation[]) {
     };
   });
 
-  await Promise.all(
-    normalized
-      .filter((conversation, index) => conversation !== items[index])
-      .map((conversation) => saveImageConversation(conversation)),
-  );
+  const changedConversations = normalized.filter((conversation, index) => conversation !== items[index]);
+  if (changedConversations.length > 0) {
+    await saveImageConversations(normalized);
+  }
 
   return normalized;
 }
@@ -258,6 +261,7 @@ export default function ImagePage() {
           return;
         }
 
+        conversationsRef.current = normalizedItems;
         setConversations(normalizedItems);
         const storedConversationId =
           typeof window !== "undefined" ? window.localStorage.getItem(ACTIVE_CONVERSATION_STORAGE_KEY) : null;
@@ -338,27 +342,26 @@ export default function ImagePage() {
   }, [conversations, selectedConversationId]);
 
   const persistConversation = async (conversation: ImageConversation) => {
-    setConversations((prev) => {
-      const next = [conversation, ...prev.filter((item) => item.id !== conversation.id)];
-      return next.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
-    });
-    await saveImageConversation(conversation);
+    const nextConversations = sortImageConversations([
+      conversation,
+      ...conversationsRef.current.filter((item) => item.id !== conversation.id),
+    ]);
+    conversationsRef.current = nextConversations;
+    setConversations(nextConversations);
+    await saveImageConversations(nextConversations);
   };
 
   const updateConversation = useCallback(
     async (conversationId: string, updater: (current: ImageConversation | null) => ImageConversation) => {
-      let nextConversation: ImageConversation | null = null;
-
-      setConversations((prev) => {
-        const current = prev.find((item) => item.id === conversationId) ?? null;
-        nextConversation = updater(current);
-        const next = [nextConversation, ...prev.filter((item) => item.id !== conversationId)];
-        return next.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
-      });
-
-      if (nextConversation) {
-        await saveImageConversation(nextConversation);
-      }
+      const current = conversationsRef.current.find((item) => item.id === conversationId) ?? null;
+      const nextConversation = updater(current);
+      const nextConversations = sortImageConversations([
+        nextConversation,
+        ...conversationsRef.current.filter((item) => item.id !== conversationId),
+      ]);
+      conversationsRef.current = nextConversations;
+      setConversations(nextConversations);
+      await saveImageConversations(nextConversations);
     },
     [],
   );
@@ -386,6 +389,7 @@ export default function ImagePage() {
 
   const handleDeleteConversation = async (id: string) => {
     const nextConversations = conversations.filter((item) => item.id !== id);
+    conversationsRef.current = nextConversations;
     setConversations(nextConversations);
     if (selectedConversationId === id) {
       setSelectedConversationId(pickFallbackConversationId(nextConversations));
@@ -398,6 +402,7 @@ export default function ImagePage() {
       const message = error instanceof Error ? error.message : "删除会话失败";
       toast.error(message);
       const items = await listImageConversations();
+      conversationsRef.current = items;
       setConversations(items);
     }
   };
@@ -405,6 +410,7 @@ export default function ImagePage() {
   const handleClearHistory = async () => {
     try {
       await clearImageConversations();
+      conversationsRef.current = [];
       setConversations([]);
       setSelectedConversationId(null);
       resetComposer();

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -49,6 +49,14 @@ type AccountUpdateResponse = {
   items: Account[];
 };
 
+export type ImageSessionResponse = {
+  session_id: string;
+  created: number;
+  data: Array<{ b64_json: string; revised_prompt?: string }>;
+  updated_at: string;
+  expires_at: string;
+};
+
 export type SettingsConfig = {
   proxy: string;
   "auth-key"?: string;
@@ -143,6 +151,50 @@ export async function editImage(files: File | File[], prompt: string, model: Ima
       body: formData,
     },
   );
+}
+
+function appendImageFiles(formData: FormData, files: File | File[] | null | undefined) {
+  if (!files) {
+    return;
+  }
+
+  const uploadFiles = Array.isArray(files) ? files : [files];
+  uploadFiles.forEach((file) => {
+    formData.append("image", file);
+  });
+}
+
+export async function createImageSession(
+  files: File | File[] | null,
+  prompt: string,
+  model: ImageModel = "gpt-image-1",
+) {
+  const formData = new FormData();
+  appendImageFiles(formData, files);
+  formData.append("prompt", prompt);
+  formData.append("model", model);
+
+  return httpRequest<ImageSessionResponse>("/api/image/sessions", {
+    method: "POST",
+    body: formData,
+  });
+}
+
+export async function createImageSessionTurn(
+  sessionId: string,
+  files: File | File[] | null,
+  prompt: string,
+  model: ImageModel = "gpt-image-1",
+) {
+  const formData = new FormData();
+  appendImageFiles(formData, files);
+  formData.append("prompt", prompt);
+  formData.append("model", model);
+
+  return httpRequest<ImageSessionResponse>(`/api/image/sessions/${sessionId}/turns`, {
+    method: "POST",
+    body: formData,
+  });
 }
 
 export async function fetchSettingsConfig() {

--- a/web/src/store/image-conversations.ts
+++ b/web/src/store/image-conversations.ts
@@ -42,6 +42,11 @@ export type ImageConversation = {
   turns: ImageTurn[];
 };
 
+export type ImageConversationStats = {
+  queued: number;
+  running: number;
+};
+
 const imageConversationStorage = localforage.createInstance({
   name: "chatgpt2api",
   storeName: "image_conversations",
@@ -185,4 +190,22 @@ export async function deleteImageConversation(id: string): Promise<void> {
 
 export async function clearImageConversations(): Promise<void> {
   await imageConversationStorage.removeItem(IMAGE_CONVERSATIONS_KEY);
+}
+
+export function getImageConversationStats(conversation: ImageConversation | null): ImageConversationStats {
+  if (!conversation) {
+    return { queued: 0, running: 0 };
+  }
+
+  return conversation.turns.reduce(
+    (acc, turn) => {
+      if (turn.status === "queued") {
+        acc.queued += 1;
+      } else if (turn.status === "generating") {
+        acc.running += 1;
+      }
+      return acc;
+    },
+    { queued: 0, running: 0 },
+  );
 }

--- a/web/src/store/image-conversations.ts
+++ b/web/src/store/image-conversations.ts
@@ -19,20 +19,27 @@ export type StoredImage = {
   error?: string;
 };
 
-export type ImageConversationStatus = "generating" | "success" | "error";
+export type ImageTurnStatus = "queued" | "generating" | "success" | "error";
+
+export type ImageTurn = {
+  id: string;
+  prompt: string;
+  model: ImageModel;
+  mode: ImageConversationMode;
+  referenceImages: StoredReferenceImage[];
+  count: number;
+  images: StoredImage[];
+  createdAt: string;
+  status: ImageTurnStatus;
+  error?: string;
+};
 
 export type ImageConversation = {
   id: string;
   title: string;
-  prompt: string;
-  model: ImageModel;
-  mode?: ImageConversationMode;
-  referenceImages?: StoredReferenceImage[];
-  count: number;
-  images: StoredImage[];
   createdAt: string;
-  status: ImageConversationStatus;
-  error?: string;
+  updatedAt: string;
+  turns: ImageTurn[];
 };
 
 const imageConversationStorage = localforage.createInstance({
@@ -52,23 +59,119 @@ function normalizeStoredImage(image: StoredImage): StoredImage {
   };
 }
 
-function normalizeConversation(conversation: ImageConversation): ImageConversation {
+function normalizeReferenceImage(image: StoredReferenceImage): StoredReferenceImage {
   return {
-    ...conversation,
-    mode: conversation.mode === "edit" ? "edit" : "generate",
-    images: (conversation.images || []).map(normalizeStoredImage),
+    name: image.name || "reference.png",
+    type: image.type || "image/png",
+    dataUrl: image.dataUrl,
+  };
+}
+
+function dataUrlMimeType(dataUrl: string) {
+  const match = dataUrl.match(/^data:(.*?);base64,/);
+  return match?.[1] || "image/png";
+}
+
+function getLegacyReferenceImages(source: Record<string, unknown>): StoredReferenceImage[] {
+  if (Array.isArray(source.referenceImages)) {
+    return source.referenceImages
+      .filter((image): image is StoredReferenceImage => {
+        if (!image || typeof image !== "object") {
+          return false;
+        }
+        const candidate = image as StoredReferenceImage;
+        return typeof candidate.dataUrl === "string" && candidate.dataUrl.length > 0;
+      })
+      .map(normalizeReferenceImage);
+  }
+
+  if (source.sourceImage && typeof source.sourceImage === "object") {
+    const image = source.sourceImage as { dataUrl?: unknown; fileName?: unknown };
+    if (typeof image.dataUrl === "string" && image.dataUrl) {
+      return [
+        {
+          name: typeof image.fileName === "string" && image.fileName ? image.fileName : "reference.png",
+          type: dataUrlMimeType(image.dataUrl),
+          dataUrl: image.dataUrl,
+        },
+      ];
+    }
+  }
+
+  return [];
+}
+
+function normalizeTurn(turn: ImageTurn & Record<string, unknown>): ImageTurn {
+  const normalizedImages = Array.isArray(turn.images) ? turn.images.map(normalizeStoredImage) : [];
+  const derivedStatus: ImageTurnStatus =
+    normalizedImages.some((image) => image.status === "loading")
+      ? "generating"
+      : normalizedImages.some((image) => image.status === "error")
+        ? "error"
+        : "success";
+
+  return {
+    id: String(turn.id || `${Date.now()}`),
+    prompt: String(turn.prompt || ""),
+    model: (turn.model as ImageModel) || "gpt-image-1",
+    mode: turn.mode === "edit" ? "edit" : "generate",
+    referenceImages: getLegacyReferenceImages(turn),
+    count: Math.max(1, Number(turn.count || normalizedImages.length || 1)),
+    images: normalizedImages,
+    createdAt: String(turn.createdAt || new Date().toISOString()),
+    status:
+      turn.status === "queued" ||
+      turn.status === "generating" ||
+      turn.status === "success" ||
+      turn.status === "error"
+        ? turn.status
+        : derivedStatus,
+    error: typeof turn.error === "string" ? turn.error : undefined,
+  };
+}
+
+function normalizeConversation(conversation: ImageConversation & Record<string, unknown>): ImageConversation {
+  const turns = Array.isArray(conversation.turns)
+    ? conversation.turns.map((turn) => normalizeTurn(turn as ImageTurn & Record<string, unknown>))
+    : [
+        normalizeTurn({
+          id: String(conversation.id || `${Date.now()}`),
+          prompt: String(conversation.prompt || ""),
+          model: (conversation.model as ImageModel) || "gpt-image-1",
+          mode: conversation.mode === "edit" ? "edit" : "generate",
+          referenceImages: getLegacyReferenceImages(conversation),
+          count: Number(conversation.count || 1),
+          images: Array.isArray(conversation.images) ? (conversation.images as StoredImage[]) : [],
+          createdAt: String(conversation.createdAt || new Date().toISOString()),
+          status:
+            conversation.status === "generating" || conversation.status === "success" || conversation.status === "error"
+              ? conversation.status
+              : "success",
+          error: typeof conversation.error === "string" ? conversation.error : undefined,
+        }),
+      ];
+  const lastTurn = turns.length > 0 ? turns[turns.length - 1] : null;
+
+  return {
+    id: String(conversation.id || `${Date.now()}`),
+    title: String(conversation.title || ""),
+    createdAt: String(conversation.createdAt || lastTurn?.createdAt || new Date().toISOString()),
+    updatedAt: String(conversation.updatedAt || lastTurn?.createdAt || new Date().toISOString()),
+    turns,
   };
 }
 
 export async function listImageConversations(): Promise<ImageConversation[]> {
-  const items = (await imageConversationStorage.getItem<ImageConversation[]>(IMAGE_CONVERSATIONS_KEY)) || [];
-  return items.map(normalizeConversation).sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  const items =
+    (await imageConversationStorage.getItem<Array<ImageConversation & Record<string, unknown>>>(IMAGE_CONVERSATIONS_KEY)) ||
+    [];
+  return items.map(normalizeConversation).sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
 }
 
 export async function saveImageConversation(conversation: ImageConversation): Promise<void> {
   const items = await listImageConversations();
   const nextItems = [normalizeConversation(conversation), ...items.filter((item) => item.id !== conversation.id)];
-  nextItems.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  nextItems.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
   await imageConversationStorage.setItem(IMAGE_CONVERSATIONS_KEY, nextItems);
 }
 

--- a/web/src/store/image-conversations.ts
+++ b/web/src/store/image-conversations.ts
@@ -39,6 +39,7 @@ export type ImageConversation = {
   title: string;
   createdAt: string;
   updatedAt: string;
+  sessionId?: string;
   turns: ImageTurn[];
 };
 
@@ -162,6 +163,7 @@ function normalizeConversation(conversation: ImageConversation & Record<string, 
     title: String(conversation.title || ""),
     createdAt: String(conversation.createdAt || lastTurn?.createdAt || new Date().toISOString()),
     updatedAt: String(conversation.updatedAt || lastTurn?.createdAt || new Date().toISOString()),
+    sessionId: typeof conversation.sessionId === "string" && conversation.sessionId ? conversation.sessionId : undefined,
     turns,
   };
 }

--- a/web/src/store/image-conversations.ts
+++ b/web/src/store/image-conversations.ts
@@ -54,6 +54,7 @@ const imageConversationStorage = localforage.createInstance({
 });
 
 const IMAGE_CONVERSATIONS_KEY = "items";
+let imageConversationWriteQueue: Promise<void> = Promise.resolve();
 
 function normalizeStoredImage(image: StoredImage): StoredImage {
   if (image.status === "loading" || image.status === "error" || image.status === "success") {
@@ -168,30 +169,62 @@ function normalizeConversation(conversation: ImageConversation & Record<string, 
   };
 }
 
-export async function listImageConversations(): Promise<ImageConversation[]> {
+function sortImageConversations(conversations: ImageConversation[]): ImageConversation[] {
+  return [...conversations].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+}
+
+function queueImageConversationWrite<T>(operation: () => Promise<T>): Promise<T> {
+  const result = imageConversationWriteQueue.then(operation);
+  imageConversationWriteQueue = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
+}
+
+async function readStoredImageConversations(): Promise<ImageConversation[]> {
   const items =
     (await imageConversationStorage.getItem<Array<ImageConversation & Record<string, unknown>>>(IMAGE_CONVERSATIONS_KEY)) ||
     [];
-  return items.map(normalizeConversation).sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+  return items.map(normalizeConversation);
+}
+
+export async function listImageConversations(): Promise<ImageConversation[]> {
+  return sortImageConversations(await readStoredImageConversations());
+}
+
+export async function saveImageConversations(conversations: ImageConversation[]): Promise<void> {
+  await queueImageConversationWrite(async () => {
+    const normalizedItems = sortImageConversations(conversations.map(normalizeConversation));
+    await imageConversationStorage.setItem(IMAGE_CONVERSATIONS_KEY, normalizedItems);
+  });
 }
 
 export async function saveImageConversation(conversation: ImageConversation): Promise<void> {
-  const items = await listImageConversations();
-  const nextItems = [normalizeConversation(conversation), ...items.filter((item) => item.id !== conversation.id)];
-  nextItems.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
-  await imageConversationStorage.setItem(IMAGE_CONVERSATIONS_KEY, nextItems);
+  await queueImageConversationWrite(async () => {
+    const items = await readStoredImageConversations();
+    const nextItems = sortImageConversations([
+      normalizeConversation(conversation),
+      ...items.filter((item) => item.id !== conversation.id),
+    ]);
+    await imageConversationStorage.setItem(IMAGE_CONVERSATIONS_KEY, nextItems);
+  });
 }
 
 export async function deleteImageConversation(id: string): Promise<void> {
-  const items = await listImageConversations();
-  await imageConversationStorage.setItem(
-    IMAGE_CONVERSATIONS_KEY,
-    items.filter((item) => item.id !== id),
-  );
+  await queueImageConversationWrite(async () => {
+    const items = await readStoredImageConversations();
+    await imageConversationStorage.setItem(
+      IMAGE_CONVERSATIONS_KEY,
+      items.filter((item) => item.id !== id),
+    );
+  });
 }
 
 export async function clearImageConversations(): Promise<void> {
-  await imageConversationStorage.removeItem(IMAGE_CONVERSATIONS_KEY);
+  await queueImageConversationWrite(async () => {
+    await imageConversationStorage.removeItem(IMAGE_CONVERSATIONS_KEY);
+  });
 }
 
 export function getImageConversationStats(conversation: ImageConversation | null): ImageConversationStats {


### PR DESCRIPTION
当前这条分支是叠在前端无状态续编辑能力之上的：
- 前置 PR: #26 
- 当前 PR: 本草稿

因此在 #26 合并前，这个 Draft PR 的 diff 会暂时包含前置提交

## 本次改动

- 新增 web-only 接口：
  - `POST /api/image/sessions`
  - `POST /api/image/sessions/{session_id}/turns`
- 服务端使用内存 session 句柄保存：
  - 绑定的 access token
  - `upstream_conversation_id`
  - `upstream_parent_message_id`
  - `updated_at`
- 图片页在前端本地历史中只保存 `sessionId`，不保存 token 或 upstream 字段
- 同一窗口内的后续单图请求改走 session 句柄接口
- 当 session 失效时，前端会退化为“基于当前结果图重新建立新 session 继续编辑”

## 限制

- 这套 web-only session 接口每轮固定只支持 `n=1`
- 多张图片生成/编辑仍然沿用前置 PR 的无状态路径