### PR TITLE
feat: improve mobile image generation UX

### DIFF
--- a/web/src/app/image/components/image-composer.tsx
+++ b/web/src/app/image/components/image-composer.tsx
@@ -6,11 +6,9 @@ import { ImageLightbox } from "@/components/image-lightbox";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import type { ImageConversationMode } from "@/store/image-conversations";
 import { cn } from "@/lib/utils";
 
 type ImageComposerProps = {
-  mode: ImageConversationMode;
   prompt: string;
   imageCount: string;
   imageSize: string;
@@ -19,7 +17,6 @@ type ImageComposerProps = {
   referenceImages: Array<{ name: string; dataUrl: string }>;
   textareaRef: RefObject<HTMLTextAreaElement | null>;
   fileInputRef: RefObject<HTMLInputElement | null>;
-  onModeChange: (value: ImageConversationMode) => void;
   onPromptChange: (value: string) => void;
   onImageCountChange: (value: string) => void;
   onImageSizeChange: (value: string) => void;
@@ -30,7 +27,6 @@ type ImageComposerProps = {
 };
 
 export function ImageComposer({
-  mode,
   prompt,
   imageCount,
   imageSize,
@@ -39,7 +35,6 @@ export function ImageComposer({
   referenceImages,
   textareaRef,
   fileInputRef,
-  onModeChange,
   onPromptChange,
   onImageCountChange,
   onImageSizeChange,
@@ -92,32 +87,30 @@ export function ImageComposer({
   };
 
   return (
-    <div className="shrink-0 flex justify-center">
+    <div className="shrink-0 flex justify-center px-1 sm:px-0">
       <div style={{ width: "min(980px, 100%)" }}>
-        {mode === "edit" && (
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept="image/*"
-            multiple
-            className="hidden"
-            onChange={(event) => {
-              void onReferenceImageChange(Array.from(event.target.files || []));
-            }}
-          />
-        )}
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          multiple
+          className="hidden"
+          onChange={(event) => {
+            void onReferenceImageChange(Array.from(event.target.files || []));
+          }}
+        />
 
-        {mode === "edit" && referenceImages.length > 0 ? (
-          <div className="mb-3 flex flex-wrap gap-2 px-1">
+        {referenceImages.length > 0 ? (
+          <div className="mb-2 flex gap-2 overflow-x-auto px-1 pb-1 sm:mb-3 sm:flex-wrap sm:overflow-visible sm:pb-0">
             {referenceImages.map((image, index) => (
-              <div key={`${image.name}-${index}`} className="relative size-16">
+              <div key={`${image.name}-${index}`} className="relative size-14 shrink-0 sm:size-16">
                 <button
                   type="button"
                   onClick={() => {
                     setLightboxIndex(index);
                     setLightboxOpen(true);
                   }}
-                  className="group size-16 overflow-hidden rounded-2xl border border-stone-200 bg-stone-50 transition hover:border-stone-300"
+                  className="group size-14 overflow-hidden rounded-2xl border border-stone-200 bg-stone-50 transition hover:border-stone-300 sm:size-16"
                   aria-label={`预览参考图 ${image.name || index + 1}`}
                 >
                   <img
@@ -142,7 +135,7 @@ export function ImageComposer({
           </div>
         ) : null}
 
-        <div className="rounded-[32px] border border-stone-200 bg-white">
+        <div className="rounded-[24px] border border-stone-200 bg-white shadow-[0_14px_60px_-42px_rgba(15,23,42,0.45)] sm:rounded-[32px] sm:shadow-none">
           <div
             className="relative cursor-text"
             onClick={() => {
@@ -162,7 +155,9 @@ export function ImageComposer({
               onChange={(event) => onPromptChange(event.target.value)}
               onPaste={handleTextareaPaste}
               placeholder={
-                mode === "edit" ? "描述你希望如何修改这张参考图，可直接粘贴图片" : "输入你想要生成的画面，也可直接粘贴图片"
+                referenceImages.length > 0
+                  ? "描述你希望如何修改参考图"
+                  : "输入你想要生成的画面，也可直接粘贴图片"
               }
               onKeyDown={(event) => {
                 if (event.key === "Enter" && !event.shiftKey) {
@@ -170,37 +165,35 @@ export function ImageComposer({
                   void onSubmit();
                 }
               }}
-              className="min-h-[148px] resize-none rounded-[32px] border-0 bg-transparent px-6 pt-6 pb-20 text-[15px] leading-7 text-stone-900 shadow-none placeholder:text-stone-400 focus-visible:ring-0"
+              className="min-h-[82px] resize-none rounded-[24px] border-0 bg-transparent px-4 pt-4 pb-2 text-[15px] leading-6 text-stone-900 shadow-none placeholder:text-stone-400 focus-visible:ring-0 sm:min-h-[148px] sm:rounded-[32px] sm:px-6 sm:pt-6 sm:pb-20 sm:leading-7"
             />
 
-            <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-white via-white/95 to-transparent px-4 pb-4 pt-6 sm:px-6">
-              <div className="flex items-end justify-between gap-3">
-                <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2 sm:gap-3">
-                  {mode === "edit" && (
-                    <Button
-                      type="button"
-                      variant="outline"
-                      className="h-9 rounded-full border-stone-200 bg-white px-3 text-xs font-medium text-stone-700 shadow-none sm:h-10 sm:px-4 sm:text-sm"
-                      onClick={onPickReferenceImage}
-                    >
-                      <ImagePlus className="size-3.5 sm:size-4" />
-                      <span className="hidden sm:inline">{referenceImages.length > 0 ? "继续添加参考图" : "上传参考图"}</span>
-                      <span className="sm:hidden">{referenceImages.length > 0 ? "继续" : "上传"}</span>
-                    </Button>
-                  )}
-                  <div className="rounded-full bg-stone-100 px-2 py-1 text-[10px] font-medium text-stone-600 sm:px-3 sm:py-2 sm:text-xs">
+            <div className="border-t border-stone-100 bg-white px-3 pb-3 pt-2 sm:absolute sm:inset-x-0 sm:bottom-0 sm:border-t-0 sm:bg-gradient-to-t sm:from-white sm:via-white/95 sm:to-transparent sm:px-6 sm:pb-4 sm:pt-6">
+              <div className="flex items-end justify-between gap-2 sm:gap-3">
+                <div className="hide-scrollbar flex min-w-0 flex-1 flex-nowrap items-center gap-1.5 overflow-x-auto pb-0.5 sm:flex-wrap sm:gap-3 sm:overflow-visible sm:pb-0">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="h-9 shrink-0 rounded-full border-stone-200 bg-white px-3 text-xs font-medium text-stone-700 shadow-none sm:h-10 sm:px-4 sm:text-sm"
+                    onClick={onPickReferenceImage}
+                  >
+                    <ImagePlus className="size-3.5 sm:size-4" />
+                    <span>{referenceImages.length > 0 ? "添加参考图" : "上传"}</span>
+                  </Button>
+                  <div className="shrink-0 rounded-full bg-stone-100 px-2 py-1 text-[10px] font-medium text-stone-600 sm:px-3 sm:py-2 sm:text-xs">
                     <span className="hidden xs:inline">剩余额度 </span>{availableQuota}
                   </div>
                   {activeTaskCount > 0 && (
-                    <div className="flex items-center gap-1 rounded-full bg-amber-50 px-2 py-1 text-[10px] font-medium text-amber-700 sm:gap-1.5 sm:px-3 sm:py-2 sm:text-xs">
+                    <div className="flex shrink-0 items-center gap-1 rounded-full bg-amber-50 px-2 py-1 text-[10px] font-medium text-amber-700 sm:gap-1.5 sm:px-3 sm:py-2 sm:text-xs">
                       <LoaderCircle className="size-3 animate-spin" />
                       {activeTaskCount}<span className="hidden sm:inline"> 个任务处理中</span>
                     </div>
                   )}
-                  <div className="flex items-center gap-1.5 rounded-full border border-stone-200 bg-white px-2 py-0.5 sm:gap-2 sm:px-3 sm:py-1">
+                  <div className="flex h-9 shrink-0 items-center gap-1.5 rounded-full border border-stone-200 bg-white px-2 py-0.5 sm:h-auto sm:gap-2 sm:px-3 sm:py-1">
                     <span className="text-[11px] font-medium text-stone-700 sm:text-sm">张数</span>
                     <Input
                       type="number"
+                      inputMode="numeric"
                       min="1"
                       max="10"
                       step="1"
@@ -211,19 +204,19 @@ export function ImageComposer({
                   </div>
                   <div
                     ref={sizeMenuRef}
-                    className="relative flex items-center gap-1.5 rounded-full border border-stone-200 bg-white px-2 py-0.5 text-[11px] sm:gap-2 sm:px-3 sm:py-1 sm:text-[13px]"
+                    className="relative flex h-9 shrink-0 items-center gap-1.5 rounded-full border border-stone-200 bg-white px-2 py-0.5 text-[11px] sm:h-auto sm:gap-2 sm:px-3 sm:py-1 sm:text-[13px]"
                   >
                     <span className="font-medium text-stone-700 sm:text-sm">比例</span>
                     <button
                       type="button"
-                      className="flex h-7 w-[110px] items-center justify-between bg-transparent text-left text-xs font-bold text-stone-700 sm:h-8 sm:w-[132px]"
+                      className="flex h-7 w-[78px] items-center justify-between bg-transparent text-left text-xs font-bold text-stone-700 min-[390px]:w-[96px] sm:h-8 sm:w-[132px]"
                       onClick={() => setIsSizeMenuOpen((open) => !open)}
                     >
                       <span className="truncate">{imageSizeLabel}</span>
                       <ChevronDown className={cn("size-4 shrink-0 opacity-60 transition", isSizeMenuOpen && "rotate-180")} />
                     </button>
                     {isSizeMenuOpen ? (
-                      <div className="absolute bottom-[calc(100%+10px)] left-0 z-50 w-[170px] overflow-hidden rounded-3xl border border-white/80 bg-white p-2 shadow-[0_24px_80px_-32px_rgba(15,23,42,0.35)] sm:w-[186px]">
+                      <div className="fixed inset-x-4 bottom-[calc(env(safe-area-inset-bottom)+5.75rem)] z-[80] max-h-[45dvh] overflow-y-auto rounded-3xl border border-white/80 bg-white p-2 shadow-[0_24px_80px_-32px_rgba(15,23,42,0.35)] sm:absolute sm:inset-x-auto sm:bottom-[calc(100%+10px)] sm:left-0 sm:w-[186px]">
                         {imageSizeOptions.map((option) => {
                           const active = option.value === imageSize;
                           return (
@@ -248,22 +241,14 @@ export function ImageComposer({
                     ) : null}
                   </div>
 
-                  <div className="flex items-center gap-1.5 sm:gap-2">
-                    <ModeButton active={mode === "generate"} onClick={() => onModeChange("generate")}>
-                      文生图
-                    </ModeButton>
-                    <ModeButton active={mode === "edit"} onClick={() => onModeChange("edit")}>
-                      图生图
-                    </ModeButton>
-                  </div>
                 </div>
 
                 <button
                   type="button"
                   onClick={() => void onSubmit()}
-                  disabled={!prompt.trim() || (mode === "edit" && referenceImages.length === 0)}
-                  className="inline-flex size-9 shrink-0 items-center justify-center rounded-full bg-stone-950 text-white transition hover:bg-stone-800 disabled:cursor-not-allowed disabled:bg-stone-300 sm:size-11"
-                  aria-label={mode === "edit" ? "编辑图片" : "生成图片"}
+                  disabled={!prompt.trim()}
+                  className="inline-flex size-10 shrink-0 items-center justify-center rounded-full bg-stone-950 text-white transition hover:bg-stone-800 disabled:cursor-not-allowed disabled:bg-stone-300 sm:size-11"
+                  aria-label={referenceImages.length > 0 ? "编辑图片" : "生成图片"}
                 >
                   <ArrowUp className="size-3.5 sm:size-4" />
                 </button>
@@ -276,25 +261,3 @@ export function ImageComposer({
   );
 }
 
-function ModeButton({
-  active,
-  children,
-  onClick,
-}: {
-  active: boolean;
-  children: string;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={cn(
-        "rounded-full px-2.5 py-1.5 text-xs font-medium transition sm:px-4 sm:py-2 sm:text-sm",
-        active ? "bg-stone-950 text-white" : "bg-stone-100 text-stone-600 hover:bg-stone-200",
-      )}
-    >
-      {children}
-    </button>
-  );
-}

--- a/web/src/app/image/components/image-results.tsx
+++ b/web/src/app/image/components/image-results.tsx
@@ -41,10 +41,10 @@ export function ImageResults({
 
   if (!selectedConversation) {
     return (
-      <div className="flex h-full min-h-[420px] items-center justify-center text-center">
+      <div className="flex h-full min-h-[260px] items-center justify-center text-center sm:min-h-[420px]">
         <div className="w-full max-w-4xl">
           <h1
-            className="text-3xl font-semibold tracking-tight text-stone-950 md:text-5xl"
+            className="text-2xl font-semibold tracking-tight text-stone-950 sm:text-3xl md:text-5xl"
             style={{
               fontFamily: '"Palatino Linotype","Book Antiqua","URW Palladio L","Times New Roman",serif',
             }}
@@ -52,7 +52,7 @@ export function ImageResults({
             Turn ideas into images
           </h1>
           <p
-            className="mt-4 text-[15px] italic tracking-[0.01em] text-stone-500"
+            className="mx-auto mt-3 max-w-[280px] text-sm italic tracking-[0.01em] text-stone-500 sm:mt-4 sm:max-w-none sm:text-[15px]"
             style={{
               fontFamily: '"Palatino Linotype","Book Antiqua","URW Palladio L","Times New Roman",serif',
             }}
@@ -65,7 +65,7 @@ export function ImageResults({
   }
 
   return (
-    <div className="mx-auto flex w-full max-w-[980px] flex-col gap-8">
+    <div className="mx-auto flex w-full max-w-[980px] flex-col gap-5 sm:gap-8">
       {selectedConversation.turns.map((turn, turnIndex) => {
         const referenceLightboxImages = turn.referenceImages.map((image, index) => ({
           id: `${turn.id}-reference-${index}`,
@@ -85,10 +85,10 @@ export function ImageResults({
         );
 
         return (
-          <div key={turn.id} className="flex flex-col gap-4">
+          <div key={turn.id} className="flex flex-col gap-3 sm:gap-4">
             <div className="flex justify-end">
-              <div className="max-w-[82%] px-1 py-1 text-[15px] leading-7 text-stone-900">
-                <div className="mb-2 flex flex-wrap justify-end gap-2 text-[11px] text-stone-400">
+              <div className="max-w-[90%] px-1 py-1 text-[14px] leading-6 text-stone-900 sm:max-w-[82%] sm:text-[15px] sm:leading-7">
+                <div className="mb-1.5 flex flex-wrap justify-end gap-2 text-[11px] text-stone-400 sm:mb-2">
                   <span>第 {turnIndex + 1} 轮</span>
                   <span>
                     {turn.mode === "edit" ? "编辑图" : "文生图"}
@@ -135,7 +135,7 @@ export function ImageResults({
                   </div>
                 ) : null}
 
-                <div className="mb-4 flex flex-wrap items-center gap-2 text-xs text-stone-500">
+                <div className="mb-3 flex flex-wrap items-center gap-1.5 text-[11px] text-stone-500 sm:mb-4 sm:gap-2 sm:text-xs">
                   <span className="rounded-full bg-stone-100 px-3 py-1">{turn.count} 张</span>
                   <span className="rounded-full bg-stone-100 px-3 py-1">{getTurnStatusLabel(turn.status)}</span>
                   {turn.status === "queued" ? (
@@ -143,7 +143,7 @@ export function ImageResults({
                   ) : null}
                 </div>
 
-                <div className="columns-1 gap-4 space-y-4 sm:columns-2 xl:columns-3">
+                <div className="columns-1 gap-3 space-y-3 sm:columns-2 sm:gap-4 sm:space-y-4 xl:columns-3">
                   {turn.images.map((image, index) => {
                     if (image.status === "success" && image.b64_json) {
                       const currentIndex = successfulTurnImages.findIndex((item) => item.id === image.id);
@@ -198,16 +198,16 @@ export function ImageResults({
                         <div
                           key={image.id}
                           className={cn(
-                            "break-inside-avoid overflow-hidden border border-rose-200 bg-rose-50",
-                            turn.size === "1:1" && "aspect-square",
-                            turn.size === "16:9" && "aspect-video",
-                            turn.size === "9:16" && "aspect-[9/16]",
-                            turn.size === "4:3" && "aspect-[4/3]",
-                            turn.size === "3:4" && "aspect-[3/4]",
-                            !["1:1", "16:9", "9:16", "4:3", "3:4"].includes(turn.size) && "aspect-square",
+                            "break-inside-avoid overflow-hidden rounded-2xl border border-rose-200 bg-rose-50 sm:rounded-none",
+                            turn.size === "1:1" && "sm:aspect-square",
+                            turn.size === "16:9" && "sm:aspect-video",
+                            turn.size === "9:16" && "sm:aspect-[9/16]",
+                            turn.size === "4:3" && "sm:aspect-[4/3]",
+                            turn.size === "3:4" && "sm:aspect-[3/4]",
+                            !["1:1", "16:9", "9:16", "4:3", "3:4"].includes(turn.size) && "sm:aspect-square",
                           )}
                         >
-                          <div className="flex h-full items-center justify-center px-6 py-8 text-center text-sm leading-6 text-rose-600">
+                          <div className="flex h-full min-h-16 items-center justify-center px-4 py-4 text-center text-sm leading-6 text-rose-600 sm:px-6 sm:py-8">
                             {image.error || "生成失败"}
                           </div>
                         </div>

--- a/web/src/app/image/components/image-sidebar.tsx
+++ b/web/src/app/image/components/image-sidebar.tsx
@@ -49,7 +49,12 @@ export function ImageSidebar({
           </div>
         )}
 
-        <div className="min-h-0 flex-1 space-y-2 overflow-y-auto pr-1 [scrollbar-color:rgba(120,113,108,.45)_transparent] [scrollbar-width:thin] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-stone-400/45 [&::-webkit-scrollbar-track]:bg-transparent">
+        <div
+          className={cn(
+            "min-h-0 flex-1 overflow-y-auto [scrollbar-color:rgba(120,113,108,.45)_transparent] [scrollbar-width:thin] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-stone-400/45 [&::-webkit-scrollbar-track]:bg-transparent",
+            hideActionButtons ? "space-y-1 pr-0" : "space-y-2 pr-1",
+          )}
+        >
           {isLoadingHistory ? (
             <div className="flex items-center gap-2 px-2 py-3 text-sm text-stone-500">
               <LoaderCircle className="size-4 animate-spin" />
@@ -62,21 +67,22 @@ export function ImageSidebar({
               const active = conversation.id === selectedConversationId;
               const stats = getImageConversationStats(conversation);
               return (
-                  <div
-                    key={conversation.id}
-                    className={cn(
-                      "group relative w-full border-l-2 px-3 py-2 text-left transition sm:py-3",
+                <div
+                  key={conversation.id}
+                  className={cn(
+                    "group relative w-full border-l-2 text-left transition",
+                    hideActionButtons ? "px-4 py-3.5" : "px-3 py-2 sm:py-3",
                     active
-                      ? "border-stone-900 bg-black/[0.03] text-stone-950"
+                      ? "border-stone-900 bg-black/[0.035] text-stone-950"
                       : "border-transparent text-stone-700 hover:border-stone-300 hover:bg-white/40",
                   )}
                 >
                   <button
                     type="button"
                     onClick={() => onSelectConversation(conversation.id)}
-                    className="block w-full pr-8 text-left"
+                    className={cn("block w-full text-left", hideActionButtons ? "pr-0" : "pr-8")}
                   >
-                    <div className="truncate text-sm font-semibold">
+                    <div className={cn("truncate font-semibold", hideActionButtons ? "text-base" : "text-sm")}>
                       <span className="truncate">{conversation.title}</span>
                     </div>
                     <div className={cn("mt-1 text-xs", active ? "text-stone-500" : "text-stone-400")}>
@@ -93,14 +99,16 @@ export function ImageSidebar({
                       </div>
                     ) : null}
                   </button>
-                  <button
-                    type="button"
-                    onClick={() => void onDeleteConversation(conversation.id)}
-                    className="absolute top-3 right-2 inline-flex size-7 items-center justify-center rounded-md text-stone-400 opacity-0 transition hover:bg-stone-100 hover:text-rose-500 group-hover:opacity-100"
-                    aria-label="删除会话"
-                  >
-                    <Trash2 className="size-4" />
-                  </button>
+                  {!hideActionButtons ? (
+                    <button
+                      type="button"
+                      onClick={() => void onDeleteConversation(conversation.id)}
+                      className="absolute top-3 right-2 inline-flex size-7 items-center justify-center rounded-md text-stone-400 opacity-0 transition hover:bg-stone-100 hover:text-rose-500 group-hover:opacity-100"
+                      aria-label="删除会话"
+                    >
+                      <Trash2 className="size-4" />
+                    </button>
+                  ) : null}
                 </div>
               );
             })

--- a/web/src/app/image/page.tsx
+++ b/web/src/app/image/page.tsx
@@ -183,7 +183,6 @@ function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
 
   const [imagePrompt, setImagePrompt] = useState("");
   const [imageCount, setImageCount] = useState("1");
-  const [imageMode, setImageMode] = useState<ImageConversationMode>("generate");
   const [imageSize, setImageSize] = useState("");
   const [isHistoryOpen, setIsHistoryOpen] = useState(false);
   const [referenceImageFiles, setReferenceImageFiles] = useState<File[]>([]);
@@ -374,7 +373,6 @@ function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
   }, []);
 
   const resetComposer = useCallback(() => {
-    setImageMode("generate");
     clearComposerInputs();
   }, [clearComposerInputs]);
 
@@ -457,7 +455,6 @@ function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
 
       setReferenceImageFiles((prev) => [...prev, ...files]);
       setReferenceImages((prev) => [...prev, ...previews]);
-      setImageMode("edit");
       if (fileInputRef.current) {
         fileInputRef.current.value = "";
       }
@@ -500,7 +497,6 @@ function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
       }
 
       setSelectedConversationId(conversationId);
-      setImageMode("edit");
       setReferenceImages((prev) => [...prev, nextReferenceImage]);
       setReferenceImageFiles((prev) => [
         ...prev,
@@ -740,10 +736,7 @@ function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
       return;
     }
 
-    if (imageMode === "edit" && referenceImageFiles.length === 0) {
-      toast.error("请先上传参考图");
-      return;
-    }
+    const effectiveImageMode: ImageConversationMode = referenceImageFiles.length > 0 ? "edit" : "generate";
 
     const targetConversation = selectedConversationId
       ? conversationsRef.current.find((conversation) => conversation.id === selectedConversationId) ?? null
@@ -755,8 +748,8 @@ function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
       id: turnId,
       prompt,
       model: "gpt-image-2",
-      mode: imageMode,
-      referenceImages: imageMode === "edit" ? referenceImages : [],
+      mode: effectiveImageMode,
+      referenceImages: effectiveImageMode === "edit" ? referenceImages : [],
       count: parsedCount,
       size: imageSize,
       images: Array.from({ length: parsedCount }, (_, index) => ({
@@ -799,7 +792,7 @@ function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
 
   return (
     <>
-      <section className="mx-auto grid h-[calc(100vh-5rem)] min-h-0 w-full max-w-[1380px] grid-cols-1 gap-3 px-3 pb-6 lg:grid-cols-[240px_minmax(0,1fr)]">
+      <section className="mx-auto grid h-[calc(100dvh-6.25rem)] min-h-0 w-full max-w-[1380px] grid-cols-1 gap-2 px-0 pb-[calc(env(safe-area-inset-bottom)+0.5rem)] sm:h-[calc(100dvh-5rem)] sm:gap-3 sm:px-3 sm:pb-6 lg:grid-cols-[240px_minmax(0,1fr)]">
         <div className="hidden h-full min-h-0 border-r border-stone-200/70 pr-3 lg:block">
           <ImageSidebar
             conversations={conversations}
@@ -814,14 +807,14 @@ function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
         </div>
 
         <Dialog open={isHistoryOpen} onOpenChange={setIsHistoryOpen}>
-          <DialogContent className="flex h-[80vh] w-[92vw] max-w-[420px] flex-col overflow-hidden rounded-[32px] border-stone-200 bg-white p-0 shadow-2xl">
-            <DialogHeader className="px-6 pt-6 pb-2">
-              <DialogTitle className="flex items-center gap-2 text-lg font-bold">
+          <DialogContent className="flex h-[min(82dvh,760px)] w-[92vw] max-w-[460px] flex-col overflow-hidden rounded-[32px] border-white/80 bg-white p-0 shadow-[0_32px_110px_-38px_rgba(15,23,42,0.45)] sm:rounded-[36px]">
+            <DialogHeader className="px-6 pt-7 pb-4 sm:px-8">
+              <DialogTitle className="flex items-center gap-2 text-xl font-bold tracking-tight">
                 <History className="size-5" />
                 历史记录
               </DialogTitle>
             </DialogHeader>
-            <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-8">
+            <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-8 sm:px-8">
               <ImageSidebar
                 conversations={conversations}
                 isLoadingHistory={isLoadingHistory}
@@ -843,11 +836,11 @@ function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
           </DialogContent>
         </Dialog>
 
-        <div className="flex min-h-0 flex-col gap-3 sm:gap-4">
-          <div className="flex items-center justify-between gap-3 lg:hidden">
+        <div className="flex min-h-0 flex-col gap-2 sm:gap-4">
+          <div className="flex items-center justify-between gap-2 px-1 lg:hidden">
             <Button
               variant="outline"
-              className="h-10 flex-1 rounded-2xl border-stone-200 bg-white/85 text-stone-700 shadow-sm"
+              className="h-10 flex-1 rounded-2xl border-stone-200 bg-white/90 text-stone-700 shadow-sm"
               onClick={() => setIsHistoryOpen(true)}
             >
               <History className="mr-2 size-4" />
@@ -872,7 +865,7 @@ function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
 
           <div
             ref={resultsViewportRef}
-            className="hide-scrollbar min-h-0 flex-1 overflow-y-auto px-2 py-3 sm:px-4 sm:py-4"
+            className="hide-scrollbar min-h-0 flex-1 overflow-y-auto px-1 py-2 sm:px-4 sm:py-4"
           >
             <ImageResults
               selectedConversation={selectedConversation}
@@ -883,7 +876,6 @@ function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
           </div>
 
           <ImageComposer
-            mode={imageMode}
             prompt={imagePrompt}
             imageCount={imageCount}
             imageSize={imageSize}
@@ -892,7 +884,6 @@ function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
             referenceImages={referenceImages}
             textareaRef={textareaRef}
             fileInputRef={fileInputRef}
-            onModeChange={setImageMode}
             onPromptChange={setImagePrompt}
             onImageCountChange={setImageCount}
             onImageSizeChange={setImageSize}

--- a/web/src/components/top-nav.tsx
+++ b/web/src/components/top-nav.tsx
@@ -64,11 +64,11 @@ export function TopNav() {
 
   return (
     <header className="border-b border-stone-100/50">
-      <div className="flex h-12 items-center justify-between px-3 sm:px-6">
-        <div className="flex items-center gap-2 sm:gap-3">
+      <div className="flex min-h-12 flex-col gap-1 px-3 py-2 sm:h-12 sm:flex-row sm:items-center sm:justify-between sm:gap-3 sm:px-6 sm:py-0">
+        <div className="flex items-center justify-between gap-2 sm:justify-start sm:gap-3">
           <Link
             href="/image"
-            className="py-1 text-[14px] font-bold tracking-tight text-stone-950 transition hover:text-stone-700 sm:text-[15px]"
+            className="shrink-0 py-1 text-[15px] font-bold tracking-tight text-stone-950 transition hover:text-stone-700"
           >
             chatgpt2api
           </Link>
@@ -82,8 +82,15 @@ export function TopNav() {
             <Github className="size-4" />
             <span className="hidden md:inline">GitHub</span>
           </a>
+          <button
+            type="button"
+            className="ml-auto shrink-0 py-1 text-xs text-stone-400 transition hover:text-stone-700 sm:hidden"
+            onClick={() => void handleLogout()}
+          >
+            退出
+          </button>
         </div>
-        <div className="flex flex-1 justify-center gap-3 sm:gap-8">
+        <nav className="hide-scrollbar -mx-1 flex min-w-0 flex-1 gap-1 overflow-x-auto px-1 sm:mx-0 sm:justify-center sm:gap-8 sm:overflow-visible sm:px-0">
           {navItems.map((item) => {
             const active = pathname === item.href;
             return (
@@ -91,17 +98,19 @@ export function TopNav() {
                 key={item.href}
                 href={item.href}
                 className={cn(
-                  "relative py-1 text-[13px] font-medium transition sm:text-[15px]",
-                  active ? "font-semibold text-stone-950" : "text-stone-500 hover:text-stone-900",
+                  "relative shrink-0 whitespace-nowrap rounded-full px-2.5 py-1 text-[13px] font-medium transition sm:rounded-none sm:px-0 sm:text-[15px]",
+                  active
+                    ? "bg-stone-950 text-white sm:bg-transparent sm:font-semibold sm:text-stone-950"
+                    : "text-stone-500 hover:text-stone-900",
                 )}
               >
                 {item.label}
-                {active ? <span className="absolute inset-x-0 -bottom-[1px] h-0.5 bg-stone-950" /> : null}
+                {active ? <span className="absolute inset-x-0 -bottom-[1px] hidden h-0.5 bg-stone-950 sm:block" /> : null}
               </Link>
             );
           })}
-        </div>
-        <div className="flex items-center justify-end gap-2 sm:gap-3">
+        </nav>
+        <div className="hidden items-center justify-end gap-2 sm:flex sm:gap-3">
           <span className="hidden rounded-md bg-stone-100 px-2 py-1 text-[10px] font-medium text-stone-500 sm:inline-block sm:text-[11px]">
             {roleLabel}
           </span>


### PR DESCRIPTION
改动概要：
优化移动端顶部导航：改为两行布局，导航项横向滑动，避免挤压换行。
优化画图页移动端布局：使用 100dvh 和安全区，减少底部输入区占屏。
优化底部输入栏：上传按钮常驻，去掉“文生图/图生图”切换和无用模式标签。
自动判断生成模式：无参考图走文生图，有参考图走图生图/编辑图，不改变原有历史数据结构。
优化参考图预览：移动端参考图横向滚动，尺寸更紧凑。
优化历史记录弹窗：移动端弹窗更接近全屏卡片，选中项左侧高亮。
优化结果区移动端间距与失败态：失败结果不再占巨大方块。
修复比例下拉菜单：移动端改为固定浮层，避免被底部横向工具栏裁剪。