### PR TITLE
fix(image): 刷新后恢复图片任务 / recover image tasks after refresh

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -8,7 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
-from api import accounts, ai, register, system
+from api import accounts, ai, image_tasks, register, system
 from api.support import resolve_web_asset, start_limited_account_watcher
 from services.config import config
 
@@ -37,6 +37,7 @@ def create_app() -> FastAPI:
     )
     app.include_router(ai.create_router())
     app.include_router(accounts.create_router())
+    app.include_router(image_tasks.create_router())
     app.include_router(register.create_router())
     app.include_router(system.create_router(app_version))
     if config.images_dir.exists():

--- a/api/image_tasks.py
+++ b/api/image_tasks.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, File, Form, Header, HTTPException, Query, Request, UploadFile
+from fastapi.concurrency import run_in_threadpool
+from pydantic import BaseModel, Field
+
+from api.support import require_identity, resolve_image_base_url
+from services.image_task_service import image_task_service
+
+
+class ImageGenerationTaskRequest(BaseModel):
+    client_task_id: str = Field(..., min_length=1)
+    prompt: str = Field(..., min_length=1)
+    model: str = "gpt-image-2"
+    size: str | None = None
+
+
+def _parse_task_ids(value: str) -> list[str]:
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def create_router() -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/api/image-tasks")
+    async def list_image_tasks(
+        ids: str = Query(default=""),
+        authorization: str | None = Header(default=None),
+    ):
+        identity = require_identity(authorization)
+        return await run_in_threadpool(image_task_service.list_tasks, identity, _parse_task_ids(ids))
+
+    @router.post("/api/image-tasks/generations")
+    async def create_generation_task(
+        body: ImageGenerationTaskRequest,
+        request: Request,
+        authorization: str | None = Header(default=None),
+    ):
+        identity = require_identity(authorization)
+        try:
+            return await run_in_threadpool(
+                image_task_service.submit_generation,
+                identity,
+                client_task_id=body.client_task_id,
+                prompt=body.prompt,
+                model=body.model,
+                size=body.size,
+                base_url=resolve_image_base_url(request),
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail={"error": str(exc)}) from exc
+
+    @router.post("/api/image-tasks/edits")
+    async def create_edit_task(
+        request: Request,
+        authorization: str | None = Header(default=None),
+        image: list[UploadFile] | None = File(default=None),
+        image_list: list[UploadFile] | None = File(default=None, alias="image[]"),
+        client_task_id: str = Form(...),
+        prompt: str = Form(...),
+        model: str = Form(default="gpt-image-2"),
+        size: str | None = Form(default=None),
+    ):
+        identity = require_identity(authorization)
+        uploads = [*(image or []), *(image_list or [])]
+        if not uploads:
+            raise HTTPException(status_code=400, detail={"error": "image file is required"})
+        images: list[tuple[bytes, str, str]] = []
+        for upload in uploads:
+            image_data = await upload.read()
+            if not image_data:
+                raise HTTPException(status_code=400, detail={"error": "image file is empty"})
+            images.append((image_data, upload.filename or "image.png", upload.content_type or "image/png"))
+        try:
+            return await run_in_threadpool(
+                image_task_service.submit_edit,
+                identity,
+                client_task_id=client_task_id,
+                prompt=prompt,
+                model=model,
+                size=size,
+                base_url=resolve_image_base_url(request),
+                images=images,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail={"error": str(exc)}) from exc
+
+    return router

--- a/services/image_task_service.py
+++ b/services/image_task_service.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import json
+import threading
+import time
+from collections.abc import Callable
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from services.config import DATA_DIR, config
+from services.protocol import openai_v1_image_edit, openai_v1_image_generations
+
+TASK_STATUS_QUEUED = "queued"
+TASK_STATUS_RUNNING = "running"
+TASK_STATUS_SUCCESS = "success"
+TASK_STATUS_ERROR = "error"
+TERMINAL_STATUSES = {TASK_STATUS_SUCCESS, TASK_STATUS_ERROR}
+UNFINISHED_STATUSES = {TASK_STATUS_QUEUED, TASK_STATUS_RUNNING}
+
+
+def _now_iso() -> str:
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _timestamp(value: object) -> float:
+    if not isinstance(value, str) or not value.strip():
+        return 0.0
+    for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S.%f", "%Y-%m-%dT%H:%M:%S"):
+        try:
+            return datetime.strptime(value[:26], fmt).timestamp()
+        except ValueError:
+            continue
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+    except Exception:
+        return 0.0
+
+
+def _clean(value: object, default: str = "") -> str:
+    return str(value or default).strip()
+
+
+def _owner_id(identity: dict[str, object]) -> str:
+    return _clean(identity.get("id")) or "anonymous"
+
+
+def _task_key(owner_id: str, task_id: str) -> str:
+    return f"{owner_id}:{task_id}"
+
+
+def _public_task(task: dict[str, Any]) -> dict[str, Any]:
+    item = {
+        "id": task.get("id"),
+        "status": task.get("status"),
+        "mode": task.get("mode"),
+        "model": task.get("model"),
+        "size": task.get("size"),
+        "created_at": task.get("created_at"),
+        "updated_at": task.get("updated_at"),
+    }
+    if task.get("data") is not None:
+        item["data"] = task.get("data")
+    if task.get("error"):
+        item["error"] = task.get("error")
+    return item
+
+
+class ImageTaskService:
+    def __init__(
+        self,
+        path: Path,
+        *,
+        generation_handler: Callable[[dict[str, Any]], dict[str, Any]] = openai_v1_image_generations.handle,
+        edit_handler: Callable[[dict[str, Any]], dict[str, Any]] = openai_v1_image_edit.handle,
+        retention_days_getter: Callable[[], int] | None = None,
+    ):
+        self.path = path
+        self.generation_handler = generation_handler
+        self.edit_handler = edit_handler
+        self.retention_days_getter = retention_days_getter or (lambda: config.image_retention_days)
+        self._lock = threading.RLock()
+        self._tasks: dict[str, dict[str, Any]] = {}
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self._lock:
+            self._tasks = self._load_locked()
+            changed = self._recover_unfinished_locked()
+            changed = self._cleanup_locked() or changed
+            if changed:
+                self._save_locked()
+
+    def submit_generation(
+        self,
+        identity: dict[str, object],
+        *,
+        client_task_id: str,
+        prompt: str,
+        model: str,
+        size: str | None,
+        base_url: str,
+    ) -> dict[str, Any]:
+        payload = {
+            "prompt": prompt,
+            "model": model,
+            "n": 1,
+            "size": size,
+            "response_format": "url",
+            "base_url": base_url,
+        }
+        return self._submit(identity, client_task_id=client_task_id, mode="generate", payload=payload)
+
+    def submit_edit(
+        self,
+        identity: dict[str, object],
+        *,
+        client_task_id: str,
+        prompt: str,
+        model: str,
+        size: str | None,
+        base_url: str,
+        images: list[tuple[bytes, str, str]],
+    ) -> dict[str, Any]:
+        payload = {
+            "prompt": prompt,
+            "images": images,
+            "model": model,
+            "n": 1,
+            "size": size,
+            "response_format": "url",
+            "base_url": base_url,
+        }
+        return self._submit(identity, client_task_id=client_task_id, mode="edit", payload=payload)
+
+    def list_tasks(self, identity: dict[str, object], task_ids: list[str]) -> dict[str, Any]:
+        owner = _owner_id(identity)
+        requested_ids = [_clean(task_id) for task_id in task_ids if _clean(task_id)]
+        with self._lock:
+            if self._cleanup_locked():
+                self._save_locked()
+            items = []
+            missing_ids = []
+            for task_id in requested_ids:
+                task = self._tasks.get(_task_key(owner, task_id))
+                if task is None:
+                    missing_ids.append(task_id)
+                else:
+                    items.append(_public_task(task))
+            if not requested_ids:
+                items = [
+                    _public_task(task)
+                    for task in self._tasks.values()
+                    if task.get("owner_id") == owner
+                ]
+                items.sort(key=lambda item: str(item.get("updated_at") or ""), reverse=True)
+                missing_ids = []
+            return {"items": items, "missing_ids": missing_ids}
+
+    def _submit(
+        self,
+        identity: dict[str, object],
+        *,
+        client_task_id: str,
+        mode: str,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        task_id = _clean(client_task_id)
+        if not task_id:
+            raise ValueError("client_task_id is required")
+        owner = _owner_id(identity)
+        key = _task_key(owner, task_id)
+        now = _now_iso()
+        should_start = False
+        with self._lock:
+            cleaned = self._cleanup_locked()
+            task = self._tasks.get(key)
+            if task is not None:
+                if cleaned:
+                    self._save_locked()
+                return _public_task(task)
+            task = {
+                "id": task_id,
+                "owner_id": owner,
+                "status": TASK_STATUS_QUEUED,
+                "mode": mode,
+                "model": _clean(payload.get("model"), "gpt-image-2"),
+                "size": _clean(payload.get("size")),
+                "created_at": now,
+                "updated_at": now,
+            }
+            self._tasks[key] = task
+            self._save_locked()
+            should_start = True
+
+        if should_start:
+            thread = threading.Thread(
+                target=self._run_task,
+                args=(key, mode, payload),
+                name=f"image-task-{task_id[:16]}",
+                daemon=True,
+            )
+            thread.start()
+        return _public_task(task)
+
+    def _run_task(self, key: str, mode: str, payload: dict[str, Any]) -> None:
+        self._update_task(key, status=TASK_STATUS_RUNNING, error="")
+        try:
+            handler = self.edit_handler if mode == "edit" else self.generation_handler
+            result = handler(payload)
+            if not isinstance(result, dict):
+                raise RuntimeError("image task returned streaming result unexpectedly")
+            data = result.get("data")
+            if not isinstance(data, list) or not data:
+                message = _clean(result.get("message")) or "image task returned no image data"
+                raise RuntimeError(message)
+            self._update_task(key, status=TASK_STATUS_SUCCESS, data=data, error="")
+        except Exception as exc:
+            self._update_task(key, status=TASK_STATUS_ERROR, error=str(exc) or "image task failed", data=[])
+
+    def _update_task(self, key: str, **updates: Any) -> None:
+        with self._lock:
+            task = self._tasks.get(key)
+            if task is None:
+                return
+            task.update(updates)
+            task["updated_at"] = _now_iso()
+            self._save_locked()
+
+    def _load_locked(self) -> dict[str, dict[str, Any]]:
+        if not self.path.exists():
+            return {}
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
+        except Exception:
+            return {}
+        raw_items = raw.get("tasks") if isinstance(raw, dict) else raw
+        if not isinstance(raw_items, list):
+            return {}
+        tasks: dict[str, dict[str, Any]] = {}
+        for item in raw_items:
+            if not isinstance(item, dict):
+                continue
+            task_id = _clean(item.get("id"))
+            owner = _clean(item.get("owner_id"))
+            if not task_id or not owner:
+                continue
+            status = _clean(item.get("status"))
+            if status not in {TASK_STATUS_QUEUED, TASK_STATUS_RUNNING, TASK_STATUS_SUCCESS, TASK_STATUS_ERROR}:
+                status = TASK_STATUS_ERROR
+            task = {
+                "id": task_id,
+                "owner_id": owner,
+                "status": status,
+                "mode": "edit" if item.get("mode") == "edit" else "generate",
+                "model": _clean(item.get("model"), "gpt-image-2"),
+                "size": _clean(item.get("size")),
+                "created_at": _clean(item.get("created_at"), _now_iso()),
+                "updated_at": _clean(item.get("updated_at"), _clean(item.get("created_at"), _now_iso())),
+            }
+            data = item.get("data")
+            if isinstance(data, list):
+                task["data"] = data
+            error = _clean(item.get("error"))
+            if error:
+                task["error"] = error
+            tasks[_task_key(owner, task_id)] = task
+        return tasks
+
+    def _save_locked(self) -> None:
+        items = sorted(self._tasks.values(), key=lambda item: str(item.get("updated_at") or ""), reverse=True)
+        tmp_path = self.path.with_suffix(self.path.suffix + ".tmp")
+        tmp_path.write_text(json.dumps({"tasks": items}, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        tmp_path.replace(self.path)
+
+    def _recover_unfinished_locked(self) -> bool:
+        changed = False
+        for task in self._tasks.values():
+            if task.get("status") in UNFINISHED_STATUSES:
+                task["status"] = TASK_STATUS_ERROR
+                task["error"] = "服务已重启，未完成的图片任务已中断"
+                task["updated_at"] = _now_iso()
+                changed = True
+        return changed
+
+    def _cleanup_locked(self) -> bool:
+        try:
+            retention_days = max(1, int(self.retention_days_getter()))
+        except Exception:
+            retention_days = 30
+        cutoff = time.time() - retention_days * 86400
+        removed_keys = [
+            key
+            for key, task in self._tasks.items()
+            if task.get("status") in TERMINAL_STATUSES and _timestamp(task.get("updated_at")) < cutoff
+        ]
+        for key in removed_keys:
+            self._tasks.pop(key, None)
+        return bool(removed_keys)
+
+
+image_task_service = ImageTaskService(DATA_DIR / "image_tasks.json")

--- a/test/test_image_task_service.py
+++ b/test/test_image_task_service.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from services.image_task_service import ImageTaskService
+
+
+OWNER = {"id": "owner-1", "name": "Owner", "role": "admin"}
+OTHER_OWNER = {"id": "owner-2", "name": "Other", "role": "user"}
+
+
+def wait_for_task(service: ImageTaskService, identity: dict[str, object], task_id: str, status: str, timeout: float = 2.0):
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        result = service.list_tasks(identity, [task_id])
+        last = (result.get("items") or [None])[0]
+        if last and last.get("status") == status:
+            return last
+        time.sleep(0.02)
+    raise AssertionError(f"task {task_id} did not reach {status}, last={last}")
+
+
+class ImageTaskServiceTests(unittest.TestCase):
+    def make_service(self, path: Path, handler=None) -> ImageTaskService:
+        return ImageTaskService(
+            path,
+            generation_handler=handler or (lambda _payload: {"data": [{"url": "http://example.test/image.png"}]}),
+            edit_handler=handler or (lambda _payload: {"data": [{"url": "http://example.test/edit.png"}]}),
+            retention_days_getter=lambda: 30,
+        )
+
+    def test_duplicate_submit_uses_existing_task(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            calls = 0
+
+            def handler(_payload):
+                nonlocal calls
+                calls += 1
+                time.sleep(0.05)
+                return {"data": [{"url": "http://example.test/image.png"}]}
+
+            service = self.make_service(Path(tmp_dir) / "image_tasks.json", handler)
+            first = service.submit_generation(
+                OWNER,
+                client_task_id="task-1",
+                prompt="cat",
+                model="gpt-image-2",
+                size=None,
+                base_url="http://local.test",
+            )
+            second = service.submit_generation(
+                OWNER,
+                client_task_id="task-1",
+                prompt="cat",
+                model="gpt-image-2",
+                size=None,
+                base_url="http://local.test",
+            )
+
+            self.assertEqual(first["id"], "task-1")
+            self.assertEqual(second["id"], "task-1")
+            task = wait_for_task(service, OWNER, "task-1", "success")
+            self.assertEqual(task["data"][0]["url"], "http://example.test/image.png")
+            self.assertEqual(calls, 1)
+
+    def test_different_owner_cannot_query_task(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            service = self.make_service(Path(tmp_dir) / "image_tasks.json")
+            service.submit_generation(
+                OWNER,
+                client_task_id="private-task",
+                prompt="cat",
+                model="gpt-image-2",
+                size=None,
+                base_url="http://local.test",
+            )
+
+            wait_for_task(service, OWNER, "private-task", "success")
+            result = service.list_tasks(OTHER_OWNER, ["private-task"])
+
+            self.assertEqual(result["items"], [])
+            self.assertEqual(result["missing_ids"], ["private-task"])
+
+    def test_success_task_persists_to_new_service_instance(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "image_tasks.json"
+            service = self.make_service(path)
+            service.submit_generation(
+                OWNER,
+                client_task_id="persisted-task",
+                prompt="cat",
+                model="gpt-image-2",
+                size=None,
+                base_url="http://local.test",
+            )
+            wait_for_task(service, OWNER, "persisted-task", "success")
+
+            reloaded = self.make_service(path)
+            result = reloaded.list_tasks(OWNER, ["persisted-task"])
+
+            self.assertEqual(result["missing_ids"], [])
+            self.assertEqual(result["items"][0]["status"], "success")
+            self.assertEqual(result["items"][0]["data"][0]["url"], "http://example.test/image.png")
+
+    def test_startup_marks_unfinished_tasks_as_error(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "image_tasks.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "tasks": [
+                            {
+                                "id": "queued-task",
+                                "owner_id": "owner-1",
+                                "status": "queued",
+                                "mode": "generate",
+                                "model": "gpt-image-2",
+                                "created_at": "2099-01-01 00:00:00",
+                                "updated_at": "2099-01-01 00:00:00",
+                            },
+                            {
+                                "id": "running-task",
+                                "owner_id": "owner-1",
+                                "status": "running",
+                                "mode": "generate",
+                                "model": "gpt-image-2",
+                                "created_at": "2099-01-01 00:00:00",
+                                "updated_at": "2099-01-01 00:00:00",
+                            },
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            service = self.make_service(path)
+            result = service.list_tasks(OWNER, ["queued-task", "running-task"])
+
+            self.assertEqual([item["status"] for item in result["items"]], ["error", "error"])
+            self.assertTrue(all("已中断" in item.get("error", "") for item in result["items"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_image_tasks_api.py
+++ b/test/test_image_tasks_api.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import api.image_tasks as image_tasks_module
+
+
+AUTH_HEADERS = {"Authorization": "Bearer chatgpt2api"}
+
+
+class FakeImageTaskService:
+    def __init__(self):
+        self.generation_calls = []
+        self.edit_calls = []
+
+    def submit_generation(self, identity, **kwargs):
+        self.generation_calls.append((identity, kwargs))
+        return {
+            "id": kwargs["client_task_id"],
+            "status": "success",
+            "mode": "generate",
+            "created_at": "2026-01-01 00:00:00",
+            "updated_at": "2026-01-01 00:00:00",
+            "data": [{"url": f"{kwargs['base_url']}/images/fake.png"}],
+        }
+
+    def submit_edit(self, identity, **kwargs):
+        self.edit_calls.append((identity, kwargs))
+        return {
+            "id": kwargs["client_task_id"],
+            "status": "queued",
+            "mode": "edit",
+            "created_at": "2026-01-01 00:00:00",
+            "updated_at": "2026-01-01 00:00:00",
+        }
+
+    def list_tasks(self, _identity, ids):
+        return {
+            "items": [
+                {
+                    "id": task_id,
+                    "status": "success",
+                    "mode": "generate",
+                    "created_at": "2026-01-01 00:00:00",
+                    "updated_at": "2026-01-01 00:00:00",
+                    "data": [{"url": "http://testserver/images/fake.png"}],
+                }
+                for task_id in ids
+                if task_id != "missing"
+            ],
+            "missing_ids": [task_id for task_id in ids if task_id == "missing"],
+        }
+
+
+class ImageTasksApiTests(unittest.TestCase):
+    def setUp(self):
+        self.fake_service = FakeImageTaskService()
+        self.service_patcher = mock.patch.object(image_tasks_module, "image_task_service", self.fake_service)
+        self.service_patcher.start()
+        self.addCleanup(self.service_patcher.stop)
+        app = FastAPI()
+        app.include_router(image_tasks_module.create_router())
+        self.client = TestClient(app)
+
+    def test_create_generation_task(self):
+        response = self.client.post(
+            "/api/image-tasks/generations",
+            headers=AUTH_HEADERS,
+            json={"client_task_id": "task-1", "prompt": "cat", "model": "gpt-image-2"},
+        )
+
+        self.assertEqual(response.status_code, 200, response.text)
+        payload = response.json()
+        self.assertEqual(payload["id"], "task-1")
+        self.assertEqual(payload["status"], "success")
+        self.assertEqual(len(self.fake_service.generation_calls), 1)
+
+    def test_create_edit_task_accepts_multiple_images(self):
+        response = self.client.post(
+            "/api/image-tasks/edits",
+            headers=AUTH_HEADERS,
+            data={"client_task_id": "edit-1", "prompt": "edit", "model": "gpt-image-2"},
+            files=[
+                ("image", ("one.png", b"one", "image/png")),
+                ("image", ("two.png", b"two", "image/png")),
+            ],
+        )
+
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(response.json()["id"], "edit-1")
+        self.assertEqual(len(self.fake_service.edit_calls), 1)
+        images = self.fake_service.edit_calls[0][1]["images"]
+        self.assertEqual(len(images), 2)
+
+    def test_list_tasks_reports_missing_ids(self):
+        response = self.client.get("/api/image-tasks?ids=task-1,missing", headers=AUTH_HEADERS)
+
+        self.assertEqual(response.status_code, 200, response.text)
+        payload = response.json()
+        self.assertEqual([item["id"] for item in payload["items"]], ["task-1"])
+        self.assertEqual(payload["missing_ids"], ["missing"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/src/app/image/components/image-results.tsx
+++ b/web/src/app/image/components/image-results.tsx
@@ -21,6 +21,13 @@ type ImageResultsProps = {
   formatConversationTime: (value: string) => string;
 };
 
+function getStoredImageSrc(image: StoredImage) {
+  if (image.b64_json) {
+    return `data:image/png;base64,${image.b64_json}`;
+  }
+  return image.url || "";
+}
+
 export function ImageResults({
   selectedConversation,
   onOpenLightbox,
@@ -71,18 +78,19 @@ export function ImageResults({
           id: `${turn.id}-reference-${index}`,
           src: image.dataUrl,
         }));
-        const successfulTurnImages = turn.images.flatMap((image) =>
-          image.status === "success" && image.b64_json
+        const successfulTurnImages = turn.images.flatMap((image) => {
+          const src = image.status === "success" ? getStoredImageSrc(image) : "";
+          return src
             ? [
                 {
                   id: image.id,
-                  src: `data:image/png;base64,${image.b64_json}`,
-                  sizeLabel: formatBase64ImageSize(image.b64_json),
+                  src,
+                  sizeLabel: image.b64_json ? formatBase64ImageSize(image.b64_json) : undefined,
                   dimensions: imageDimensions[image.id],
                 },
               ]
-            : [],
-        );
+            : [];
+        });
 
         return (
           <div key={turn.id} className="flex flex-col gap-4">
@@ -145,9 +153,10 @@ export function ImageResults({
 
                 <div className="columns-1 gap-4 space-y-4 sm:columns-2 xl:columns-3">
                   {turn.images.map((image, index) => {
-                    if (image.status === "success" && image.b64_json) {
+                    const imageSrc = image.status === "success" ? getStoredImageSrc(image) : "";
+                    if (image.status === "success" && imageSrc) {
                       const currentIndex = successfulTurnImages.findIndex((item) => item.id === image.id);
-                      const sizeLabel = formatBase64ImageSize(image.b64_json);
+                      const sizeLabel = image.b64_json ? formatBase64ImageSize(image.b64_json) : "";
                       const dimensions = imageDimensions[image.id];
                       const imageMeta = [sizeLabel, dimensions].filter(Boolean).join(" · ");
 
@@ -162,7 +171,7 @@ export function ImageResults({
                             className="group block w-full cursor-zoom-in"
                           >
                             <img
-                              src={`data:image/png;base64,${image.b64_json}`}
+                              src={imageSrc}
                               alt={`Generated result ${index + 1}`}
                               className="block h-auto w-full transition duration-200 group-hover:brightness-90"
                               onLoad={(event) => {

--- a/web/src/app/image/page.tsx
+++ b/web/src/app/image/page.tsx
@@ -17,7 +17,14 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { editImage, fetchAccounts, generateImage, type Account } from "@/lib/api";
+import {
+  createImageEditTask,
+  createImageGenerationTask,
+  fetchAccounts,
+  fetchImageTasks,
+  type Account,
+  type ImageTask,
+} from "@/lib/api";
 import { useAuthGuard } from "@/lib/use-auth-guard";
 import {
   clearImageConversations,
@@ -103,6 +110,81 @@ function buildReferenceImageFromResult(image: StoredImage, fileName: string): St
   };
 }
 
+async function fetchImageAsFile(url: string, fileName: string) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error("读取结果图失败");
+  }
+  const blob = await response.blob();
+  return new File([blob], fileName, { type: blob.type || "image/png" });
+}
+
+async function buildReferenceImageFromStoredImage(image: StoredImage, fileName: string) {
+  const direct = buildReferenceImageFromResult(image, fileName);
+  if (direct) {
+    return {
+      referenceImage: direct,
+      file: dataUrlToFile(direct.dataUrl, direct.name, direct.type),
+    };
+  }
+
+  if (!image.url) {
+    return null;
+  }
+  const file = await fetchImageAsFile(image.url, fileName);
+  return {
+    referenceImage: {
+      name: file.name,
+      type: file.type || "image/png",
+      dataUrl: await readFileAsDataUrl(file),
+    },
+    file,
+  };
+}
+
+function taskDataToStoredImage(image: StoredImage, task: ImageTask): StoredImage {
+  if (task.status === "success") {
+    const first = task.data?.[0];
+    if (!first?.b64_json && !first?.url) {
+      return {
+        ...image,
+        taskId: task.id,
+        status: "error",
+        error: "未返回图片数据",
+      };
+    }
+    return {
+      ...image,
+      taskId: task.id,
+      status: "success",
+      b64_json: first.b64_json,
+      url: first.url,
+      revised_prompt: first.revised_prompt,
+      error: undefined,
+    };
+  }
+
+  if (task.status === "error") {
+    return {
+      ...image,
+      taskId: task.id,
+      status: "error",
+      error: task.error || "生成失败",
+    };
+  }
+
+  return {
+    ...image,
+    taskId: task.id,
+    status: "loading",
+    error: undefined,
+  };
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
+}
+
 function pickFallbackConversationId(conversations: ImageConversation[]) {
   const activeConversation = conversations.find((conversation) =>
     conversation.turns.some((turn) => turn.status === "queued" || turn.status === "generating"),
@@ -114,65 +196,138 @@ function sortImageConversations(conversations: ImageConversation[]) {
   return [...conversations].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
 }
 
-async function recoverConversationHistory(items: ImageConversation[]) {
-  const normalized = items.map((conversation) => {
-    let changed = false;
+function deriveTurnStatus(turn: ImageTurn): Pick<ImageTurn, "status" | "error"> {
+  const loadingCount = turn.images.filter((image) => image.status === "loading").length;
+  const failedCount = turn.images.filter((image) => image.status === "error").length;
+  const successCount = turn.images.filter((image) => image.status === "success").length;
+  if (loadingCount > 0) {
+    return { status: turn.status === "queued" ? "queued" : "generating", error: undefined };
+  }
+  if (failedCount > 0) {
+    return { status: "error", error: `其中 ${failedCount} 张未成功生成` };
+  }
+  if (successCount > 0) {
+    return { status: "success", error: undefined };
+  }
+  return { status: "queued", error: undefined };
+}
 
+async function syncConversationImageTasks(items: ImageConversation[]) {
+  const taskIds = Array.from(
+    new Set(
+      items.flatMap((conversation) =>
+        conversation.turns.flatMap((turn) =>
+          turn.images.flatMap((image) => (image.status === "loading" && image.taskId ? [image.taskId] : [])),
+        ),
+      ),
+    ),
+  );
+  if (taskIds.length === 0) {
+    return items;
+  }
+
+  let taskList: Awaited<ReturnType<typeof fetchImageTasks>>;
+  try {
+    taskList = await fetchImageTasks(taskIds);
+  } catch {
+    return items;
+  }
+  const taskMap = new Map(taskList.items.map((task) => [task.id, task]));
+  let changed = false;
+  const normalized = items.map((conversation) => {
+    const turns = conversation.turns.map((turn) => {
+      let turnChanged = false;
+      const images = turn.images.map((image) => {
+        if (image.status !== "loading" || !image.taskId) {
+          return image;
+        }
+        const task = taskMap.get(image.taskId);
+        if (!task) {
+          return image;
+        }
+        const nextImage = taskDataToStoredImage(image, task);
+        if (nextImage !== image) {
+          turnChanged = true;
+        }
+        return nextImage;
+      });
+      if (!turnChanged) {
+        return turn;
+      }
+      changed = true;
+      const derived = deriveTurnStatus({ ...turn, images });
+      return {
+        ...turn,
+        ...derived,
+        images,
+      };
+    });
+    if (turns === conversation.turns || !turns.some((turn, index) => turn !== conversation.turns[index])) {
+      return conversation;
+    }
+    return {
+      ...conversation,
+      turns,
+      updatedAt: new Date().toISOString(),
+    };
+  });
+
+  if (changed) {
+    await saveImageConversations(normalized);
+  }
+  return normalized;
+}
+
+async function recoverConversationHistory(items: ImageConversation[]) {
+  let changed = false;
+  const normalized = items.map((conversation) => {
     const turns = conversation.turns.map((turn) => {
       if (turn.status !== "queued" && turn.status !== "generating") {
         return turn;
       }
 
-      const loadingCount = turn.images.filter((image) => image.status === "loading").length;
-      if (loadingCount > 0) {
-        const message = "页面刷新或任务中断，未完成的图片已标记为失败";
-        changed = true;
+      let turnChanged = false;
+      const images = turn.images.map((image) => {
+        if (image.status !== "loading" || image.taskId) {
+          return image;
+        }
+        turnChanged = true;
         return {
-          ...turn,
+          ...image,
           status: "error" as const,
-          error: message,
-          images: turn.images.map((image) =>
-            image.status === "loading" ? { ...image, status: "error" as const, error: message } : image,
-          ),
+          error: "页面刷新或任务中断，未找到可恢复的任务 ID",
         };
-      }
-
-      const failedCount = turn.images.filter((image) => image.status === "error").length;
-      const successCount = turn.images.filter((image) => image.status === "success").length;
-      const nextStatus: ImageTurnStatus =
-        failedCount > 0 ? "error" : successCount > 0 ? "success" : "queued";
-      const nextError = failedCount > 0 ? turn.error || `其中 ${failedCount} 张未成功生成` : undefined;
-      if (nextStatus === turn.status && nextError === turn.error) {
+      });
+      const derived = deriveTurnStatus({ ...turn, images });
+      if (!turnChanged && derived.status === turn.status && derived.error === turn.error) {
         return turn;
       }
-
       changed = true;
       return {
         ...turn,
-        status: nextStatus,
-        error: nextError,
+        ...derived,
+        images,
       };
     });
 
-    if (!changed) {
+    if (!turns.some((turn, index) => turn !== conversation.turns[index])) {
       return conversation;
     }
 
-    const lastTurn = turns.length > 0 ? turns[turns.length - 1] : null;
     return {
       ...conversation,
       turns,
-      updatedAt: lastTurn?.createdAt || conversation.updatedAt,
+      updatedAt: new Date().toISOString(),
     };
   });
 
-  const changedConversations = normalized.filter((conversation, index) => conversation !== items[index]);
-  if (changedConversations.length > 0) {
+  if (changed) {
     await saveImageConversations(normalized);
   }
 
-  return normalized;
+  return syncConversationImageTasks(normalized);
 }
+
 
 function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
   const didLoadQuotaRef = useRef(false);
@@ -490,25 +645,30 @@ function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
   }, []);
 
   const handleContinueEdit = useCallback(
-    (conversationId: string, image: StoredImage | StoredReferenceImage) => {
-      const nextReferenceImage =
-        "dataUrl" in image
-          ? image
-          : buildReferenceImageFromResult(image, `conversation-${conversationId}-${Date.now()}.png`);
-      if (!nextReferenceImage) {
-        return;
-      }
+    async (conversationId: string, image: StoredImage | StoredReferenceImage) => {
+      try {
+        const nextReference =
+          "dataUrl" in image
+            ? {
+                referenceImage: image,
+                file: dataUrlToFile(image.dataUrl, image.name, image.type),
+              }
+            : await buildReferenceImageFromStoredImage(image, `conversation-${conversationId}-${Date.now()}.png`);
+        if (!nextReference) {
+          return;
+        }
 
-      setSelectedConversationId(conversationId);
-      setImageMode("edit");
-      setReferenceImages((prev) => [...prev, nextReferenceImage]);
-      setReferenceImageFiles((prev) => [
-        ...prev,
-        dataUrlToFile(nextReferenceImage.dataUrl, nextReferenceImage.name, nextReferenceImage.type),
-      ]);
-      setImagePrompt("");
-      textareaRef.current?.focus();
-      toast.success("已加入当前参考图，继续输入描述即可编辑");
+        setSelectedConversationId(conversationId);
+        setImageMode("edit");
+        setReferenceImages((prev) => [...prev, nextReference.referenceImage]);
+        setReferenceImageFiles((prev) => [...prev, nextReference.file]);
+        setImagePrompt("");
+        textareaRef.current?.focus();
+        toast.success("已加入当前参考图，继续输入描述即可编辑");
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "读取结果图失败";
+        toast.error(message);
+      }
     },
     [],
   );
@@ -531,157 +691,115 @@ function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
       }
 
       const snapshot = conversationsRef.current.find((conversation) => conversation.id === conversationId);
-      const queuedTurn = snapshot?.turns.find((turn) => turn.status === "queued");
-      if (!snapshot || !queuedTurn) {
+      const activeTurn = snapshot?.turns.find(
+        (turn) =>
+          (turn.status === "queued" || turn.status === "generating") &&
+          turn.images.some((image) => image.status === "loading"),
+      );
+      if (!snapshot || !activeTurn) {
         return;
       }
 
       activeConversationQueueIds.add(conversationId);
-      await updateConversation(conversationId, (current) => {
-        const conversation = current ?? snapshot;
-        return {
-          ...conversation,
-          updatedAt: new Date().toISOString(),
-          turns: conversation.turns.map((turn) =>
-            turn.id === queuedTurn.id
-              ? {
-                  ...turn,
-                  status: "generating",
-                  error: undefined,
-                }
-              : turn,
-          ),
-        };
-      });
-
-      try {
-        const referenceFiles = queuedTurn.referenceImages.map((image, index) =>
-          dataUrlToFile(image.dataUrl, image.name || `${queuedTurn.id}-${index + 1}.png`, image.type),
-        );
-        const pendingImages = queuedTurn.images.filter((image) => image.status === "loading");
-
-        if (queuedTurn.mode === "edit" && referenceFiles.length === 0) {
-          throw new Error("未找到可用于继续编辑的参考图");
-        }
-
-        if (pendingImages.length === 0) {
-          const existingFailedCount = queuedTurn.images.filter((image) => image.status === "error").length;
-          const existingSuccessCount = queuedTurn.images.filter((image) => image.status === "success").length;
-          await updateConversation(conversationId, (current) => {
-            const conversation = current ?? snapshot;
+      const applyTasks = async (tasks: ImageTask[]) => {
+        const taskMap = new Map(tasks.map((task) => [task.id, task]));
+        await updateConversation(conversationId, (current) => {
+          const conversation = current ?? snapshot;
+          const turns = conversation.turns.map((turn) => {
+            if (turn.id !== activeTurn.id) {
+              return turn;
+            }
+            const images = turn.images.map((image) => {
+              const taskId = image.taskId || image.id;
+              const task = taskMap.get(taskId);
+              return task ? taskDataToStoredImage({ ...image, taskId }, task) : image;
+            });
+            const derived = deriveTurnStatus({ ...turn, status: "generating", images });
             return {
-              ...conversation,
-              updatedAt: new Date().toISOString(),
-              turns: conversation.turns.map((turn) =>
-                turn.id === queuedTurn.id
-                  ? {
-                      ...turn,
-                      status: existingFailedCount > 0 ? "error" : existingSuccessCount > 0 ? "success" : "queued",
-                      error: existingFailedCount > 0 ? `其中 ${existingFailedCount} 张未成功生成` : undefined,
-                    }
-                  : turn,
-              ),
+              ...turn,
+              ...derived,
+              images,
             };
           });
-          return;
-        }
-
-        const tasks = pendingImages.map(async (pendingImage) => {
-          try {
-            const data =
-              queuedTurn.mode === "edit"
-                ? await editImage(referenceFiles, queuedTurn.prompt, queuedTurn.model, queuedTurn.size)
-                : await generateImage(queuedTurn.prompt, queuedTurn.model, queuedTurn.size);
-            const first = data.data?.[0];
-            if (!first?.b64_json) {
-              throw new Error("未返回图片数据");
-            }
-
-            const nextImage: StoredImage = {
-              id: pendingImage.id,
-              status: "success",
-              b64_json: first.b64_json,
-            };
-
-            await updateConversation(
-              conversationId,
-              (current) => {
-                const conversation = current ?? snapshot;
-                return {
-                  ...conversation,
-                  updatedAt: new Date().toISOString(),
-                  turns: conversation.turns.map((turn) =>
-                    turn.id === queuedTurn.id
-                      ? {
-                          ...turn,
-                          images: turn.images.map((image) => (image.id === nextImage.id ? nextImage : image)),
-                        }
-                      : turn,
-                  ),
-                };
-              },
-              { persist: false },
-            );
-
-            return nextImage;
-          } catch (error) {
-            const message = error instanceof Error ? error.message : "生成失败";
-            const failedImage: StoredImage = {
-              id: pendingImage.id,
-              status: "error",
-              error: message,
-            };
-
-            await updateConversation(
-              conversationId,
-              (current) => {
-                const conversation = current ?? snapshot;
-                return {
-                  ...conversation,
-                  updatedAt: new Date().toISOString(),
-                  turns: conversation.turns.map((turn) =>
-                    turn.id === queuedTurn.id
-                      ? {
-                          ...turn,
-                          images: turn.images.map((image) => (image.id === failedImage.id ? failedImage : image)),
-                        }
-                      : turn,
-                  ),
-                };
-              },
-              { persist: false },
-            );
-
-            throw error;
-          }
+          return {
+            ...conversation,
+            updatedAt: new Date().toISOString(),
+            turns,
+          };
         });
+      };
 
-        const settled = await Promise.allSettled(tasks);
-        const resumedSuccessCount = settled.filter(
-          (item): item is PromiseFulfilledResult<StoredImage> => item.status === "fulfilled",
-        ).length;
-        const resumedFailedCount = settled.length - resumedSuccessCount;
-        const existingSuccessCount = queuedTurn.images.filter((image) => image.status === "success").length;
-        const existingFailedCount = queuedTurn.images.filter((image) => image.status === "error").length;
-        const successCount = existingSuccessCount + resumedSuccessCount;
-        const failedCount = existingFailedCount + resumedFailedCount;
-
+      try {
         await updateConversation(conversationId, (current) => {
           const conversation = current ?? snapshot;
           return {
             ...conversation,
             updatedAt: new Date().toISOString(),
             turns: conversation.turns.map((turn) =>
-              turn.id === queuedTurn.id
+              turn.id === activeTurn.id
                 ? {
                     ...turn,
-                    status: failedCount > 0 ? "error" : "success",
-                    error: failedCount > 0 ? `其中 ${failedCount} 张未成功生成` : undefined,
+                    status: "generating",
+                    error: undefined,
+                    images: turn.images.map((image) =>
+                      image.status === "loading" ? { ...image, taskId: image.taskId || image.id } : image,
+                    ),
                   }
                 : turn,
             ),
           };
         });
+
+        const referenceFiles = activeTurn.referenceImages.map((image, index) =>
+          dataUrlToFile(image.dataUrl, image.name || `${activeTurn.id}-${index + 1}.png`, image.type),
+        );
+        if (activeTurn.mode === "edit" && referenceFiles.length === 0) {
+          throw new Error("未找到可用于继续编辑的参考图");
+        }
+
+        const pendingImages = activeTurn.images.filter((image) => image.status === "loading");
+        const submitted = await Promise.all(
+          pendingImages.map((image) => {
+            const taskId = image.taskId || image.id;
+            return activeTurn.mode === "edit"
+              ? createImageEditTask(taskId, referenceFiles, activeTurn.prompt, activeTurn.model, activeTurn.size)
+              : createImageGenerationTask(taskId, activeTurn.prompt, activeTurn.model, activeTurn.size);
+          }),
+        );
+        await applyTasks(submitted);
+
+        while (true) {
+          const latestConversation = conversationsRef.current.find((conversation) => conversation.id === conversationId);
+          const latestTurn = latestConversation?.turns.find((turn) => turn.id === activeTurn.id);
+          const loadingTaskIds =
+            latestTurn?.images.flatMap((image) =>
+              image.status === "loading" && image.taskId ? [image.taskId] : [],
+            ) || [];
+          if (loadingTaskIds.length === 0) {
+            break;
+          }
+
+          await sleep(2000);
+          const taskList = await fetchImageTasks(loadingTaskIds);
+          if (taskList.items.length > 0) {
+            await applyTasks(taskList.items);
+          }
+          if (taskList.missing_ids.length > 0 && latestTurn) {
+            const missingImages = latestTurn.images.filter(
+              (image) => image.status === "loading" && image.taskId && taskList.missing_ids.includes(image.taskId),
+            );
+            const resubmitted = await Promise.all(
+              missingImages.map((image) =>
+                activeTurn.mode === "edit"
+                  ? createImageEditTask(image.taskId || image.id, referenceFiles, activeTurn.prompt, activeTurn.model, activeTurn.size)
+                  : createImageGenerationTask(image.taskId || image.id, activeTurn.prompt, activeTurn.model, activeTurn.size),
+              ),
+            );
+            if (resubmitted.length > 0) {
+              await applyTasks(resubmitted);
+            }
+          }
+        }
 
         await loadQuota();
       } catch (error) {
@@ -692,7 +810,7 @@ function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
             ...conversation,
             updatedAt: new Date().toISOString(),
             turns: conversation.turns.map((turn) =>
-              turn.id === queuedTurn.id
+              turn.id === activeTurn.id
                 ? {
                     ...turn,
                     status: "error",
@@ -711,7 +829,11 @@ function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
         for (const conversation of conversationsRef.current) {
           if (
             !activeConversationQueueIds.has(conversation.id) &&
-            conversation.turns.some((turn) => turn.status === "queued")
+            conversation.turns.some(
+              (turn) =>
+                (turn.status === "queued" || turn.status === "generating") &&
+                turn.images.some((image) => image.status === "loading"),
+            )
           ) {
             void runConversationQueue(conversation.id);
           }
@@ -726,7 +848,11 @@ function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
     for (const conversation of conversations) {
       if (
         !activeConversationQueueIds.has(conversation.id) &&
-        conversation.turns.some((turn) => turn.status === "queued")
+        conversation.turns.some(
+          (turn) =>
+            (turn.status === "queued" || turn.status === "generating") &&
+            turn.images.some((image) => image.status === "loading"),
+        )
       ) {
         void runConversationQueue(conversation.id);
       }
@@ -759,10 +885,14 @@ function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
       referenceImages: imageMode === "edit" ? referenceImages : [],
       count: parsedCount,
       size: imageSize,
-      images: Array.from({ length: parsedCount }, (_, index) => ({
-        id: `${turnId}-${index}`,
-        status: "loading" as const,
-      })),
+      images: Array.from({ length: parsedCount }, (_, index) => {
+        const imageId = `${turnId}-${index}`;
+        return {
+          id: imageId,
+          taskId: imageId,
+          status: "loading" as const,
+        };
+      }),
       createdAt: now,
       status: "queued",
     };

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -79,7 +79,24 @@ export type SystemLog = {
 
 export type ImageResponse = {
   created: number;
-  data: Array<{ b64_json: string; revised_prompt?: string }>;
+  data: Array<{ b64_json?: string; url?: string; revised_prompt?: string }>;
+};
+
+export type ImageTask = {
+  id: string;
+  status: "queued" | "running" | "success" | "error";
+  mode: "generate" | "edit";
+  model?: ImageModel;
+  size?: string;
+  created_at: string;
+  updated_at: string;
+  data?: Array<{ b64_json?: string; url?: string; revised_prompt?: string }>;
+  error?: string;
+};
+
+type ImageTaskListResponse = {
+  items: ImageTask[];
+  missing_ids: string[];
 };
 
 export type LoginResponse = {
@@ -230,6 +247,54 @@ export async function editImage(files: File | File[], prompt: string, model?: Im
       body: formData,
     },
   );
+}
+
+export async function createImageGenerationTask(clientTaskId: string, prompt: string, model?: ImageModel, size?: string) {
+  return httpRequest<ImageTask>("/api/image-tasks/generations", {
+    method: "POST",
+    body: {
+      client_task_id: clientTaskId,
+      prompt,
+      ...(model ? { model } : {}),
+      ...(size ? { size } : {}),
+    },
+  });
+}
+
+export async function createImageEditTask(
+  clientTaskId: string,
+  files: File | File[],
+  prompt: string,
+  model?: ImageModel,
+  size?: string,
+) {
+  const formData = new FormData();
+  const uploadFiles = Array.isArray(files) ? files : [files];
+
+  uploadFiles.forEach((file) => {
+    formData.append("image", file);
+  });
+  formData.append("client_task_id", clientTaskId);
+  formData.append("prompt", prompt);
+  if (model) {
+    formData.append("model", model);
+  }
+  if (size) {
+    formData.append("size", size);
+  }
+
+  return httpRequest<ImageTask>("/api/image-tasks/edits", {
+    method: "POST",
+    body: formData,
+  });
+}
+
+export async function fetchImageTasks(ids: string[]) {
+  const params = new URLSearchParams();
+  if (ids.length > 0) {
+    params.set("ids", ids.join(","));
+  }
+  return httpRequest<ImageTaskListResponse>(`/api/image-tasks${params.toString() ? `?${params.toString()}` : ""}`);
 }
 
 export async function fetchSettingsConfig() {

--- a/web/src/store/image-conversations.ts
+++ b/web/src/store/image-conversations.ts
@@ -14,8 +14,11 @@ export type StoredReferenceImage = {
 
 export type StoredImage = {
   id: string;
+  taskId?: string;
   status?: "loading" | "success" | "error";
   b64_json?: string;
+  url?: string;
+  revised_prompt?: string;
   error?: string;
 };
 
@@ -57,12 +60,18 @@ const IMAGE_CONVERSATIONS_KEY = "items";
 let imageConversationWriteQueue: Promise<void> = Promise.resolve();
 
 function normalizeStoredImage(image: StoredImage): StoredImage {
+  const normalized = {
+    ...image,
+    taskId: typeof image.taskId === "string" && image.taskId ? image.taskId : undefined,
+    url: typeof image.url === "string" && image.url ? image.url : undefined,
+    revised_prompt: typeof image.revised_prompt === "string" ? image.revised_prompt : undefined,
+  };
   if (image.status === "loading" || image.status === "error" || image.status === "success") {
-    return image;
+    return normalized;
   }
   return {
-    ...image,
-    status: image.b64_json ? "success" : "loading",
+    ...normalized,
+    status: image.b64_json || image.url ? "success" : "loading",
   };
 }
 


### PR DESCRIPTION
## 概要 / Summary

- 新增内部幂等图片任务 API，让内置画图页在刷新页面或切换页面后，不会重新发起生成，也不会丢失结果。
- Add an internal idempotent image task API so the built-in image page can survive refresh/navigation without restarting generation or losing results.

- 将任务和最终结果持久化到 `data/image_tasks.json`；服务重启时会把未完成任务标记为中断。
- Persist task metadata and final results to `data/image_tasks.json`; unfinished tasks are marked interrupted on service restart to avoid permanent loading states.

- 更新画图页本地历史和结果展示，支持轮询任务状态、恢复 URL 图片结果，并可继续用恢复后的图片进行编辑。
- Update local image history/results to poll task status, restore URL-based outputs, and continue editing from recovered images.

Fixes #65

## 变更说明 / Changes

- 新增 `/api/image-tasks/generations`、`/api/image-tasks/edits`、`/api/image-tasks?ids=...` 内部接口。
- Added internal endpoints: `/api/image-tasks/generations`, `/api/image-tasks/edits`, and `/api/image-tasks?ids=...`.

- 任务按 `identity.id + client_task_id` 幂等处理，避免刷新或重复提交造成重复消耗额度。
- Tasks are idempotent by `identity.id + client_task_id`, preventing duplicate quota usage after refresh or repeated submission.

- 画图页刷新后不再直接把 loading 图片标记失败，而是查询任务状态并补回结果。
- The image page no longer marks loading images as failed after refresh; it queries task status and restores completed results.

## 测试 / Tests

- `uv run python -m unittest test.test_image_task_service test.test_image_tasks_api`
