### PR TITLE
fix: /v1/chat/completions 支持多张参考图进行图生图

### DIFF
--- a/services/chatgpt_service.py
+++ b/services/chatgpt_service.py
@@ -955,11 +955,11 @@ class ChatGPTService:
         if not prompt:
             raise HTTPException(status_code=400, detail={"error": "prompt is required"})
 
-        image_info = extract_chat_image(body)
+        image_infos = extract_chat_image(body)
         try:
-            if image_info:
-                image_data, mime_type = image_info
-                image_result = self.edit_with_pool(prompt, [(image_data, "image.png", mime_type)], model, n)
+            if image_infos:
+                images = [(data, f"image_{idx}.png", mime) for idx, (data, mime) in enumerate(image_infos, start=1)]
+                image_result = self.edit_with_pool(prompt, images, model, n)
             else:
                 image_result = self.generate_with_pool(prompt, model, n)
         except ImageGenerationError as exc:
@@ -979,11 +979,11 @@ class ChatGPTService:
         if not prompt:
             raise HTTPException(status_code=400, detail={"error": "prompt is required"})
 
-        image_info = extract_chat_image(body)
+        image_infos = extract_chat_image(body)
         encoded_images = []
-        if image_info:
-            image_data, mime_type = image_info
-            encoded_images = self._encode_images([(image_data, "image.png", mime_type)])
+        if image_infos:
+            images = [(data, f"image_{idx}.png", mime) for idx, (data, mime) in enumerate(image_infos, start=1)]
+            encoded_images = self._encode_images(images)
 
         last_error = ""
         while True:

--- a/utils/helper.py
+++ b/utils/helper.py
@@ -155,9 +155,10 @@ def extract_prompt_from_message_content(content: object) -> str:
     return "\n".join(parts).strip()
 
 
-def extract_image_from_message_content(content: object) -> tuple[bytes, str] | None:
+def extract_image_from_message_content(content: object) -> list[tuple[bytes, str]]:
     if not isinstance(content, list):
-        return None
+        return []
+    images = []
     for item in content:
         if not isinstance(item, dict):
             continue
@@ -168,29 +169,30 @@ def extract_image_from_message_content(content: object) -> tuple[bytes, str] | N
             if url.startswith("data:"):
                 header, _, data = url.partition(",")
                 mime = header.split(";")[0].removeprefix("data:")
-                return base64.b64decode(data), mime or "image/png"
-        if item_type == "input_image":
+                images.append((base64.b64decode(data), mime or "image/png"))
+        elif item_type == "input_image":
             image_url = str(item.get("image_url") or "")
             if image_url.startswith("data:"):
                 header, _, data = image_url.partition(",")
                 mime = header.split(";")[0].removeprefix("data:")
-                return base64.b64decode(data), mime or "image/png"
-    return None
+                images.append((base64.b64decode(data), mime or "image/png"))
+    return images
 
 
-def extract_chat_image(body: dict[str, object]) -> tuple[bytes, str] | None:
+def extract_chat_image(body: dict[str, object]) -> list[tuple[bytes, str]]:
     messages = body.get("messages")
     if not isinstance(messages, list):
-        return None
+        return []
+    all_images = []
     for message in reversed(messages):
         if not isinstance(message, dict):
             continue
         if str(message.get("role") or "").strip().lower() != "user":
             continue
-        result = extract_image_from_message_content(message.get("content"))
-        if result:
-            return result
-    return None
+        images = extract_image_from_message_content(message.get("content"))
+        if images:
+            all_images.extend(images)
+    return all_images
 
 
 def extract_chat_prompt(body: dict[str, object]) -> str:


### PR DESCRIPTION
## 修复：/v1/chat/completions 支持多张参考图

### 问题
Web UI 的图生图功能支持多张参考图，但通过 API 调用 `/v1/chat/completions` 只能上传 1 张。

### 修改
- `utils/helper.py`：修改 `extract_image_from_message_content` 和 `extract_chat_image` 返回多张图片列表
- `services/chatgpt_service.py`：修改 `_create_image_chat_completion` 和 `_stream_image_chat_completion` 处理多张图片

### 测试
已测试多图上传功能正常。