### PR TITLE
feat: add MiniMax provider support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.13"
 dependencies = [
     "curl-cffi>=0.15.0",
     "fastapi>=0.136.0",
+    "openai>=1.0.0",
     "pillow>=12.2.0",
     "pybase64>=1.4.3",
     "python-multipart>=0.0.26",

--- a/services/chatgpt_service.py
+++ b/services/chatgpt_service.py
@@ -12,6 +12,7 @@ from fastapi import HTTPException
 
 from services.account_service import AccountService
 from services.config import config
+from services.minimax_backend_api import MINIMAX_MODELS, MinimaxBackendAPI, is_minimax_model
 from services.openai_backend_api import CODEX_IMAGE_MODEL, OpenAIBackendAPI
 from utils.helper import (
     IMAGE_MODELS,
@@ -110,6 +111,19 @@ class ChatGPTService:
                 "owned_by": "chatgpt2api",
                 "permission": [],
                 "root": model,
+                "parent": None,
+            })
+        for model_id in MINIMAX_MODELS:
+            if model_id in seen:
+                continue
+            seen.add(model_id)
+            data.append({
+                "id": model_id,
+                "object": "model",
+                "created": 0,
+                "owned_by": "minimax",
+                "permission": [],
+                "root": model_id,
                 "parent": None,
             })
         return result
@@ -1038,6 +1052,11 @@ class ChatGPTService:
     def _create_text_chat_completion(self, body: dict[str, object]) -> dict[str, object]:
         model = str(body.get("model") or "auto").strip() or "auto"
         messages = self._chat_messages_from_body(body)
+        if is_minimax_model(model):
+            try:
+                return MinimaxBackendAPI().chat_completions(messages=messages, model=model, stream=False)
+            except Exception as exc:
+                raise HTTPException(status_code=502, detail={"error": str(exc)}) from exc
         try:
             return self._new_backend(self._get_text_access_token()).chat_completions(messages=messages, model=model, stream=False)
         except Exception as exc:
@@ -1055,6 +1074,12 @@ class ChatGPTService:
 
         model = str(body.get("model") or "auto").strip() or "auto"
         messages = self._chat_messages_from_body(body)
+        if is_minimax_model(model):
+            try:
+                yield from MinimaxBackendAPI().chat_completions(messages=messages, model=model, stream=True)
+            except Exception as exc:
+                raise HTTPException(status_code=502, detail={"error": str(exc)}) from exc
+            return
         try:
             yield from self._new_backend(self._get_text_access_token()).chat_completions(messages=messages, model=model, stream=True)
         except Exception as exc:

--- a/services/minimax_backend_api.py
+++ b/services/minimax_backend_api.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Iterator
+
+import openai
+
+MINIMAX_MODELS = [
+    "MiniMax-M2.7",
+    "MiniMax-M2.7-highspeed",
+]
+
+
+def is_minimax_model(model: str) -> bool:
+    return str(model or "").lower().startswith("minimax")
+
+
+class MinimaxBackendAPI:
+    """MiniMax OpenAI-compatible API client.
+
+    Wraps the MiniMax chat API (OpenAI-compatible) and exposes the same interface
+    as OpenAIBackendAPI for text chat completions.
+    """
+
+    def __init__(self) -> None:
+        api_key = os.environ.get("MINIMAX_API_KEY", "")
+        base_url = os.environ.get("MINIMAX_BASE_URL", "https://api.minimax.io/v1")
+        self.client = openai.OpenAI(api_key=api_key, base_url=base_url)
+
+    @staticmethod
+    def list_models() -> Dict[str, Any]:
+        return {
+            "object": "list",
+            "data": [
+                {
+                    "id": model_id,
+                    "object": "model",
+                    "created": 0,
+                    "owned_by": "minimax",
+                    "permission": [],
+                    "root": model_id,
+                    "parent": None,
+                }
+                for model_id in MINIMAX_MODELS
+            ],
+        }
+
+    def chat_completions(
+        self,
+        messages: list[Dict[str, Any]],
+        model: str = "MiniMax-M2.7",
+        stream: bool = False,
+    ) -> Dict[str, Any] | Iterator[Dict[str, Any]]:
+        """Call MiniMax chat completions API with OpenAI-compatible interface.
+
+        Notes:
+        - MiniMax temperature must be in (0.0, 1.0], defaults to 1.0.
+        - response_format is not supported and is omitted.
+        """
+        params: Dict[str, Any] = {
+            "model": model,
+            "messages": messages,
+            "temperature": 1.0,
+            "stream": stream,
+        }
+        if stream:
+            return self._stream_chat_completions(params)
+        response = self.client.chat.completions.create(**params)
+        return response.model_dump(exclude_none=True)
+
+    def _stream_chat_completions(self, params: Dict[str, Any]) -> Iterator[Dict[str, Any]]:
+        with self.client.chat.completions.create(**params) as stream:
+            for chunk in stream:
+                yield chunk.model_dump(exclude_none=True)

--- a/test/test_minimax_provider.py
+++ b/test/test_minimax_provider.py
@@ -1,0 +1,188 @@
+"""Unit tests for MiniMax provider integration."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+ROOT_DIR = __import__("pathlib").Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+
+class TestIsMinimaxModel(unittest.TestCase):
+    def setUp(self):
+        from services.minimax_backend_api import is_minimax_model
+        self.is_minimax_model = is_minimax_model
+
+    def test_minimax_m27_detected(self):
+        self.assertTrue(self.is_minimax_model("MiniMax-M2.7"))
+
+    def test_minimax_m27_highspeed_detected(self):
+        self.assertTrue(self.is_minimax_model("MiniMax-M2.7-highspeed"))
+
+    def test_case_insensitive(self):
+        self.assertTrue(self.is_minimax_model("minimax-m2.7"))
+        self.assertTrue(self.is_minimax_model("MINIMAX-M2.7"))
+
+    def test_non_minimax_model_rejected(self):
+        self.assertFalse(self.is_minimax_model("gpt-4"))
+        self.assertFalse(self.is_minimax_model("auto"))
+        self.assertFalse(self.is_minimax_model("claude-3"))
+        self.assertFalse(self.is_minimax_model(""))
+
+    def test_none_rejected(self):
+        self.assertFalse(self.is_minimax_model(None))
+
+
+class TestMinimaxBackendAPIListModels(unittest.TestCase):
+    def test_list_models_returns_correct_structure(self):
+        from services.minimax_backend_api import MinimaxBackendAPI
+        result = MinimaxBackendAPI.list_models()
+        self.assertEqual(result["object"], "list")
+        self.assertIsInstance(result["data"], list)
+        model_ids = [item["id"] for item in result["data"]]
+        self.assertIn("MiniMax-M2.7", model_ids)
+        self.assertIn("MiniMax-M2.7-highspeed", model_ids)
+
+    def test_list_models_owned_by_minimax(self):
+        from services.minimax_backend_api import MinimaxBackendAPI
+        result = MinimaxBackendAPI.list_models()
+        for item in result["data"]:
+            self.assertEqual(item["owned_by"], "minimax")
+            self.assertEqual(item["object"], "model")
+
+
+class TestMinimaxBackendAPIInit(unittest.TestCase):
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    @patch("openai.OpenAI")
+    def test_uses_env_api_key(self, mock_openai_cls):
+        from importlib import reload
+        import services.minimax_backend_api as mod
+        reload(mod)
+        mod.MinimaxBackendAPI()
+        mock_openai_cls.assert_called_once_with(
+            api_key="test-key-123",
+            base_url="https://api.minimax.io/v1",
+        )
+
+    @patch.dict(os.environ, {
+        "MINIMAX_API_KEY": "test-key",
+        "MINIMAX_BASE_URL": "https://custom.minimax.io/v1",
+    })
+    @patch("openai.OpenAI")
+    def test_uses_custom_base_url(self, mock_openai_cls):
+        from importlib import reload
+        import services.minimax_backend_api as mod
+        reload(mod)
+        mod.MinimaxBackendAPI()
+        mock_openai_cls.assert_called_once_with(
+            api_key="test-key",
+            base_url="https://custom.minimax.io/v1",
+        )
+
+
+class TestMinimaxBackendAPIChatCompletions(unittest.TestCase):
+    def _make_api(self):
+        with patch("openai.OpenAI"):
+            from services.minimax_backend_api import MinimaxBackendAPI
+            api = MinimaxBackendAPI()
+        return api
+
+    def test_non_stream_passes_correct_params(self):
+        api = self._make_api()
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "id": "chatcmpl-test",
+            "choices": [{"message": {"role": "assistant", "content": "Hello"}}],
+        }
+        api.client.chat.completions.create = MagicMock(return_value=mock_response)
+
+        result = api.chat_completions(
+            messages=[{"role": "user", "content": "Hi"}],
+            model="MiniMax-M2.7",
+            stream=False,
+        )
+
+        api.client.chat.completions.create.assert_called_once_with(
+            model="MiniMax-M2.7",
+            messages=[{"role": "user", "content": "Hi"}],
+            temperature=1.0,
+            stream=False,
+        )
+        self.assertIsInstance(result, dict)
+
+    def test_temperature_is_always_1_0(self):
+        """MiniMax requires temperature > 0, defaults to 1.0."""
+        api = self._make_api()
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {"id": "chatcmpl-test", "choices": []}
+        api.client.chat.completions.create = MagicMock(return_value=mock_response)
+
+        api.chat_completions(
+            messages=[{"role": "user", "content": "test"}],
+            model="MiniMax-M2.7",
+            stream=False,
+        )
+
+        call_kwargs = api.client.chat.completions.create.call_args[1]
+        self.assertEqual(call_kwargs["temperature"], 1.0)
+
+    def test_stream_returns_iterator(self):
+        api = self._make_api()
+        mock_chunk1 = MagicMock()
+        mock_chunk1.model_dump.return_value = {
+            "id": "chatcmpl-test",
+            "choices": [{"delta": {"content": "He"}}],
+        }
+        mock_chunk2 = MagicMock()
+        mock_chunk2.model_dump.return_value = {
+            "id": "chatcmpl-test",
+            "choices": [{"delta": {"content": "llo"}}],
+        }
+
+        mock_stream_ctx = MagicMock()
+        mock_stream_ctx.__enter__ = MagicMock(return_value=iter([mock_chunk1, mock_chunk2]))
+        mock_stream_ctx.__exit__ = MagicMock(return_value=False)
+        api.client.chat.completions.create = MagicMock(return_value=mock_stream_ctx)
+
+        result = api.chat_completions(
+            messages=[{"role": "user", "content": "Hi"}],
+            model="MiniMax-M2.7",
+            stream=True,
+        )
+        chunks = list(result)
+        self.assertEqual(len(chunks), 2)
+        self.assertIn("id", chunks[0])
+
+
+class TestMinimaxModelConstants(unittest.TestCase):
+    def test_only_m27_models_exported(self):
+        from services.minimax_backend_api import MINIMAX_MODELS
+        self.assertIn("MiniMax-M2.7", MINIMAX_MODELS)
+        self.assertIn("MiniMax-M2.7-highspeed", MINIMAX_MODELS)
+        self.assertEqual(len(MINIMAX_MODELS), 2)
+
+
+class TestBaseURLDefault(unittest.TestCase):
+    def test_default_base_url_is_international(self):
+        """Base URL must use international domain, not api.minimax.chat."""
+        with patch("openai.OpenAI") as mock_openai_cls, \
+             patch.dict(os.environ, {"MINIMAX_API_KEY": "key"}, clear=False):
+            # Remove MINIMAX_BASE_URL so default is used
+            env_copy = {k: v for k, v in os.environ.items() if k != "MINIMAX_BASE_URL"}
+            with patch.dict(os.environ, env_copy, clear=True):
+                from importlib import reload
+                import services.minimax_backend_api as mod
+                reload(mod)
+                mod.MinimaxBackendAPI()
+                _, kwargs = mock_openai_cls.call_args
+                base_url = kwargs.get("base_url", "")
+                self.assertIn("api.minimax.io", base_url)
+                self.assertNotIn("api.minimax.chat", base_url)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `services/minimax_backend_api.py` with `MinimaxBackendAPI` class that wraps the MiniMax OpenAI-compatible chat API
- Route model names starting with `minimax` (case-insensitive) to MiniMax API instead of ChatGPT
- Expose `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` models in the `/v1/models` endpoint
- Support both streaming and non-streaming chat completions
- Add `openai>=1.0.0` dependency (used to call the MiniMax OpenAI-compatible API)
- Add `MINIMAX_API_KEY` and `MINIMAX_BASE_URL` environment variable support

## Models Added

| Model ID | Description |
|----------|-------------|
| `MiniMax-M2.7` | Peak Performance. Ultimate Value. Master the Complex |
| `MiniMax-M2.7-highspeed` | Same performance, faster and more agile |

## Usage

Set `MINIMAX_API_KEY` environment variable, then use model names starting with `MiniMax-`:

```bash
MINIMAX_API_KEY=your-key uvicorn main:app
```

```python
# Non-streaming
POST /v1/chat/completions
{"model": "MiniMax-M2.7", "messages": [...]}

# Streaming
POST /v1/chat/completions
{"model": "MiniMax-M2.7", "stream": true, "messages": [...]}
```

## API Reference

- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api

## Testing

14 unit tests added covering:
- Model name detection (`is_minimax_model`)
- Provider initialization with env vars
- Default base URL uses international domain (`api.minimax.io`)
- Non-streaming and streaming chat completions
- Temperature constraint (MiniMax requires `temperature > 0`, defaults to `1.0`)
- Model list structure