### PR TITLE
fix: filter invalid file_upload id in image results for image-to-image

### DIFF
--- a/services/openai_backend_api.py
+++ b/services/openai_backend_api.py
@@ -641,7 +641,16 @@ class OpenAIBackendAPI:
     def _resolve_image_urls(self, conversation_id: str, file_ids: list[str], sediment_ids: list[str]) -> list[str]:
         """把图片结果 id 解析成可下载 URL。"""
         urls = []
+        skip_patterns = {"file_upload"}
         for file_id in file_ids:
+            if file_id in skip_patterns:
+                logger.debug({
+                    "event": "image_file_id_skipped",
+                    "source": "file",
+                    "conversation_id": conversation_id,
+                    "id": file_id,
+                })
+                continue
             try:
                 url = self._get_file_download_url(file_id)
             except Exception as exc:
@@ -749,6 +758,8 @@ class OpenAIBackendAPI:
         conversation_id = sse_result["conversation_id"]
         file_ids = list(sse_result["file_ids"])
         sediment_ids = list(sse_result["sediment_ids"])
+        invalid_file_id_patterns = {"file_upload"}
+        file_ids = [fid for fid in file_ids if fid not in invalid_file_id_patterns]
         if conversation_id and not file_ids and not sediment_ids:
             polled_file_ids, polled_sediment_ids = self._poll_image_results(conversation_id)
             file_ids.extend([item for item in polled_file_ids if item not in file_ids])
@@ -1020,6 +1031,8 @@ class OpenAIBackendAPI:
         finally:
             sse.close()
 
+        invalid_file_id_patterns = {"file_upload"}
+        file_ids = [fid for fid in file_ids if fid not in invalid_file_id_patterns]
         if conversation_id and not file_ids and not sediment_ids:
             polled_file_ids, polled_sediment_ids = self._poll_image_results(conversation_id)
             self._append_unique(file_ids, polled_file_ids)


### PR DESCRIPTION

## 原因分析

在图生图场景下，ChatGPT 后端返回的 SSE 流中包含 `file_upload` 这个占位符 ID。正则表达式 `r"(file[-_][A-Za-z0-9]+)"` 会匹配到它，但 `file_upload` 并不是一个真实的可下载文件 ID。

由于 `file_ids=['file_upload']` 非空，polling 逻辑被跳过，导致无法获取真实生成的图片。

## 修复内容

1. 在 `_resolve_image_urls` 函数中添加过滤逻辑，跳过 `file_upload` 无效 ID
2. 在非流式图生图响应处理中，polling 判断前过滤掉 `file_upload`
3. 在流式图生图响应处理中，同样过滤 `file_upload`

这样修复后，当 `file_upload` 被过滤后，如果 `file_ids` 为空，系统会正确触发 polling 来获取真实的图片文件 ID。