### PR TITLE
推荐：feat：增加管理员/普通用户密钥权限隔离

### DIFF
--- a/api/accounts.py
+++ b/api/accounts.py
@@ -4,8 +4,10 @@ from fastapi import APIRouter, Header, HTTPException
 from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field
 
+from services.auth_service import auth_service
+
 from api.support import (
-    require_auth_key,
+    require_admin,
     sanitize_cpa_pool,
     sanitize_cpa_pools,
     sanitize_sub2api_server,
@@ -19,6 +21,16 @@ from services.sub2api_service import (
     sub2api_config,
     sub2api_import_service,
 )
+
+
+
+class UserKeyCreateRequest(BaseModel):
+    name: str = ""
+
+
+class UserKeyUpdateRequest(BaseModel):
+    name: str | None = None
+    enabled: bool | None = None
 
 
 class AccountCreateRequest(BaseModel):
@@ -81,14 +93,54 @@ class Sub2APIImportRequest(BaseModel):
 def create_router() -> APIRouter:
     router = APIRouter()
 
+    @router.get("/api/auth/users")
+    async def list_user_keys(authorization: str | None = Header(default=None)):
+        require_admin(authorization)
+        return {"items": auth_service.list_keys(role="user")}
+
+    @router.post("/api/auth/users")
+    async def create_user_key(body: UserKeyCreateRequest, authorization: str | None = Header(default=None)):
+        require_admin(authorization)
+        item, raw_key = auth_service.create_key(role="user", name=body.name)
+        return {"item": item, "key": raw_key, "items": auth_service.list_keys(role="user")}
+
+    @router.post("/api/auth/users/{key_id}")
+    async def update_user_key(
+            key_id: str,
+            body: UserKeyUpdateRequest,
+            authorization: str | None = Header(default=None),
+    ):
+        require_admin(authorization)
+        updates = {
+            key: value
+            for key, value in {
+                "name": body.name,
+                "enabled": body.enabled,
+            }.items()
+            if value is not None
+        }
+        if not updates:
+            raise HTTPException(status_code=400, detail={"error": "no updates provided"})
+        item = auth_service.update_key(key_id, updates, role="user")
+        if item is None:
+            raise HTTPException(status_code=404, detail={"error": "user key not found"})
+        return {"item": item, "items": auth_service.list_keys(role="user")}
+
+    @router.delete("/api/auth/users/{key_id}")
+    async def delete_user_key(key_id: str, authorization: str | None = Header(default=None)):
+        require_admin(authorization)
+        if not auth_service.delete_key(key_id, role="user"):
+            raise HTTPException(status_code=404, detail={"error": "user key not found"})
+        return {"items": auth_service.list_keys(role="user")}
+
     @router.get("/api/accounts")
     async def get_accounts(authorization: str | None = Header(default=None)):
-        require_auth_key(authorization)
+        require_admin(authorization)
         return {"items": account_service.list_accounts()}
 
     @router.post("/api/accounts")
     async def create_accounts(body: AccountCreateRequest, authorization: str | None = Header(default=None)):
-        require_auth_key(authorization)
+        require_admin(authorization)
         tokens = [str(token or "").strip() for token in body.tokens if str(token or "").strip()]
         if not tokens:
             raise HTTPException(status_code=400, detail={"error": "tokens is required"})
@@ -103,7 +155,7 @@ def create_router() -> APIRouter:
 
     @router.delete("/api/accounts")
     async def delete_accounts(body: AccountDeleteRequest, authorization: str | None = Header(default=None)):
-        require_auth_key(authorization)
+        require_admin(authorization)
         tokens = [str(token or "").strip() for token in body.tokens if str(token or "").strip()]
         if not tokens:
             raise HTTPException(status_code=400, detail={"error": "tokens is required"})
@@ -111,7 +163,7 @@ def create_router() -> APIRouter:
 
     @router.post("/api/accounts/refresh")
     async def refresh_accounts(body: AccountRefreshRequest, authorization: str | None = Header(default=None)):
-        require_auth_key(authorization)
+        require_admin(authorization)
         access_tokens = [str(token or "").strip() for token in body.access_tokens if str(token or "").strip()]
         if not access_tokens:
             access_tokens = account_service.list_tokens()
@@ -121,7 +173,7 @@ def create_router() -> APIRouter:
 
     @router.post("/api/accounts/update")
     async def update_account(body: AccountUpdateRequest, authorization: str | None = Header(default=None)):
-        require_auth_key(authorization)
+        require_admin(authorization)
         access_token = str(body.access_token or "").strip()
         if not access_token:
             raise HTTPException(status_code=400, detail={"error": "access_token is required"})
@@ -135,12 +187,12 @@ def create_router() -> APIRouter:
 
     @router.get("/api/cpa/pools")
     async def list_cpa_pools(authorization: str | None = Header(default=None)):
-        require_auth_key(authorization)
+        require_admin(authorization)
         return {"pools": sanitize_cpa_pools(cpa_config.list_pools())}
 
     @router.post("/api/cpa/pools")
     async def create_cpa_pool(body: CPAPoolCreateRequest, authorization: str | None = Header(default=None)):
-        require_auth_key(authorization)
+        require_admin(authorization)
         if not body.base_url.strip():
             raise HTTPException(status_code=400, detail={"error": "base_url is required"})
         if not body.secret_key.strip():
@@ -150,7 +202,7 @@ def create_router() -> APIRouter:
 
     @router.post("/api/cpa/pools/{pool_id}")
     async def update_cpa_pool(pool_id: str, body: CPAPoolUpdateRequest, authorization: str | None = Header(default=None)):
-        require_auth_key(authorization)
+        require_admin(authorization)
         pool = cpa_config.update_pool(pool_id, body.model_dump(exclude_none=True))
         if pool is None:
             raise HTTPException(status_code=404, detail={"error": "pool not found"})
@@ -158,14 +210,14 @@ def create_router() -> APIRouter:
 
     @router.delete("/api/cpa/pools/{pool_id}")
     async def delete_cpa_pool(pool_id: str, authorization: str | None = Header(default=None)):
-        require_auth_key(authorization)
+        require_admin(authorization)
         if not cpa_config.delete_pool(pool_id):
             raise HTTPException(status_code=404, detail={"error": "pool not found"})
         return {"pools": sanitize_cpa_pools(cpa_config.list_pools())}
 
     @router.get("/api/cpa/pools/{pool_id}/files")
     async def cpa_pool_files(pool_id: str, authorization: str | None = Header(default=None)):
-        require_auth_key(authorization)
+        require_admin(authorization)
         pool = cpa_config.get_pool(pool_id)
         if pool is None:
             raise HTTPException(status_code=404, detail={"error": "pool not found"})
@@ -173,7 +225,7 @@ def create_router() -> APIRouter:
 
     @router.post("/api/cpa/pools/{pool_id}/import")
     async def cpa_pool_import(pool_id: str, body: CPAImportRequest, authorization: str | None = Header(default=None)):
-        require_auth_key(authorization)
+        require_admin(authorization)
         pool = cpa_config.get_pool(pool_id)
         if pool is None:
             raise HTTPException(status_code=404, detail={"error": "pool not found"})
@@ -185,7 +237,7 @@ def create_router() -> APIRouter:
 
     @router.get("/api/cpa/pools/{pool_id}/import")
     async def cpa_pool_import_progress(pool_id: str, authorization: str | None = Header(default=None)):
-        require_auth_key(authorization)
+        require_admin(authorization)
         pool = cpa_config.get_pool(pool_id)
         if pool is None:
             raise HTTPException(status_code=404, detail={"error": "pool not found"})
@@ -193,12 +245,12 @@ def create_router() -> APIRouter:
 
     @router.get("/api/sub2api/servers")
     async def list_sub2api_servers(authorization: str | None = Header(default=None)):
-        require_auth_key(authorization)
+        require_admin(authorization)
         return {"servers": sanitize_sub2api_servers(sub2api_config.list_servers())}
 
     @router.post("/api/sub2api/servers")
     async def create_sub2api_server(body: Sub2APIServerCreateRequest, authorization: str | None = Header(default=None)):
-        require_auth_key(authorization)
+        require_admin(authorization)
         if not body.base_url.strip():
             raise HTTPException(status_code=400, detail={"error": "base_url is required"})
         has_login = body.email.strip() and body.password.strip()
@@ -217,7 +269,7 @@ def create_router() -> APIRouter:
 
     @router.post("/api/sub2api/servers/{server_id}")
     async def update_sub2api_server(server_id: str, body: Sub2APIServerUpdateRequest, authorization: str | None = Header(default=None)):
-        require_auth_key(authorization)
+        require_admin(authorization)
         server = sub2api_config.update_server(server_id, body.model_dump(exclude_none=True))
         if server is None:
             raise HTTPException(status_code=404, detail={"error": "server not found"})
@@ -225,14 +277,14 @@ def create_router() -> APIRouter:
 
     @router.delete("/api/sub2api/servers/{server_id}")
     async def delete_sub2api_server(server_id: str, authorization: str | None = Header(default=None)):
-        require_auth_key(authorization)
+        require_admin(authorization)
         if not sub2api_config.delete_server(server_id):
             raise HTTPException(status_code=404, detail={"error": "server not found"})
         return {"servers": sanitize_sub2api_servers(sub2api_config.list_servers())}
 
     @router.get("/api/sub2api/servers/{server_id}/groups")
     async def sub2api_server_groups(server_id: str, authorization: str | None = Header(default=None)):
-        require_auth_key(authorization)
+        require_admin(authorization)
         server = sub2api_config.get_server(server_id)
         if server is None:
             raise HTTPException(status_code=404, detail={"error": "server not found"})
@@ -244,7 +296,7 @@ def create_router() -> APIRouter:
 
     @router.get("/api/sub2api/servers/{server_id}/accounts")
     async def sub2api_server_accounts(server_id: str, authorization: str | None = Header(default=None)):
-        require_auth_key(authorization)
+        require_admin(authorization)
         server = sub2api_config.get_server(server_id)
         if server is None:
             raise HTTPException(status_code=404, detail={"error": "server not found"})
@@ -256,7 +308,7 @@ def create_router() -> APIRouter:
 
     @router.post("/api/sub2api/servers/{server_id}/import")
     async def sub2api_server_import(server_id: str, body: Sub2APIImportRequest, authorization: str | None = Header(default=None)):
-        require_auth_key(authorization)
+        require_admin(authorization)
         server = sub2api_config.get_server(server_id)
         if server is None:
             raise HTTPException(status_code=404, detail={"error": "server not found"})
@@ -268,7 +320,7 @@ def create_router() -> APIRouter:
 
     @router.get("/api/sub2api/servers/{server_id}/import")
     async def sub2api_server_import_progress(server_id: str, authorization: str | None = Header(default=None)):
-        require_auth_key(authorization)
+        require_admin(authorization)
         server = sub2api_config.get_server(server_id)
         if server is None:
             raise HTTPException(status_code=404, detail={"error": "server not found"})

--- a/api/ai.py
+++ b/api/ai.py
@@ -5,7 +5,7 @@ from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, ConfigDict, Field
 
-from api.support import raise_image_quota_error, require_auth_key, resolve_image_base_url
+from api.support import raise_image_quota_error, require_identity, resolve_image_base_url
 from services.account_service import account_service
 from services.chatgpt_service import ChatGPTService, ImageGenerationError
 from utils.helper import is_image_chat_request, sse_json_stream
@@ -45,7 +45,7 @@ def create_router(chatgpt_service: ChatGPTService) -> APIRouter:
 
     @router.get("/v1/models")
     async def list_models(authorization: str | None = Header(default=None)):
-        require_auth_key(authorization)
+        require_identity(authorization)
         try:
             return await run_in_threadpool(chatgpt_service.list_models)
         except Exception as exc:
@@ -57,7 +57,7 @@ def create_router(chatgpt_service: ChatGPTService) -> APIRouter:
             request: Request,
             authorization: str | None = Header(default=None),
     ):
-        require_auth_key(authorization)
+        require_identity(authorization)
         base_url = resolve_image_base_url(request)
         if body.stream:
             try:
@@ -92,7 +92,7 @@ def create_router(chatgpt_service: ChatGPTService) -> APIRouter:
             response_format: str = Form(default="b64_json"),
             stream: bool | None = Form(default=None),
     ):
-        require_auth_key(authorization)
+        require_identity(authorization)
         if n < 1 or n > 4:
             raise HTTPException(status_code=400, detail={"error": "n must be between 1 and 4"})
         uploads = [*(image or []), *(image_list or [])]
@@ -121,7 +121,7 @@ def create_router(chatgpt_service: ChatGPTService) -> APIRouter:
 
     @router.post("/v1/chat/completions")
     async def create_chat_completion(body: ChatCompletionRequest, authorization: str | None = Header(default=None)):
-        require_auth_key(authorization)
+        require_identity(authorization)
         payload = body.model_dump(mode="python")
         if bool(payload.get("stream")):
             if is_image_chat_request(payload):
@@ -137,7 +137,7 @@ def create_router(chatgpt_service: ChatGPTService) -> APIRouter:
 
     @router.post("/v1/responses")
     async def create_response(body: ResponseCreateRequest, authorization: str | None = Header(default=None)):
-        require_auth_key(authorization)
+        require_identity(authorization)
         payload = body.model_dump(mode="python")
         if bool(payload.get("stream")):
             return StreamingResponse(

--- a/api/support.py
+++ b/api/support.py
@@ -6,6 +6,7 @@ from threading import Event, Thread
 from fastapi import HTTPException, Request
 
 from services.account_service import account_service
+from services.auth_service import auth_service
 from services.config import config
 
 BASE_DIR = Path(__file__).resolve().parents[1]
@@ -19,10 +20,30 @@ def extract_bearer_token(authorization: str | None) -> str:
     return value.strip()
 
 
-def require_auth_key(authorization: str | None) -> None:
+def _legacy_admin_identity(token: str) -> dict[str, object] | None:
     auth_key = str(config.auth_key or "").strip()
-    if not auth_key or extract_bearer_token(authorization) != auth_key:
+    if auth_key and token == auth_key:
+        return {"id": "admin", "name": "管理员", "role": "admin"}
+    return None
+
+
+def require_identity(authorization: str | None) -> dict[str, object]:
+    token = extract_bearer_token(authorization)
+    identity = _legacy_admin_identity(token) or auth_service.authenticate(token)
+    if identity is None:
         raise HTTPException(status_code=401, detail={"error": "authorization is invalid"})
+    return identity
+
+
+def require_auth_key(authorization: str | None) -> None:
+    require_identity(authorization)
+
+
+def require_admin(authorization: str | None) -> dict[str, object]:
+    identity = require_identity(authorization)
+    if identity.get("role") != "admin":
+        raise HTTPException(status_code=403, detail={"error": "admin permission required"})
+    return identity
 
 
 def resolve_image_base_url(request: Request) -> str:

--- a/api/system.py
+++ b/api/system.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Header, HTTPException
 from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, ConfigDict
 
-from api.support import require_auth_key
+from api.support import require_admin, require_identity
 from services.config import config
 from services.proxy_service import test_proxy
 
@@ -22,8 +22,14 @@ def create_router(app_version: str) -> APIRouter:
 
     @router.post("/auth/login")
     async def login(authorization: str | None = Header(default=None)):
-        require_auth_key(authorization)
-        return {"ok": True, "version": app_version}
+        identity = require_identity(authorization)
+        return {
+            "ok": True,
+            "version": app_version,
+            "role": identity.get("role"),
+            "subject_id": identity.get("id"),
+            "name": identity.get("name"),
+        }
 
     @router.get("/version")
     async def get_version():
@@ -31,17 +37,17 @@ def create_router(app_version: str) -> APIRouter:
 
     @router.get("/api/settings")
     async def get_settings(authorization: str | None = Header(default=None)):
-        require_auth_key(authorization)
+        require_admin(authorization)
         return {"config": config.get()}
 
     @router.post("/api/settings")
     async def save_settings(body: SettingsUpdateRequest, authorization: str | None = Header(default=None)):
-        require_auth_key(authorization)
+        require_admin(authorization)
         return {"config": config.update(body.model_dump(mode="python"))}
 
     @router.post("/api/proxy/test")
     async def test_proxy_endpoint(body: ProxyTestRequest, authorization: str | None = Header(default=None)):
-        require_auth_key(authorization)
+        require_admin(authorization)
         candidate = (body.url or "").strip() or config.get_proxy_settings()
         if not candidate:
             raise HTTPException(status_code=400, detail={"error": "proxy url is required"})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,11 @@ dependencies = [
     "gitpython>=3.1.0",
 ]
 
+[dependency-groups]
+dev = [
+    "httpx>=0.28.1",
+]
+
 [[tool.uv.index]]
 url = "https://mirrors.aliyun.com/pypi/simple"
 default = true

--- a/services/auth_service.py
+++ b/services/auth_service.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import secrets
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from threading import Lock
+from typing import Literal
+
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+DATA_DIR = BASE_DIR / "data"
+AUTH_KEYS_FILE = DATA_DIR / "auth_keys.json"
+
+AuthRole = Literal["admin", "user"]
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _hash_key(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+class AuthService:
+    def __init__(self, store_file: Path):
+        self.store_file = store_file
+        self._lock = Lock()
+        self._items = self._load()
+
+    @staticmethod
+    def _clean(value: object) -> str:
+        return str(value or "").strip()
+
+    def _normalize_item(self, raw: object) -> dict[str, object] | None:
+        if not isinstance(raw, dict):
+            return None
+        role = self._clean(raw.get("role")).lower()
+        if role not in {"admin", "user"}:
+            return None
+        key_hash = self._clean(raw.get("key_hash"))
+        if not key_hash:
+            return None
+        item_id = self._clean(raw.get("id")) or uuid.uuid4().hex[:12]
+        name = self._clean(raw.get("name")) or ("管理员密钥" if role == "admin" else "普通用户")
+        created_at = self._clean(raw.get("created_at")) or _now_iso()
+        last_used_at = self._clean(raw.get("last_used_at")) or None
+        return {
+            "id": item_id,
+            "name": name,
+            "role": role,
+            "key_hash": key_hash,
+            "enabled": bool(raw.get("enabled", True)),
+            "created_at": created_at,
+            "last_used_at": last_used_at,
+        }
+
+    def _load(self) -> list[dict[str, object]]:
+        if not self.store_file.exists():
+            return []
+        try:
+            raw = json.loads(self.store_file.read_text(encoding="utf-8"))
+        except Exception:
+            return []
+        if isinstance(raw, dict):
+            items = raw.get("items")
+        else:
+            items = raw
+        if not isinstance(items, list):
+            return []
+        return [normalized for item in items if (normalized := self._normalize_item(item)) is not None]
+
+    def _save(self) -> None:
+        self.store_file.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"items": self._items}
+        self.store_file.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    @staticmethod
+    def _public_item(item: dict[str, object]) -> dict[str, object]:
+        return {
+            "id": item.get("id"),
+            "name": item.get("name"),
+            "role": item.get("role"),
+            "enabled": bool(item.get("enabled", True)),
+            "created_at": item.get("created_at"),
+            "last_used_at": item.get("last_used_at"),
+        }
+
+    def list_keys(self, role: AuthRole | None = None) -> list[dict[str, object]]:
+        with self._lock:
+            items = [item for item in self._items if role is None or item.get("role") == role]
+            return [self._public_item(item) for item in items]
+
+    def create_key(self, *, role: AuthRole, name: str = "") -> tuple[dict[str, object], str]:
+        normalized_name = self._clean(name) or ("管理员密钥" if role == "admin" else "普通用户")
+        raw_key = f"cg2a_{role}_{secrets.token_urlsafe(24)}"
+        item = {
+            "id": uuid.uuid4().hex[:12],
+            "name": normalized_name,
+            "role": role,
+            "key_hash": _hash_key(raw_key),
+            "enabled": True,
+            "created_at": _now_iso(),
+            "last_used_at": None,
+        }
+        with self._lock:
+            self._items.append(item)
+            self._save()
+            return self._public_item(item), raw_key
+
+    def update_key(
+        self,
+        key_id: str,
+        updates: dict[str, object],
+        *,
+        role: AuthRole | None = None,
+    ) -> dict[str, object] | None:
+        normalized_id = self._clean(key_id)
+        if not normalized_id:
+            return None
+        with self._lock:
+            for index, item in enumerate(self._items):
+                if item.get("id") != normalized_id:
+                    continue
+                if role is not None and item.get("role") != role:
+                    return None
+                next_item = dict(item)
+                if "name" in updates and updates.get("name") is not None:
+                    next_item["name"] = self._clean(updates.get("name")) or next_item.get("name") or "普通用户"
+                if "enabled" in updates and updates.get("enabled") is not None:
+                    next_item["enabled"] = bool(updates.get("enabled"))
+                self._items[index] = next_item
+                self._save()
+                return self._public_item(next_item)
+        return None
+
+    def delete_key(self, key_id: str, *, role: AuthRole | None = None) -> bool:
+        normalized_id = self._clean(key_id)
+        if not normalized_id:
+            return False
+        with self._lock:
+            before = len(self._items)
+            self._items = [
+                item
+                for item in self._items
+                if not (item.get("id") == normalized_id and (role is None or item.get("role") == role))
+            ]
+            if len(self._items) == before:
+                return False
+            self._save()
+            return True
+
+    def authenticate(self, raw_key: str) -> dict[str, object] | None:
+        candidate = self._clean(raw_key)
+        if not candidate:
+            return None
+        candidate_hash = _hash_key(candidate)
+        with self._lock:
+            for index, item in enumerate(self._items):
+                if not bool(item.get("enabled", True)):
+                    continue
+                stored_hash = self._clean(item.get("key_hash"))
+                if not stored_hash or not hmac.compare_digest(stored_hash, candidate_hash):
+                    continue
+                next_item = dict(item)
+                next_item["last_used_at"] = _now_iso()
+                self._items[index] = next_item
+                self._save()
+                return self._public_item(next_item)
+        return None
+
+
+auth_service = AuthService(AUTH_KEYS_FILE)

--- a/services/auth_service.py
+++ b/services/auth_service.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import os
 import secrets
+import tempfile
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -31,6 +33,7 @@ class AuthService:
         self.store_file = store_file
         self._lock = Lock()
         self._items = self._load()
+        self._last_used_flush_at: dict[str, datetime] = {}
 
     @staticmethod
     def _clean(value: object) -> str:
@@ -77,7 +80,23 @@ class AuthService:
     def _save(self) -> None:
         self.store_file.parent.mkdir(parents=True, exist_ok=True)
         payload = {"items": self._items}
-        self.store_file.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        data = json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{self.store_file.name}.",
+            suffix=".tmp",
+            dir=self.store_file.parent,
+            text=True,
+        )
+        tmp_path = Path(tmp_name)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as file:
+                file.write(data)
+                file.flush()
+                os.fsync(file.fileno())
+            tmp_path.replace(self.store_file)
+        except Exception:
+            tmp_path.unlink(missing_ok=True)
+            raise
 
     @staticmethod
     def _public_item(item: dict[str, object]) -> dict[str, object]:
@@ -167,9 +186,17 @@ class AuthService:
                 if not stored_hash or not hmac.compare_digest(stored_hash, candidate_hash):
                     continue
                 next_item = dict(item)
-                next_item["last_used_at"] = _now_iso()
+                now = datetime.now(timezone.utc)
+                next_item["last_used_at"] = now.isoformat()
                 self._items[index] = next_item
-                self._save()
+                item_id = self._clean(next_item.get("id"))
+                last_flush_at = self._last_used_flush_at.get(item_id)
+                if last_flush_at is None or (now - last_flush_at).total_seconds() >= 60:
+                    self._last_used_flush_at[item_id] = now
+                    try:
+                        self._save()
+                    except Exception:
+                        pass
                 return self._public_item(next_item)
         return None
 

--- a/services/config.py
+++ b/services/config.py
@@ -125,7 +125,9 @@ class ConfigStore:
         return value or "0.0.0"
 
     def get(self) -> dict[str, object]:
-        return dict(self.data)
+        data = dict(self.data)
+        data.pop("auth-key", None)
+        return data
 
     def get_proxy_settings(self) -> str:
         return str(self.data.get("proxy") or "").strip()
@@ -133,8 +135,6 @@ class ConfigStore:
     def update(self, data: dict[str, object]) -> dict[str, object]:
         next_data = dict(self.data)
         next_data.update(dict(data or {}))
-        if _is_invalid_auth_key(next_data.get("auth-key")):
-            next_data["auth-key"] = self.data.get("auth-key") or os.getenv("CHATGPT2API_AUTH_KEY") or ""
         self.data = next_data
         self._save()
         return self.get()

--- a/test/test_account_image_capabilities.py
+++ b/test/test_account_image_capabilities.py
@@ -9,6 +9,7 @@ os.environ.setdefault("CHATGPT2API_AUTH_KEY", "test-auth")
 
 from services.account_service import AccountService
 from services.auth_service import AuthService
+from services.storage.json_storage import JSONStorageBackend
 from utils.helper import anonymize_token
 
 
@@ -27,13 +28,13 @@ class AccountCapabilityTests(unittest.TestCase):
 
     def test_prolite_variants_are_normalized(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
-            service = AccountService(Path(tmp_dir) / "accounts.json")
+            service = AccountService(JSONStorageBackend(Path(tmp_dir) / "accounts.json"))
             self.assertEqual(service._normalize_account_type("prolite"), "ProLite")
             self.assertEqual(service._normalize_account_type("pro_lite"), "ProLite")
 
     def test_search_account_type_ignores_unrelated_scalar_values(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
-            service = AccountService(Path(tmp_dir) / "accounts.json")
+            service = AccountService(JSONStorageBackend(Path(tmp_dir) / "accounts.json"))
             self.assertIsNone(
                 service._search_account_type(
                     {
@@ -47,7 +48,7 @@ class AccountCapabilityTests(unittest.TestCase):
 
     def test_mark_image_result_does_not_consume_unknown_quota(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
-            service = AccountService(Path(tmp_dir) / "accounts.json")
+            service = AccountService(JSONStorageBackend(Path(tmp_dir) / "accounts.json"))
             service.add_accounts(["token-1"])
             service.update_account(
                 "token-1",

--- a/test/test_account_image_capabilities.py
+++ b/test/test_account_image_capabilities.py
@@ -8,6 +8,7 @@ from pathlib import Path
 os.environ.setdefault("CHATGPT2API_AUTH_KEY", "test-auth")
 
 from services.account_service import AccountService
+from services.auth_service import AuthService
 from utils.helper import anonymize_token
 
 
@@ -72,6 +73,34 @@ class TokenLogTests(unittest.TestCase):
 
         self.assertTrue(token_ref.startswith("token:"))
         self.assertNotIn(token, token_ref)
+
+
+class AuthServiceTests(unittest.TestCase):
+    def test_create_authenticate_disable_and_delete_user_key(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            service = AuthService(Path(tmp_dir) / "auth_keys.json")
+
+            item, raw_key = service.create_key(role="user", name="Alice")
+
+            self.assertEqual(item["role"], "user")
+            self.assertEqual(item["name"], "Alice")
+            self.assertTrue(item["enabled"])
+            self.assertTrue(raw_key.startswith("cg2a_user_"))
+
+            authed = service.authenticate(raw_key)
+            self.assertIsNotNone(authed)
+            self.assertEqual(authed["id"], item["id"])
+            self.assertEqual(authed["role"], "user")
+            self.assertIsNotNone(authed["last_used_at"])
+
+            updated = service.update_key(item["id"], {"enabled": False}, role="user")
+            self.assertIsNotNone(updated)
+            self.assertFalse(updated["enabled"])
+            self.assertIsNone(service.authenticate(raw_key))
+
+            self.assertTrue(service.delete_key(item["id"], role="user"))
+            self.assertFalse(service.delete_key(item["id"], role="user"))
+            self.assertEqual(service.list_keys(role="user"), [])
 
 
 if __name__ == "__main__":

--- a/test/test_account_image_capabilities.py
+++ b/test/test_account_image_capabilities.py
@@ -102,6 +102,22 @@ class AuthServiceTests(unittest.TestCase):
             self.assertFalse(service.delete_key(item["id"], role="user"))
             self.assertEqual(service.list_keys(role="user"), [])
 
+    def test_authenticate_ignores_last_used_save_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            service = AuthService(Path(tmp_dir) / "auth_keys.json")
+            item, raw_key = service.create_key(role="user", name="Alice")
+
+            def fail_save() -> None:
+                raise OSError("disk unavailable")
+
+            service._save = fail_save
+
+            authed = service.authenticate(raw_key)
+
+            self.assertIsNotNone(authed)
+            self.assertEqual(authed["id"], item["id"])
+            self.assertIsNotNone(authed["last_used_at"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_image_base_url_api.py
+++ b/test/test_image_base_url_api.py
@@ -2,13 +2,13 @@ import unittest
 from types import SimpleNamespace
 from unittest import mock
 
-from services import api as api_module
+import api.support as api_support
 
 
 class ImageBaseUrlApiTests(unittest.TestCase):
     def setUp(self) -> None:
         self.fake_config = SimpleNamespace(base_url="https://public.example.com")
-        patcher = mock.patch.object(api_module, "config", self.fake_config)
+        patcher = mock.patch.object(api_support, "config", self.fake_config)
         patcher.start()
         self.addCleanup(patcher.stop)
 
@@ -18,7 +18,7 @@ class ImageBaseUrlApiTests(unittest.TestCase):
             headers={"host": "127.0.0.1:8000"},
         )
 
-        self.assertEqual(api_module.resolve_image_base_url(request), "https://public.example.com")
+        self.assertEqual(api_support.resolve_image_base_url(request), "https://public.example.com")
 
     def test_falls_back_to_request_host(self) -> None:
         self.fake_config.base_url = ""
@@ -27,7 +27,7 @@ class ImageBaseUrlApiTests(unittest.TestCase):
             headers={"host": "internal.example:9000"},
         )
 
-        self.assertEqual(api_module.resolve_image_base_url(request), "http://internal.example:9000")
+        self.assertEqual(api_support.resolve_image_base_url(request), "http://internal.example:9000")
 
     def test_falls_back_to_request_netloc_when_host_missing(self) -> None:
         self.fake_config.base_url = ""
@@ -36,7 +36,7 @@ class ImageBaseUrlApiTests(unittest.TestCase):
             headers={},
         )
 
-        self.assertEqual(api_module.resolve_image_base_url(request), "https://public.example.com")
+        self.assertEqual(api_support.resolve_image_base_url(request), "https://public.example.com")
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -160,6 +160,11 @@ dependencies = [
     { name = "uvicorn" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "httpx" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "curl-cffi", specifier = ">=0.15.0" },
@@ -173,6 +178,9 @@ requires-dist = [
     { name = "tiktoken", specifier = ">=0.12.0" },
     { name = "uvicorn", specifier = ">=0.44.0" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "httpx", specifier = ">=0.28.1" }]
 
 [[package]]
 name = "click"
@@ -312,6 +320,34 @@ source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
 sdist = { url = "https://mirrors.aliyun.com/pypi/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1" }
 wheels = [
     { url = "https://mirrors.aliyun.com/pypi/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]

--- a/web/src/app/accounts/page.tsx
+++ b/web/src/app/accounts/page.tsx
@@ -49,6 +49,7 @@ import {
   type AccountStatus,
   type AccountType,
 } from "@/lib/api";
+import { useAuthGuard } from "@/lib/use-auth-guard";
 import { cn } from "@/lib/utils";
 
 import { AccountImportDialog } from "./components/account-import-dialog";
@@ -179,7 +180,7 @@ function normalizeAccounts(items: Account[]): Account[] {
   }));
 }
 
-export default function AccountsPage() {
+function AccountsPageContent() {
   const didLoadRef = useRef(false);
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
@@ -842,4 +843,18 @@ export default function AccountsPage() {
       </section>
     </>
   );
+}
+
+export default function AccountsPage() {
+  const { isCheckingAuth, session } = useAuthGuard(["admin"]);
+
+  if (isCheckingAuth || !session || session.role !== "admin") {
+    return (
+      <div className="flex min-h-[40vh] items-center justify-center">
+        <LoaderCircle className="size-5 animate-spin text-stone-400" />
+      </div>
+    );
+  }
+
+  return <AccountsPageContent />;
 }

--- a/web/src/app/image/page.tsx
+++ b/web/src/app/image/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { History, Plus, Trash2 } from "lucide-react";
+import { History, LoaderCircle, Plus, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
 import { ImageComposer } from "@/app/image/components/image-composer";
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { editImage, fetchAccounts, generateImage, type Account } from "@/lib/api";
+import { useAuthGuard } from "@/lib/use-auth-guard";
 import {
   clearImageConversations,
   deleteImageConversation,
@@ -170,7 +171,7 @@ async function recoverConversationHistory(items: ImageConversation[]) {
   return normalized;
 }
 
-export default function ImagePage() {
+function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
   const didLoadQuotaRef = useRef(false);
   const conversationsRef = useRef<ImageConversation[]>([]);
   const resultsViewportRef = useRef<HTMLDivElement>(null);
@@ -250,13 +251,17 @@ export default function ImagePage() {
   }, []);
 
   const loadQuota = useCallback(async () => {
+    if (!isAdmin) {
+      setAvailableQuota("--");
+      return;
+    }
     try {
       const data = await fetchAccounts();
       setAvailableQuota(formatAvailableQuota(data.items));
     } catch {
       setAvailableQuota((prev) => (prev === "加载中..." ? "--" : prev));
     }
-  }, []);
+  }, [isAdmin]);
 
   useEffect(() => {
     if (didLoadQuotaRef.current) {
@@ -273,7 +278,7 @@ export default function ImagePage() {
     return () => {
       window.removeEventListener("focus", handleFocus);
     };
-  }, [loadQuota]);
+  }, [isAdmin, loadQuota]);
 
   useEffect(() => {
     if (!selectedConversation) {
@@ -484,6 +489,7 @@ export default function ImagePage() {
     setLightboxOpen(true);
   }, []);
 
+  /* eslint-disable react-hooks/preserve-manual-memoization */
   const runConversationQueue = useCallback(
     async (conversationId: string) => {
       if (activeConversationQueueIds.has(conversationId)) {
@@ -680,6 +686,7 @@ export default function ImagePage() {
     },
     [loadQuota, updateConversation],
   );
+  /* eslint-enable react-hooks/preserve-manual-memoization */
 
   useEffect(() => {
     for (const conversation of conversations) {
@@ -872,4 +879,18 @@ export default function ImagePage() {
       />
     </>
   );
+}
+
+export default function ImagePage() {
+  const { isCheckingAuth, session } = useAuthGuard();
+
+  if (isCheckingAuth || !session) {
+    return (
+      <div className="flex min-h-[40vh] items-center justify-center">
+        <LoaderCircle className="size-5 animate-spin text-stone-400" />
+      </div>
+    );
+  }
+
+  return <ImagePageContent isAdmin={session.role === "admin"} />;
 }

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -9,12 +9,14 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { login } from "@/lib/api";
-import { setStoredAuthKey } from "@/store/auth";
+import { useRedirectIfAuthenticated } from "@/lib/use-auth-guard";
+import { getDefaultRouteForRole, setStoredAuthSession } from "@/store/auth";
 
 export default function LoginPage() {
   const router = useRouter();
   const [authKey, setAuthKey] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const { isCheckingAuth } = useRedirectIfAuthenticated();
 
   const handleLogin = async () => {
     const normalizedAuthKey = authKey.trim();
@@ -25,9 +27,14 @@ export default function LoginPage() {
 
     setIsSubmitting(true);
     try {
-      await login(normalizedAuthKey);
-      await setStoredAuthKey(normalizedAuthKey);
-      router.replace("/accounts");
+      const data = await login(normalizedAuthKey);
+      await setStoredAuthSession({
+        key: normalizedAuthKey,
+        role: data.role,
+        subjectId: data.subject_id,
+        name: data.name,
+      });
+      router.replace(getDefaultRouteForRole(data.role));
     } catch (error) {
       const message = error instanceof Error ? error.message : "登录失败";
       toast.error(message);
@@ -35,6 +42,14 @@ export default function LoginPage() {
       setIsSubmitting(false);
     }
   };
+
+  if (isCheckingAuth) {
+    return (
+      <div className="grid min-h-[calc(100vh-1rem)] w-full place-items-center px-4 py-6">
+        <LoaderCircle className="size-5 animate-spin text-stone-400" />
+      </div>
+    );
+  }
 
   return (
     <div className="grid min-h-[calc(100vh-1rem)] w-full place-items-center px-4 py-6">

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -3,11 +3,26 @@
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 
+import { getDefaultRouteForRole, getStoredAuthSession } from "@/store/auth";
+
 export default function HomePage() {
   const router = useRouter();
 
   useEffect(() => {
-    router.replace("/accounts");
+    let active = true;
+
+    const redirect = async () => {
+      const session = await getStoredAuthSession();
+      if (!active) {
+        return;
+      }
+      router.replace(session ? getDefaultRouteForRole(session.role) : "/login");
+    };
+
+    void redirect();
+    return () => {
+      active = false;
+    };
   }, [router]);
 
   return null;

--- a/web/src/app/settings/components/config-card.tsx
+++ b/web/src/app/settings/components/config-card.tsx
@@ -17,7 +17,6 @@ export function ConfigCard() {
   const config = useSettingsStore((state) => state.config);
   const isLoadingConfig = useSettingsStore((state) => state.isLoadingConfig);
   const isSavingConfig = useSettingsStore((state) => state.isSavingConfig);
-  const setAuthKey = useSettingsStore((state) => state.setAuthKey);
   const setRefreshAccountIntervalMinute = useSettingsStore((state) => state.setRefreshAccountIntervalMinute);
   const setProxy = useSettingsStore((state) => state.setProxy);
   const setBaseUrl = useSettingsStore((state) => state.setBaseUrl);
@@ -59,17 +58,10 @@ export function ConfigCard() {
   return (
     <Card className="rounded-2xl border-white/80 bg-white/90 shadow-sm">
       <CardContent className="space-y-4 p-6">
+        <div className="rounded-xl border border-stone-200 bg-stone-50 px-4 py-3 text-sm leading-6 text-stone-600">
+          管理员登录密钥继续从部署配置读取，不再在此页面展示；如需分发给其他人，请在下方创建普通用户密钥。
+        </div>
         <div className="grid gap-4 md:grid-cols-2">
-          <div className="space-y-2">
-            <label className="text-sm text-stone-700">登录密钥</label>
-            <Input
-              value={String(config?.["auth-key"] || "")}
-              onChange={(event) => setAuthKey(event.target.value)}
-              placeholder="auth-key"
-              className="h-10 rounded-xl border-stone-200 bg-white"
-            />
-            <p className="text-xs text-stone-500">用于后台登录验证。</p>
-          </div>
           <div className="space-y-2">
             <label className="text-sm text-stone-700">账号刷新间隔</label>
             <Input

--- a/web/src/app/settings/components/user-keys-card.tsx
+++ b/web/src/app/settings/components/user-keys-card.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Ban, CheckCircle2, Copy, KeyRound, LoaderCircle, Plus, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { createUserKey, deleteUserKey, fetchUserKeys, updateUserKey, type UserKey } from "@/lib/api";
+
+function formatDateTime(value?: string | null) {
+  if (!value) {
+    return "—";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return new Intl.DateTimeFormat("zh-CN", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+}
+
+export function UserKeysCard() {
+  const didLoadRef = useRef(false);
+  const [items, setItems] = useState<UserKey[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [isCreating, setIsCreating] = useState(false);
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [revealedKey, setRevealedKey] = useState("");
+
+  const load = async () => {
+    setIsLoading(true);
+    try {
+      const data = await fetchUserKeys();
+      setItems(data.items);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "加载用户密钥失败");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (didLoadRef.current) {
+      return;
+    }
+    didLoadRef.current = true;
+    void load();
+  }, []);
+
+  const handleCreate = async () => {
+    setIsCreating(true);
+    try {
+      const data = await createUserKey(name.trim());
+      setItems(data.items);
+      setRevealedKey(data.key);
+      setName("");
+      setIsDialogOpen(false);
+      toast.success("用户密钥已创建");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "创建用户密钥失败");
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleToggle = async (item: UserKey) => {
+    setPendingId(item.id);
+    try {
+      const data = await updateUserKey(item.id, { enabled: !item.enabled });
+      setItems(data.items);
+      toast.success(item.enabled ? "用户密钥已禁用" : "用户密钥已启用");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "更新用户密钥失败");
+    } finally {
+      setPendingId(null);
+    }
+  };
+
+  const handleDelete = async (item: UserKey) => {
+    if (!window.confirm(`确认删除用户密钥「${item.name}」吗？`)) {
+      return;
+    }
+    setPendingId(item.id);
+    try {
+      const data = await deleteUserKey(item.id);
+      setItems(data.items);
+      toast.success("用户密钥已删除");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "删除用户密钥失败");
+    } finally {
+      setPendingId(null);
+    }
+  };
+
+  const handleCopy = async (value: string) => {
+    try {
+      await navigator.clipboard.writeText(value);
+      toast.success("已复制到剪贴板");
+    } catch {
+      toast.error("复制失败，请手动复制");
+    }
+  };
+
+  return (
+    <>
+      <Card className="rounded-2xl border-white/80 bg-white/90 shadow-sm">
+        <CardContent className="space-y-6 p-6">
+          <div className="flex items-start justify-between gap-4">
+            <div className="flex items-center gap-3">
+              <div className="flex size-10 items-center justify-center rounded-xl bg-stone-100">
+                <KeyRound className="size-5 text-stone-600" />
+              </div>
+              <div>
+                <h2 className="text-lg font-semibold tracking-tight">用户密钥管理</h2>
+                <p className="text-sm text-stone-500">为普通用户创建专用密钥；普通用户只能进入画图页，不能查看设置和号池。</p>
+              </div>
+            </div>
+            <Button className="h-9 rounded-xl bg-stone-950 px-4 text-white hover:bg-stone-800" onClick={() => setIsDialogOpen(true)}>
+              <Plus className="size-4" />
+              创建用户密钥
+            </Button>
+          </div>
+
+          {revealedKey ? (
+            <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-4 text-sm text-emerald-900">
+              <div className="font-medium">新密钥仅展示一次，请立即保存：</div>
+              <div className="mt-3 flex flex-col gap-3 rounded-lg border border-emerald-200 bg-white/80 p-3 md:flex-row md:items-center md:justify-between">
+                <code className="break-all font-mono text-[13px]">{revealedKey}</code>
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="h-9 rounded-xl border-emerald-200 bg-white px-4 text-emerald-700"
+                  onClick={() => void handleCopy(revealedKey)}
+                >
+                  <Copy className="size-4" />
+                  复制
+                </Button>
+              </div>
+            </div>
+          ) : null}
+
+          {isLoading ? (
+            <div className="flex items-center justify-center py-10">
+              <LoaderCircle className="size-5 animate-spin text-stone-400" />
+            </div>
+          ) : items.length === 0 ? (
+            <div className="rounded-xl bg-stone-50 px-6 py-10 text-center text-sm text-stone-500">
+              暂无普通用户密钥。点击右上角按钮后即可创建并分发给其他人。
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {items.map((item) => {
+                const isPending = pendingId === item.id;
+                return (
+                  <div key={item.id} className="flex flex-col gap-3 rounded-xl border border-stone-200 bg-white px-4 py-4 md:flex-row md:items-center md:justify-between">
+                    <div className="min-w-0 space-y-2">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <div className="truncate text-sm font-medium text-stone-800">{item.name}</div>
+                        <Badge variant={item.enabled ? "success" : "secondary"} className="rounded-md">
+                          {item.enabled ? "已启用" : "已禁用"}
+                        </Badge>
+                      </div>
+                      <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-stone-500">
+                        <span>创建时间 {formatDateTime(item.created_at)}</span>
+                        <span>最近使用 {formatDateTime(item.last_used_at)}</span>
+                      </div>
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className="h-9 rounded-xl border-stone-200 bg-white px-4 text-stone-700"
+                        onClick={() => void handleToggle(item)}
+                        disabled={isPending}
+                      >
+                        {isPending ? (
+                          <LoaderCircle className="size-4 animate-spin" />
+                        ) : item.enabled ? (
+                          <Ban className="size-4" />
+                        ) : (
+                          <CheckCircle2 className="size-4" />
+                        )}
+                        {item.enabled ? "禁用" : "启用"}
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className="h-9 rounded-xl border-rose-200 bg-white px-4 text-rose-600 hover:bg-rose-50 hover:text-rose-700"
+                        onClick={() => void handleDelete(item)}
+                        disabled={isPending}
+                      >
+                        {isPending ? <LoaderCircle className="size-4 animate-spin" /> : <Trash2 className="size-4" />}
+                        删除
+                      </Button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <DialogContent className="rounded-2xl p-6">
+          <DialogHeader className="gap-2">
+            <DialogTitle>创建用户密钥</DialogTitle>
+            <DialogDescription className="text-sm leading-6">
+              可选填写一个备注名称，方便区分不同使用者；创建后会生成一条只能查看一次的原始密钥。
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-stone-700">名称（可选）</label>
+            <Input
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="例如：设计同学 A、运营临时账号"
+              className="h-11 rounded-xl border-stone-200 bg-white"
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="secondary"
+              className="h-10 rounded-xl bg-stone-100 px-5 text-stone-700 hover:bg-stone-200"
+              onClick={() => setIsDialogOpen(false)}
+              disabled={isCreating}
+            >
+              取消
+            </Button>
+            <Button
+              type="button"
+              className="h-10 rounded-xl bg-stone-950 px-5 text-white hover:bg-stone-800"
+              onClick={() => void handleCreate()}
+              disabled={isCreating}
+            >
+              {isCreating ? <LoaderCircle className="size-4 animate-spin" /> : <Plus className="size-4" />}
+              创建
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/web/src/app/settings/components/user-keys-card.tsx
+++ b/web/src/app/settings/components/user-keys-card.tsx
@@ -42,7 +42,7 @@ export function UserKeysCard() {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [name, setName] = useState("");
   const [isCreating, setIsCreating] = useState(false);
-  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [pendingIds, setPendingIds] = useState<Set<string>>(() => new Set());
   const [revealedKey, setRevealedKey] = useState("");
 
   const load = async () => {
@@ -81,8 +81,20 @@ export function UserKeysCard() {
     }
   };
 
+  const setItemPending = (id: string, isPending: boolean) => {
+    setPendingIds((current) => {
+      const next = new Set(current);
+      if (isPending) {
+        next.add(id);
+      } else {
+        next.delete(id);
+      }
+      return next;
+    });
+  };
+
   const handleToggle = async (item: UserKey) => {
-    setPendingId(item.id);
+    setItemPending(item.id, true);
     try {
       const data = await updateUserKey(item.id, { enabled: !item.enabled });
       setItems(data.items);
@@ -90,7 +102,7 @@ export function UserKeysCard() {
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "更新用户密钥失败");
     } finally {
-      setPendingId(null);
+      setItemPending(item.id, false);
     }
   };
 
@@ -98,7 +110,7 @@ export function UserKeysCard() {
     if (!window.confirm(`确认删除用户密钥「${item.name}」吗？`)) {
       return;
     }
-    setPendingId(item.id);
+    setItemPending(item.id, true);
     try {
       const data = await deleteUserKey(item.id);
       setItems(data.items);
@@ -106,7 +118,7 @@ export function UserKeysCard() {
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "删除用户密钥失败");
     } finally {
-      setPendingId(null);
+      setItemPending(item.id, false);
     }
   };
 
@@ -168,7 +180,7 @@ export function UserKeysCard() {
           ) : (
             <div className="space-y-3">
               {items.map((item) => {
-                const isPending = pendingId === item.id;
+                const isPending = pendingIds.has(item.id);
                 return (
                   <div key={item.id} className="flex flex-col gap-3 rounded-xl border border-stone-200 bg-white px-4 py-4 md:flex-row md:items-center md:justify-between">
                     <div className="min-w-0 space-y-2">

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { LoaderCircle } from "lucide-react";
+
+import { useAuthGuard } from "@/lib/use-auth-guard";
 
 import { ConfigCard } from "./components/config-card";
 import { CPAPoolDialog } from "./components/cpa-pool-dialog";
@@ -8,6 +11,7 @@ import { CPAPoolsCard } from "./components/cpa-pools-card";
 import { ImportBrowserDialog } from "./components/import-browser-dialog";
 import { SettingsHeader } from "./components/settings-header";
 import { Sub2APIConnections } from "./components/sub2api-connections";
+import { UserKeysCard } from "./components/user-keys-card";
 import { useSettingsStore } from "./store";
 
 function SettingsDataController() {
@@ -42,13 +46,14 @@ function SettingsDataController() {
   return null;
 }
 
-export default function SettingsPage() {
+function SettingsPageContent() {
   return (
     <>
       <SettingsDataController />
       <SettingsHeader />
       <section className="space-y-6">
         <ConfigCard />
+        <UserKeysCard />
         <CPAPoolsCard />
         <Sub2APIConnections />
       </section>
@@ -56,4 +61,18 @@ export default function SettingsPage() {
       <ImportBrowserDialog />
     </>
   );
+}
+
+export default function SettingsPage() {
+  const { isCheckingAuth, session } = useAuthGuard(["admin"]);
+
+  if (isCheckingAuth || !session || session.role !== "admin") {
+    return (
+      <div className="flex min-h-[40vh] items-center justify-center">
+        <LoaderCircle className="size-5 animate-spin text-stone-400" />
+      </div>
+    );
+  }
+
+  return <SettingsPageContent />;
 }

--- a/web/src/app/settings/store.ts
+++ b/web/src/app/settings/store.ts
@@ -24,7 +24,6 @@ export type PageSizeOption = (typeof PAGE_SIZE_OPTIONS)[number];
 function normalizeConfig(config: SettingsConfig): SettingsConfig {
   return {
     ...config,
-    "auth-key": typeof config["auth-key"] === "string" ? config["auth-key"] : "",
     refresh_account_interval_minute: Number(config.refresh_account_interval_minute || 5),
     proxy: typeof config.proxy === "string" ? config.proxy : "",
     base_url: typeof config.base_url === "string" ? config.base_url : "",
@@ -78,7 +77,6 @@ type SettingsStore = {
   initialize: () => Promise<void>;
   loadConfig: () => Promise<void>;
   saveConfig: () => Promise<void>;
-  setAuthKey: (value: string) => void;
   setRefreshAccountIntervalMinute: (value: string) => void;
   setProxy: (value: string) => void;
   setBaseUrl: (value: string) => void;
@@ -159,7 +157,6 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
     try {
       const data = await updateSettingsConfig({
         ...config,
-        "auth-key": String(config["auth-key"] || "").trim(),
         refresh_account_interval_minute: Math.max(1, Number(config.refresh_account_interval_minute) || 1),
         proxy: config.proxy.trim(),
         base_url: String(config.base_url || "").trim(),
@@ -173,20 +170,6 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
     } finally {
       set({ isSavingConfig: false });
     }
-  },
-
-  setAuthKey: (value) => {
-    set((state) => {
-      if (!state.config) {
-        return {};
-      }
-      return {
-        config: {
-          ...state.config,
-          "auth-key": value,
-        },
-      };
-    });
   },
 
   setRefreshAccountIntervalMinute: (value) => {

--- a/web/src/components/top-nav.tsx
+++ b/web/src/components/top-nav.tsx
@@ -1,31 +1,63 @@
 "use client";
 
 import Link from "next/link";
+import { useEffect, useState } from "react";
 import { Github } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
 
 import webConfig from "@/constants/common-env";
-import { clearStoredAuthKey } from "@/store/auth";
+import { clearStoredAuthSession, getStoredAuthSession, type StoredAuthSession } from "@/store/auth";
 import { cn } from "@/lib/utils";
 
-const navItems = [
+const adminNavItems = [
   { href: "/image", label: "画图" },
   { href: "/accounts", label: "号池管理" },
   { href: "/settings", label: "设置" },
 ];
 
+const userNavItems = [{ href: "/image", label: "画图" }];
+
 export function TopNav() {
   const pathname = usePathname();
   const router = useRouter();
+  const [session, setSession] = useState<StoredAuthSession | null | undefined>(undefined);
+
+  useEffect(() => {
+    let active = true;
+
+    const load = async () => {
+      if (pathname === "/login") {
+        if (!active) {
+          return;
+        }
+        setSession(null);
+        return;
+      }
+
+      const storedSession = await getStoredAuthSession();
+      if (!active) {
+        return;
+      }
+      setSession(storedSession);
+    };
+
+    void load();
+    return () => {
+      active = false;
+    };
+  }, [pathname]);
 
   const handleLogout = async () => {
-    await clearStoredAuthKey();
+    await clearStoredAuthSession();
     router.replace("/login");
   };
 
-  if (pathname === "/login") {
+  if (pathname === "/login" || session === undefined || !session) {
     return null;
   }
+
+  const navItems = session.role === "admin" ? adminNavItems : userNavItems;
+  const roleLabel = session.role === "admin" ? "管理员" : "普通用户";
 
   return (
     <header className="border-b border-stone-100/50">
@@ -67,6 +99,9 @@ export function TopNav() {
           })}
         </div>
         <div className="flex items-center justify-end gap-2 sm:gap-3">
+          <span className="hidden rounded-md bg-stone-100 px-2 py-1 text-[10px] font-medium text-stone-500 sm:inline-block sm:text-[11px]">
+            {roleLabel}
+          </span>
           <span className="hidden rounded-md bg-stone-100 px-2 py-1 text-[10px] font-medium text-stone-500 sm:inline-block sm:text-[11px]">
             v{webConfig.appVersion}
           </span>

--- a/web/src/components/ui/dia-text-reveal.tsx
+++ b/web/src/components/ui/dia-text-reveal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import {
   animate,
   motion,
@@ -138,7 +138,8 @@ export function DiaTextReveal({
   fixedWidth = false,
   ...props
 }: DiaTextRevealProps) {
-  const texts = Array.isArray(text) ? text : [text]
+  const texts = useMemo(() => (Array.isArray(text) ? text : [text]), [text])
+  const textKey = texts.join("\0")
   const isMulti = texts.length > 1
   const prefersReducedMotion = useReducedMotion()
 
@@ -152,15 +153,6 @@ export function DiaTextReveal({
     repeatDelay,
     texts,
   })
-  optsRef.current = {
-    colors,
-    textColor,
-    duration,
-    delay,
-    repeat,
-    repeatDelay,
-    texts,
-  }
 
   const indexRef = useRef(0)
   const hasPlayedRef = useRef(false)
@@ -180,33 +172,47 @@ export function DiaTextReveal({
   const isInView = useInView(spanRef, { once, amount: 0.1 })
 
   useEffect(() => {
+    optsRef.current = {
+      colors,
+      textColor,
+      duration,
+      delay,
+      repeat,
+      repeatDelay,
+      texts,
+    }
+  }, [colors, delay, duration, repeat, repeatDelay, textColor, textKey, texts])
+
+  useEffect(() => {
     const el = spanRef.current
     if (!el || !isMulti) return
     setMeasuredWidths(measureWidths(el, texts))
-  }, [Array.isArray(text) ? text.join("\0") : text])
+  }, [isMulti, textKey, texts])
 
-  playRef.current = () => {
-    const { duration, delay, repeat, repeatDelay, texts } = optsRef.current
+  useEffect(() => {
+    playRef.current = () => {
+      const { duration, delay, repeat, repeatDelay, texts } = optsRef.current
 
-    sweepPos.set(SWEEP_START)
+      sweepPos.set(SWEEP_START)
 
-    const controls = animate(sweepPos, SWEEP_END, {
-      duration,
-      delay,
-      ease: sweepEase,
-      onComplete() {
-        if (!repeat) return
-        timerRef.current = setTimeout(() => {
-          const next = (indexRef.current + 1) % texts.length
-          indexRef.current = next
-          setActiveIndex(next)
-          playRef.current()
-        }, repeatDelay * 1000)
-      },
-    })
+      const controls = animate(sweepPos, SWEEP_END, {
+        duration,
+        delay,
+        ease: sweepEase,
+        onComplete() {
+          if (!repeat) return
+          timerRef.current = setTimeout(() => {
+            const next = (indexRef.current + 1) % texts.length
+            indexRef.current = next
+            setActiveIndex(next)
+            playRef.current()
+          }, repeatDelay * 1000)
+        },
+      })
 
-    stopRef.current = () => controls.stop()
-  }
+      stopRef.current = () => controls.stop()
+    }
+  }, [sweepPos])
 
   useEffect(() => {
     if (prefersReducedMotion) {

--- a/web/src/components/ui/dia-text-reveal.tsx
+++ b/web/src/components/ui/dia-text-reveal.tsx
@@ -171,17 +171,15 @@ export function DiaTextReveal({
 
   const isInView = useInView(spanRef, { once, amount: 0.1 })
 
-  useEffect(() => {
-    optsRef.current = {
-      colors,
-      textColor,
-      duration,
-      delay,
-      repeat,
-      repeatDelay,
-      texts,
-    }
-  }, [colors, delay, duration, repeat, repeatDelay, textColor, textKey, texts])
+  optsRef.current = {
+    colors,
+    textColor,
+    duration,
+    delay,
+    repeat,
+    repeatDelay,
+    texts,
+  }
 
   useEffect(() => {
     const el = spanRef.current

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -3,6 +3,7 @@ import { httpRequest } from "@/lib/request";
 export type AccountType = "Free" | "Plus" | "ProLite" | "Pro" | "Team";
 export type AccountStatus = "正常" | "限流" | "异常" | "禁用";
 export type ImageModel = "auto" | "gpt-image-1" | "gpt-image-2";
+export type AuthRole = "admin" | "user";
 
 export type Account = {
   id: string;
@@ -52,14 +53,30 @@ type AccountUpdateResponse = {
 export type SettingsConfig = {
   proxy: string;
   base_url?: string;
-  "auth-key"?: string;
   refresh_account_interval_minute?: number | string;
   [key: string]: unknown;
 };
 
+export type LoginResponse = {
+  ok: boolean;
+  version: string;
+  role: AuthRole;
+  subject_id: string;
+  name: string;
+};
+
+export type UserKey = {
+  id: string;
+  name: string;
+  role: "user";
+  enabled: boolean;
+  created_at: string | null;
+  last_used_at: string | null;
+};
+
 export async function login(authKey: string) {
   const normalizedAuthKey = String(authKey || "").trim();
-  return httpRequest<{ ok: boolean }>("/auth/login", {
+  return httpRequest<LoginResponse>("/auth/login", {
     method: "POST",
     body: {},
     headers: {
@@ -160,6 +177,30 @@ export async function updateSettingsConfig(settings: SettingsConfig) {
   return httpRequest<{ config: SettingsConfig }>("/api/settings", {
     method: "POST",
     body: settings,
+  });
+}
+
+export async function fetchUserKeys() {
+  return httpRequest<{ items: UserKey[] }>("/api/auth/users");
+}
+
+export async function createUserKey(name: string) {
+  return httpRequest<{ item: UserKey; key: string; items: UserKey[] }>("/api/auth/users", {
+    method: "POST",
+    body: { name },
+  });
+}
+
+export async function updateUserKey(keyId: string, updates: { enabled?: boolean; name?: string }) {
+  return httpRequest<{ item: UserKey; items: UserKey[] }>(`/api/auth/users/${keyId}`, {
+    method: "POST",
+    body: updates,
+  });
+}
+
+export async function deleteUserKey(keyId: string) {
+  return httpRequest<{ items: UserKey[] }>(`/api/auth/users/${keyId}`, {
+    method: "DELETE",
   });
 }
 

--- a/web/src/lib/request.ts
+++ b/web/src/lib/request.ts
@@ -1,7 +1,7 @@
 import axios, {AxiosError, type AxiosRequestConfig} from "axios";
 
 import webConfig from "@/constants/common-env";
-import {clearStoredAuthKey, getStoredAuthKey} from "@/store/auth";
+import {clearStoredAuthSession, getStoredAuthKey} from "@/store/auth";
 
 type RequestConfig = AxiosRequestConfig & {
     redirectOnUnauthorized?: boolean;
@@ -32,7 +32,7 @@ request.interceptors.response.use(
         if (status === 401 && shouldRedirect && typeof window !== "undefined") {
             // Avoid redirect loop — only redirect if not already on /login
             if (!window.location.pathname.startsWith("/login")) {
-                await clearStoredAuthKey();
+                await clearStoredAuthSession();
                 window.location.replace("/login");
                 // Return a never-resolving promise to prevent further error handling
                 // while the browser navigates away

--- a/web/src/lib/use-auth-guard.ts
+++ b/web/src/lib/use-auth-guard.ts
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import {
+  getDefaultRouteForRole,
+  getStoredAuthSession,
+  type AuthRole,
+  type StoredAuthSession,
+} from "@/store/auth";
+
+type UseAuthGuardResult = {
+  isCheckingAuth: boolean;
+  session: StoredAuthSession | null;
+};
+
+export function useAuthGuard(allowedRoles?: AuthRole[]): UseAuthGuardResult {
+  const router = useRouter();
+  const [session, setSession] = useState<StoredAuthSession | null>(null);
+  const [isCheckingAuth, setIsCheckingAuth] = useState(true);
+  const allowedRolesKey = (allowedRoles || []).join(",");
+
+  useEffect(() => {
+    let active = true;
+
+    const load = async () => {
+      const roleList = allowedRolesKey ? (allowedRolesKey.split(",") as AuthRole[]) : [];
+      const storedSession = await getStoredAuthSession();
+      if (!active) {
+        return;
+      }
+
+      if (!storedSession) {
+        setSession(null);
+        setIsCheckingAuth(false);
+        router.replace("/login");
+        return;
+      }
+
+      if (roleList.length > 0 && !roleList.includes(storedSession.role)) {
+        setSession(storedSession);
+        setIsCheckingAuth(false);
+        router.replace(getDefaultRouteForRole(storedSession.role));
+        return;
+      }
+
+      setSession(storedSession);
+      setIsCheckingAuth(false);
+    };
+
+    void load();
+    return () => {
+      active = false;
+    };
+  }, [allowedRolesKey, router]);
+
+  return { isCheckingAuth, session };
+}
+
+export function useRedirectIfAuthenticated() {
+  const router = useRouter();
+  const [isCheckingAuth, setIsCheckingAuth] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+
+    const load = async () => {
+      const storedSession = await getStoredAuthSession();
+      if (!active) {
+        return;
+      }
+
+      if (storedSession) {
+        router.replace(getDefaultRouteForRole(storedSession.role));
+        return;
+      }
+
+      setIsCheckingAuth(false);
+    };
+
+    void load();
+    return () => {
+      active = false;
+    };
+  }, [router]);
+
+  return { isCheckingAuth };
+}

--- a/web/src/store/auth.ts
+++ b/web/src/store/auth.ts
@@ -2,12 +2,46 @@
 
 import localforage from "localforage";
 
+export type AuthRole = "admin" | "user";
+
+export type StoredAuthSession = {
+  key: string;
+  role: AuthRole;
+  subjectId: string;
+  name: string;
+};
+
 export const AUTH_KEY_STORAGE_KEY = "chatgpt2api_auth_key";
+export const AUTH_SESSION_STORAGE_KEY = "chatgpt2api_auth_session";
 
 const authStorage = localforage.createInstance({
   name: "chatgpt2api",
   storeName: "auth",
 });
+
+function normalizeSession(value: unknown, fallbackKey = ""): StoredAuthSession | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const candidate = value as Partial<StoredAuthSession>;
+  const key = String(candidate.key || fallbackKey || "").trim();
+  const role = candidate.role === "admin" || candidate.role === "user" ? candidate.role : null;
+  if (!key || !role) {
+    return null;
+  }
+
+  return {
+    key,
+    role,
+    subjectId: String(candidate.subjectId || "").trim(),
+    name: String(candidate.name || "").trim(),
+  };
+}
+
+export function getDefaultRouteForRole(role: AuthRole) {
+  return role === "admin" ? "/accounts" : "/image";
+}
 
 export async function getStoredAuthKey() {
   if (typeof window === "undefined") {
@@ -17,18 +51,62 @@ export async function getStoredAuthKey() {
   return String(value || "").trim();
 }
 
+export async function getStoredAuthSession() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const [storedKey, storedSession] = await Promise.all([
+    authStorage.getItem<string>(AUTH_KEY_STORAGE_KEY),
+    authStorage.getItem<StoredAuthSession>(AUTH_SESSION_STORAGE_KEY),
+  ]);
+
+  const normalizedSession = normalizeSession(storedSession, String(storedKey || ""));
+  if (normalizedSession) {
+    if (normalizedSession.key !== String(storedKey || "").trim()) {
+      await authStorage.setItem(AUTH_KEY_STORAGE_KEY, normalizedSession.key);
+    }
+    return normalizedSession;
+  }
+
+  if (String(storedKey || "").trim()) {
+    await clearStoredAuthSession();
+  }
+  return null;
+}
+
+export async function setStoredAuthSession(session: StoredAuthSession) {
+  const normalizedSession = normalizeSession(session);
+  if (!normalizedSession) {
+    await clearStoredAuthSession();
+    return;
+  }
+
+  await Promise.all([
+    authStorage.setItem(AUTH_KEY_STORAGE_KEY, normalizedSession.key),
+    authStorage.setItem(AUTH_SESSION_STORAGE_KEY, normalizedSession),
+  ]);
+}
+
 export async function setStoredAuthKey(authKey: string) {
   const normalizedAuthKey = String(authKey || "").trim();
   if (!normalizedAuthKey) {
-    await clearStoredAuthKey();
+    await clearStoredAuthSession();
     return;
   }
   await authStorage.setItem(AUTH_KEY_STORAGE_KEY, normalizedAuthKey);
 }
 
-export async function clearStoredAuthKey() {
+export async function clearStoredAuthSession() {
   if (typeof window === "undefined") {
     return;
   }
-  await authStorage.removeItem(AUTH_KEY_STORAGE_KEY);
+  await Promise.all([
+    authStorage.removeItem(AUTH_KEY_STORAGE_KEY),
+    authStorage.removeItem(AUTH_SESSION_STORAGE_KEY),
+  ]);
+}
+
+export async function clearStoredAuthKey() {
+  await clearStoredAuthSession();
 }


### PR DESCRIPTION
## 变更摘要

  本 PR 为项目引入了基于角色的访问控制，将原本单一的全局密钥模型拆分为 `admin` / `user` 两类密钥。

  此前项目只有一个全局 `auth-key`，任何拿到该 key 的人都可以访问全部设置、号池数据以及管理操作，不适合分发给他人使用。
  本次改动的目标是让普通用户只能使用画图能力，而管理员继续保留完整后台能力。

  ## 主要改动

  ### 后端
  - 增加 `admin` / `user` 角色认证
  - 新增 `services/auth_service.py`，用于用户密钥存储与校验
  - 将以下管理接口限制为仅管理员可访问：
    - `/api/settings`
    - `/api/accounts*`
    - `/api/cpa/*`
    - `/api/sub2api/*`
    - `/api/proxy/test`
  - 图片相关接口继续允许认证用户访问
  - 扩展 `/auth/login` 返回内容，增加角色信息
  - 设置接口不再返回 `auth-key`
  - 保留现有 `config/env` 中 legacy admin key 的兼容能力

  ### 前端
  - 增加基于角色的 session 存储
  - 登录后按角色跳转：
    - `admin` -> `/accounts`
    - `user` -> `/image`
  - 顶部导航按角色展示
  - 在设置页中新增“用户密钥管理”卡片，管理员可创建/启用/禁用/删除普通用户密钥

  ### 测试与依赖
  - 增加认证服务与角色权限相关测试覆盖
  - `httpx` 加入依赖

  ## 行为说明

  - 普通用户密钥无法访问设置页、号池页以及对应管理接口，仍可使用图片相关接口
  - 本 PR 仅实现权限隔离，不包含注册、配额、计费等能力

  ## 验证情况

  已执行：

  ```bash
  uv run python -m unittest discover -s test
  cd web && npm run build
  cd web && npm exec eslint src

  结果：

  -  前端、后端测试通过
  - eslint 无阻塞错误