### PR TITLE
修复缺少真实Chatgpt ID，自动将注册的账号上传到CPA / Sub2API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,10 @@
 services:
   app:
-    build:
-      context: .
-    image: chatgpt2api-local:auto-sync
+    image: ghcr.io/basketikun/chatgpt2api:latest
     container_name: chatgpt2api
     restart: unless-stopped
     ports:
-      - "3080:80"
+      - "3000:80"
     volumes:
       - ./data:/app/data
       - ./config.json:/app/config.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,12 @@
 services:
   app:
-    image: ghcr.io/basketikun/chatgpt2api:latest
+    build:
+      context: .
+    image: chatgpt2api-local:auto-sync
     container_name: chatgpt2api
     restart: unless-stopped
     ports:
-      - "3000:80"
+      - "3080:80"
     volumes:
       - ./data:/app/data
       - ./config.json:/app/config.json

--- a/services/account_service.py
+++ b/services/account_service.py
@@ -434,6 +434,33 @@ class AccountService:
             return dict(account)
         return None
 
+    @staticmethod
+    def _extract_chatgpt_account_info(payload: dict[str, Any]) -> dict[str, Any]:
+        accounts = payload.get("accounts") if isinstance(payload, dict) else None
+        default_entry = payload.get("default") if isinstance(payload, dict) else None
+        account_id = ""
+        account_user_id = ""
+        plan_type = ""
+        if isinstance(default_entry, dict):
+            account = default_entry.get("account") if isinstance(default_entry.get("account"), dict) else {}
+            account_id = str(account.get("account_id") or "").strip()
+            account_user_id = str(account.get("account_user_id") or "").strip()
+            plan_type = str(account.get("plan_type") or "").strip()
+        if not account_id and isinstance(accounts, dict):
+            for key, entry in accounts.items():
+                if isinstance(entry, dict):
+                    account = entry.get("account") if isinstance(entry.get("account"), dict) else {}
+                    account_id = str(account.get("account_id") or key or "").strip()
+                    account_user_id = str(account.get("account_user_id") or "").strip()
+                    plan_type = str(account.get("plan_type") or "").strip()
+                    if account_id:
+                        break
+        return {
+            "chatgpt_account_id": account_id,
+            "chatgpt_account_user_id": account_user_id,
+            "chatgpt_plan_type": plan_type,
+        }
+
     def fetch_remote_info(self, access_token: str) -> dict[str, Any]:
         access_token = self._clean_token(access_token)
         if not access_token:
@@ -445,7 +472,7 @@ class AccountService:
         session = Session(**proxy_settings.build_session_kwargs(impersonate=impersonate, verify=True))
         session.headers.update(headers)
         try:
-            with ThreadPoolExecutor(max_workers=2) as executor:
+            with ThreadPoolExecutor(max_workers=3) as executor:
                 me_future = executor.submit(
                     session.get,
                     "https://chatgpt.com/backend-api/me",
@@ -466,9 +493,19 @@ class AccountService:
                     },
                     timeout=20,
                 )
+                account_future = executor.submit(
+                    session.get,
+                    "https://chatgpt.com/backend-api/accounts/check/v4-2023-04-27",
+                    headers={
+                        "x-openai-target-path": "/backend-api/accounts/check/v4-2023-04-27",
+                        "x-openai-target-route": "/backend-api/accounts/check/v4-2023-04-27",
+                    },
+                    timeout=20,
+                )
 
                 me_response = me_future.result()
                 init_response = init_future.result()
+                account_response = account_future.result()
 
             if me_response.status_code != 200:
                 raise RuntimeError(f"/backend-api/me failed: HTTP {me_response.status_code}")
@@ -478,6 +515,15 @@ class AccountService:
                 raise RuntimeError(f"/backend-api/conversation/init failed: HTTP {init_response.status_code}")
             init_payload = init_response.json()
 
+            account_payload: dict[str, Any] = {}
+            if account_response.status_code == 200:
+                try:
+                    raw_account_payload = account_response.json()
+                    if isinstance(raw_account_payload, dict):
+                        account_payload = raw_account_payload
+                except Exception:
+                    account_payload = {}
+
             limits_progress = init_payload.get("limits_progress")
             if not isinstance(limits_progress, list):
                 limits_progress = []
@@ -486,9 +532,13 @@ class AccountService:
             quota, restore_at, image_quota_unknown = self._extract_quota_and_restore_at(limits_progress)
             status = "正常" if image_quota_unknown and account_type != "Free" else ("限流" if quota == 0 else "正常")
 
+            account_info = self._extract_chatgpt_account_info(account_payload)
             result = {
                 "email": me_payload.get("email"),
                 "user_id": me_payload.get("id"),
+                "chatgpt_account_id": account_info.get("chatgpt_account_id"),
+                "chatgpt_account_user_id": account_info.get("chatgpt_account_user_id"),
+                "chatgpt_plan_type": account_info.get("chatgpt_plan_type"),
                 "type": account_type,
                 "quota": quota,
                 "image_quota_unknown": image_quota_unknown,

--- a/services/config.py
+++ b/services/config.py
@@ -29,6 +29,13 @@ def _is_invalid_auth_key(value: object) -> bool:
     return _normalize_auth_key(value) == ""
 
 
+def _bool_from_config(data: dict[str, object], key: str, default: bool = False) -> bool:
+    value = data.get(key, default)
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
 def _read_json_object(path: Path, *, name: str) -> dict[str, object]:
     if not path.exists():
         return {}
@@ -112,17 +119,19 @@ class ConfigStore:
 
     @property
     def auto_remove_invalid_accounts(self) -> bool:
-        value = self.data.get("auto_remove_invalid_accounts", False)
-        if isinstance(value, str):
-            return value.strip().lower() in {"1", "true", "yes", "on"}
-        return bool(value)
+        return _bool_from_config(self.data, "auto_remove_invalid_accounts", False)
 
     @property
     def auto_remove_rate_limited_accounts(self) -> bool:
-        value = self.data.get("auto_remove_rate_limited_accounts", False)
-        if isinstance(value, str):
-            return value.strip().lower() in {"1", "true", "yes", "on"}
-        return bool(value)
+        return _bool_from_config(self.data, "auto_remove_rate_limited_accounts", False)
+
+    @property
+    def auto_sync_cpa(self) -> bool:
+        return _bool_from_config(self.data, "auto_sync_cpa", True)
+
+    @property
+    def auto_sync_sub2api(self) -> bool:
+        return _bool_from_config(self.data, "auto_sync_sub2api", True)
 
     @property
     def log_levels(self) -> list[str]:
@@ -174,6 +183,8 @@ class ConfigStore:
         data["image_retention_days"] = self.image_retention_days
         data["auto_remove_invalid_accounts"] = self.auto_remove_invalid_accounts
         data["auto_remove_rate_limited_accounts"] = self.auto_remove_rate_limited_accounts
+        data["auto_sync_cpa"] = self.auto_sync_cpa
+        data["auto_sync_sub2api"] = self.auto_sync_sub2api
         data["log_levels"] = self.log_levels
         data.pop("auth-key", None)
         return data

--- a/services/cpa_service.py
+++ b/services/cpa_service.py
@@ -2,22 +2,30 @@
 
 from __future__ import annotations
 
+import base64
 import json
+import re
 import threading
+import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
 from threading import Lock
+from typing import Any
 
+from curl_cffi import CurlMime
 from curl_cffi.requests import Session
 
 from services.account_service import account_service
 from services.config import DATA_DIR
+from services.log_service import LOG_TYPE_ACCOUNT, log_service
 from services.proxy_service import proxy_settings
 
 
 CPA_CONFIG_FILE = DATA_DIR / "cpa_config.json"
+CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+
 
 
 def _new_id() -> str:
@@ -207,6 +215,326 @@ def fetch_remote_access_token(pool: dict, file_name: str) -> tuple[str | None, s
     if not access_token:
         return None, "missing access_token"
     return access_token, None
+
+
+def _list_sync_pools() -> list[dict]:
+    seen: set[tuple[str, str]] = set()
+    pools: list[dict] = []
+    for pool in cpa_config.list_pools():
+        base_url = str(pool.get("base_url") or "").strip().rstrip("/")
+        secret_key = str(pool.get("secret_key") or "").strip()
+        if not base_url or not secret_key:
+            continue
+        key = (base_url, secret_key)
+        if key in seen:
+            continue
+        seen.add(key)
+        pools.append(pool)
+    return pools
+
+
+def _decode_jwt_payload(token: str) -> dict[str, Any]:
+    token = str(token or "").strip()
+    if not token:
+        return {}
+    parts = token.split(".")
+    if len(parts) < 2:
+        return {}
+    payload = parts[1]
+    payload += "=" * (-len(payload) % 4)
+    try:
+        return json.loads(__import__('base64').urlsafe_b64decode(payload.encode("utf-8")).decode("utf-8"))
+    except Exception:
+        return {}
+
+
+def _token_expired_at(*tokens: str) -> str | None:
+    for token in tokens:
+        payload = _decode_jwt_payload(token)
+        try:
+            exp = int(payload.get("exp") or 0)
+        except Exception:
+            exp = 0
+        if exp > 0:
+            return datetime.fromtimestamp(exp, timezone.utc).isoformat()
+    return None
+
+
+def _safe_filename_fragment(value: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9._-]+", "_", str(value or "").strip())
+    safe = safe.strip("._-")
+    return safe or uuid.uuid4().hex
+
+
+def _first_text(*values: object) -> str:
+    for value in values:
+        text = str(value or "").strip()
+        if text:
+            return text
+    return ""
+
+
+def _b64url_json(payload: dict) -> str:
+    return base64.urlsafe_b64encode(json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")).rstrip(b"=").decode("ascii")
+
+
+def _inject_codex_identity_into_id_token(id_token: str, *, email: str, chatgpt_account_id: str, chatgpt_user_id: str, plan_type: str = "") -> str:
+    id_token = str(id_token or "").strip()
+    chatgpt_account_id = str(chatgpt_account_id or "").strip()
+    if not id_token or not chatgpt_account_id:
+        return id_token
+    try:
+        parts = id_token.split(".")
+        if len(parts) != 3:
+            return id_token
+        header_segment, payload_segment, signature_segment = parts
+        payload_segment += "=" * (-len(payload_segment) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(payload_segment.encode("utf-8")).decode("utf-8"))
+        if not isinstance(payload, dict):
+            return id_token
+        payload["aud"] = [CODEX_OAUTH_CLIENT_ID]
+        payload["azp"] = CODEX_OAUTH_CLIENT_ID
+        if email:
+            payload["email"] = email
+        auth_payload = payload.get("https://api.openai.com/auth")
+        if not isinstance(auth_payload, dict):
+            auth_payload = {}
+        auth_payload["chatgpt_account_id"] = chatgpt_account_id
+        if chatgpt_user_id:
+            auth_payload["chatgpt_user_id"] = chatgpt_user_id
+            auth_payload["user_id"] = chatgpt_user_id
+        if plan_type:
+            auth_payload["chatgpt_plan_type"] = str(plan_type).lower()
+        payload["https://api.openai.com/auth"] = auth_payload
+        return f"{header_segment}.{_b64url_json(payload)}.{signature_segment or 'sig'}"
+    except Exception:
+        return id_token
+
+def _claim_from_payload(payload: dict[str, Any], *names: str) -> str:
+    if not isinstance(payload, dict):
+        return ""
+    auth = payload.get("https://api.openai.com/auth")
+    profile = payload.get("https://api.openai.com/profile")
+    for scope in (auth, profile):
+        if isinstance(scope, dict):
+            for name in names:
+                value = _first_text(scope.get(name))
+                if value:
+                    return value
+    for name in names:
+        for key in (
+            name,
+            f"https://api.openai.com/auth.{name}",
+            f"https://api.openai.com/profile.{name}",
+        ):
+            value = _first_text(payload.get(key))
+            if value:
+                return value
+    return ""
+
+
+def _token_exp_epoch(*tokens: str) -> int | None:
+    for token in tokens:
+        payload = _decode_jwt_payload(token)
+        try:
+            exp = int(payload.get("exp") or 0)
+        except Exception:
+            exp = 0
+        if exp > 0:
+            return exp
+    return None
+
+
+def _is_chatgpt_account_id(value: str) -> bool:
+    value = str(value or "").strip()
+    return bool(re.fullmatch(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}", value))
+
+
+def _is_chatgpt_user_id(value: str) -> bool:
+    return str(value or "").strip().startswith("user-")
+
+
+def _extract_codex_identity(register_result: dict, local_account: dict | None = None) -> dict[str, str | int | None]:
+    local_account = local_account or {}
+    access_token = str(register_result.get("codex_access_token") or register_result.get("access_token") or "").strip()
+    id_token = str(register_result.get("codex_id_token") or register_result.get("id_token") or "").strip()
+    access_payload = _decode_jwt_payload(access_token)
+    id_payload = _decode_jwt_payload(id_token)
+
+    email = _first_text(
+        register_result.get("email"),
+        local_account.get("email"),
+        _claim_from_payload(id_payload, "email"),
+        _claim_from_payload(access_payload, "email"),
+    )
+    chatgpt_account_id = _first_text(
+        register_result.get("codex_chatgpt_account_id"),
+        register_result.get("chatgpt_account_id"),
+        local_account.get("chatgpt_account_id"),
+        _claim_from_payload(id_payload, "chatgpt_account_id"),
+        _claim_from_payload(access_payload, "chatgpt_account_id"),
+    )
+    existing_account_id = _first_text(register_result.get("account_id"), local_account.get("account_id"))
+    if not chatgpt_account_id and _is_chatgpt_account_id(existing_account_id):
+        chatgpt_account_id = existing_account_id
+
+    chatgpt_user_id = _first_text(
+        register_result.get("codex_chatgpt_user_id"),
+        register_result.get("chatgpt_user_id"),
+        local_account.get("chatgpt_user_id"),
+        local_account.get("user_id"),
+        _claim_from_payload(id_payload, "chatgpt_user_id", "user_id", "chatgpt_account_user_id"),
+        _claim_from_payload(access_payload, "chatgpt_user_id", "user_id", "chatgpt_account_user_id"),
+    )
+    if not chatgpt_user_id and _is_chatgpt_user_id(existing_account_id):
+        chatgpt_user_id = existing_account_id
+    client_id = _first_text(
+        register_result.get("codex_client_id"),
+        register_result.get("client_id"),
+        _claim_from_payload(access_payload, "client_id"),
+        _claim_from_payload(id_payload, "azp", "client_id"),
+        CODEX_OAUTH_CLIENT_ID,
+    )
+    return {
+        "email": email,
+        "chatgpt_account_id": chatgpt_account_id,
+        "chatgpt_user_id": chatgpt_user_id,
+        "account_id": chatgpt_account_id,
+        "client_id": client_id,
+        "expires_at": _token_exp_epoch(access_token, id_token),
+    }
+
+
+def _build_auth_file_payload(register_result: dict, local_account: dict | None = None) -> tuple[str, bytes, str]:
+    local_account = local_account or {}
+    access_token = str(register_result.get("codex_access_token") or register_result.get("access_token") or "").strip()
+    refresh_token = str(register_result.get("codex_refresh_token") or register_result.get("refresh_token") or "").strip()
+    id_token = str(register_result.get("codex_id_token") or register_result.get("id_token") or "").strip()
+    if not access_token:
+        raise ValueError("missing access_token")
+
+    identity = _extract_codex_identity(register_result, local_account=local_account)
+    email = str(identity.get("email") or "").strip()
+    account_id = str(identity.get("account_id") or "").strip()
+    chatgpt_account_id = str(identity.get("chatgpt_account_id") or "").strip()
+    chatgpt_user_id = str(identity.get("chatgpt_user_id") or "").strip()
+    client_id = CODEX_OAUTH_CLIENT_ID
+    id_token = _inject_codex_identity_into_id_token(
+        id_token,
+        email=email,
+        chatgpt_account_id=chatgpt_account_id,
+        chatgpt_user_id=chatgpt_user_id,
+        plan_type=str(local_account.get("chatgpt_plan_type") or local_account.get("type") or ""),
+    )
+    id_payload = _decode_jwt_payload(id_token)
+    id_claim_account_id = _claim_from_payload(id_payload, "chatgpt_account_id")
+    if not _is_chatgpt_account_id(id_claim_account_id):
+        raise ValueError("codex_id_token_missing_chatgpt_account_id")
+    if not _is_chatgpt_account_id(chatgpt_account_id):
+        chatgpt_account_id = id_claim_account_id
+        account_id = id_claim_account_id
+    expired = _token_expired_at(access_token, id_token) or _now_iso()
+    last_refresh = str(register_result.get("created_at") or _now_iso()).strip() or _now_iso()
+
+    credentials = {
+        "access_token": access_token,
+        "id_token": id_token,
+        "refresh_token": refresh_token,
+        "session_token": str(register_result.get("session_token") or ""),
+        "chatgpt_account_id": chatgpt_account_id,
+        "chatgpt_user_id": chatgpt_user_id,
+        "client_id": client_id,
+    }
+    credentials = {key: value for key, value in credentials.items() if value not in (None, "") or key == "session_token"}
+
+    payload = {
+        "access_token": access_token,
+        "account_id": account_id,
+        "chatgpt_account_id": chatgpt_account_id,
+        "chatgpt_user_id": chatgpt_user_id,
+        "credentials": credentials,
+        "disabled": False,
+        "email": email,
+        "expired": expired,
+        "id_token": id_token,
+        "last_refresh": last_refresh,
+        "refresh_token": refresh_token,
+        "session_token": str(register_result.get("session_token") or ""),
+        "type": "codex",
+    }
+    payload = {key: value for key, value in payload.items() if value not in (None, "") or key in {"disabled", "type", "session_token", "credentials"}}
+
+    seed = email or account_id or chatgpt_user_id or uuid.uuid4().hex
+    filename = f"codex-{_safe_filename_fragment(seed)}-{int(time.time() * 1000)}.json"
+    content = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    return filename, content, email
+
+
+def upload_auth_file(pool: dict, file_name: str, content: bytes) -> None:
+    base_url = str(pool.get("base_url") or "").strip()
+    secret_key = str(pool.get("secret_key") or "").strip()
+    if not base_url or not secret_key:
+        raise ValueError("invalid pool config")
+
+    url = f"{base_url.rstrip('/')}/v0/management/auth-files"
+    session = Session(**proxy_settings.build_session_kwargs(verify=True))
+    multipart = CurlMime()
+    multipart.addpart("files", filename=file_name, content_type="application/json", data=content)
+    try:
+        response = session.post(
+            url,
+            headers=_management_headers(secret_key),
+            multipart=multipart,
+            timeout=60,
+        )
+        if not response.ok:
+            raise RuntimeError(f"remote upload failed: HTTP {response.status_code} {response.text[:200]}")
+        try:
+            payload = response.json()
+        except Exception:
+            payload = {}
+        status = str(payload.get("status") or "ok").strip().lower() if isinstance(payload, dict) else "ok"
+        if status not in {"ok", "success"}:
+            raise RuntimeError(f"remote upload failed: {payload}")
+    finally:
+        multipart.close()
+        session.close()
+
+
+def sync_registered_account_to_pools(register_result: dict, local_account: dict | None = None) -> dict[str, Any]:
+    pools = _list_sync_pools()
+    summary: dict[str, Any] = {
+        "attempted": len(pools),
+        "succeeded": 0,
+        "failed": 0,
+        "filename": "",
+        "errors": [],
+    }
+    if not pools:
+        return summary
+
+    file_name, content, email = _build_auth_file_payload(register_result, local_account=local_account)
+    summary["filename"] = file_name
+    for pool in pools:
+        pool_name = str(pool.get("name") or pool.get("base_url") or pool.get("id") or "").strip()
+        try:
+            upload_auth_file(pool, file_name, content)
+            summary["succeeded"] += 1
+            log_service.add(
+                LOG_TYPE_ACCOUNT,
+                "CPA自动同步成功",
+                {"pool": pool_name, "filename": file_name, "email": email},
+            )
+        except Exception as exc:
+            summary["failed"] += 1
+            error_text = str(exc)
+            summary["errors"].append({"pool": pool_name, "error": error_text})
+            log_service.add(
+                LOG_TYPE_ACCOUNT,
+                "CPA自动同步失败",
+                {"pool": pool_name, "filename": file_name, "email": email, "error": error_text},
+            )
+    return summary
 
 
 class CPAImportService:

--- a/services/register/openai_register.py
+++ b/services/register/openai_register.py
@@ -19,6 +19,9 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 from services.account_service import account_service
+from services.config import config as app_config
+from services.cpa_service import sync_registered_account_to_pools
+from services.sub2api_service import sync_registered_account_to_sub2api
 from services.register import mail_provider
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -46,6 +49,10 @@ platform_base = "https://platform.openai.com"
 platform_oauth_client_id = "app_2SKx67EdpoN0G6j64rFvigXD"
 platform_oauth_redirect_uri = f"{platform_base}/auth/callback"
 platform_oauth_audience = "https://api.openai.com/v1"
+codex_oauth_client_id = "app_EMoamEEZ73f0CkXaXp7hrann"
+codex_oauth_redirect_uri = "http://localhost:1455/auth/callback"
+codex_oauth_scope = "openid email profile offline_access"
+codex_oauth_originator = "codex_cli_rs"
 platform_auth0_client = "eyJuYW1lIjoiYXV0aDAtc3BhLWpzIiwidmVyc2lvbiI6IjEuMjEuMCJ9"
 user_agent = (
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
@@ -324,7 +331,10 @@ def extract_oauth_callback_params_from_url(url: str) -> dict[str, str] | None:
     if not url:
         return None
     try:
-        params = parse_qs(urlparse(url).query)
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+        if "code" not in params and parsed.fragment:
+            params = parse_qs(parsed.fragment)
     except Exception:
         return None
     code = str((params.get("code") or [""])[0]).strip()
@@ -338,7 +348,16 @@ def extract_oauth_callback_params_from_consent_session(session: requests.Session
         consent_url = f"{auth_base}{consent_url}"
     current_url = consent_url
     for _ in range(10):
-        response = session.get(current_url, headers=navigate_headers, verify=False, timeout=30, allow_redirects=False)
+        callback_params = extract_oauth_callback_params_from_url(current_url)
+        if callback_params:
+            return callback_params
+        try:
+            parsed_current = urlparse(current_url)
+            if parsed_current.hostname in {"localhost", "127.0.0.1", "::1"}:
+                return None
+            response = session.get(current_url, headers=navigate_headers, verify=False, timeout=30, allow_redirects=False)
+        except Exception:
+            return None
         callback_params = extract_oauth_callback_params_from_url(str(response.url)) or extract_oauth_callback_params_from_url(str(response.headers.get("Location") or "").strip())
         if callback_params:
             return callback_params
@@ -385,37 +404,154 @@ def extract_oauth_callback_params_from_consent_session(session: requests.Session
     return extract_oauth_callback_params_from_url(str(org_resp.headers.get("Location") or "").strip())
 
 
-def exchange_platform_tokens(session: requests.Session, device_id: str, code_verifier: str, consent_url: str) -> dict | None:
-    callback_params = extract_oauth_callback_params_from_consent_session(session, consent_url, device_id)
+def exchange_oauth_tokens(
+    session: requests.Session,
+    device_id: str,
+    code_verifier: str,
+    consent_url: str,
+    *,
+    client_id: str,
+    redirect_uri: str,
+) -> tuple[dict | None, str]:
+    callback_params = extract_oauth_callback_params_from_url(consent_url) or extract_oauth_callback_params_from_consent_session(session, consent_url, device_id)
     if not callback_params:
-        return None
+        return None, "missing_callback_code"
     code = str(callback_params.get("code") or "").strip()
     if not code:
-        return None
-    resp = create_session(config["proxy"]).post(
-        f"{auth_base}/oauth/token",
-        headers={"Content-Type": "application/x-www-form-urlencoded"},
-        data={
-            "grant_type": "authorization_code",
-            "code": code,
-            "redirect_uri": platform_oauth_redirect_uri,
-            "client_id": platform_oauth_client_id,
-            "code_verifier": code_verifier,
-        },
-        verify=False,
-        timeout=60,
-    )
+        return None, "empty_callback_code"
+    try:
+        resp = create_session(config["proxy"]).post(
+            f"{auth_base}/oauth/token",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": redirect_uri,
+                "client_id": client_id,
+                "code_verifier": code_verifier,
+            },
+            verify=False,
+            timeout=60,
+        )
+    except Exception as exc:
+        return None, f"oauth_token_request_error:{exc}"
     data = _response_json(resp)
     if resp.status_code != 200 or not data.get("access_token") or not data.get("refresh_token") or not data.get("id_token"):
-        return None
+        err = data.get("error") if isinstance(data, dict) else None
+        if isinstance(err, dict):
+            msg = str(err.get("message") or err.get("code") or err.get("type") or "").strip()
+        else:
+            msg = str(err or data.get("error_description") or data.get("message") or "").strip() if isinstance(data, dict) else ""
+        return None, f"oauth_token_http_{getattr(resp, 'status_code', 'unknown')}{':' + msg[:160] if msg else ''}"
     payload = _decode_jwt_payload(str(data.get("id_token") or "")) or _decode_jwt_payload(str(data.get("access_token") or ""))
+    auth_payload = payload.get("https://api.openai.com/auth") if isinstance(payload.get("https://api.openai.com/auth"), dict) else {}
     return {
         "email": str(payload.get("email") or "").strip(),
         "access_token": str(data.get("access_token") or "").strip(),
         "refresh_token": str(data.get("refresh_token") or "").strip(),
         "id_token": str(data.get("id_token") or "").strip(),
-    }
+        "client_id": client_id,
+        "chatgpt_account_id": str(auth_payload.get("chatgpt_account_id") or "").strip(),
+        "chatgpt_user_id": str(auth_payload.get("chatgpt_user_id") or auth_payload.get("user_id") or "").strip(),
+    }, ""
 
+
+def _build_codex_authorize_url(email: str, code_challenge: str) -> str:
+    params = {
+        "client_id": codex_oauth_client_id,
+        "response_type": "code",
+        "redirect_uri": codex_oauth_redirect_uri,
+        "scope": codex_oauth_scope,
+        "state": secrets.token_urlsafe(32),
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+        "id_token_add_organizations": "true",
+        "codex_cli_simplified_flow": "true",
+        "prompt": "none",
+    }
+    login_hint = str(email or "").strip()
+    if login_hint:
+        params["login_hint"] = login_hint
+    return f"{auth_base}/oauth/authorize?{urlencode(params)}"
+
+
+def _build_platform_authorize_url(email: str, device_id: str, code_challenge: str) -> str:
+    params = {
+        "issuer": auth_base,
+        "client_id": platform_oauth_client_id,
+        "audience": platform_oauth_audience,
+        "redirect_uri": platform_oauth_redirect_uri,
+        "device_id": device_id,
+        "screen_hint": "login_or_signup",
+        "max_age": "0",
+        "login_hint": email,
+        "scope": "openid profile email offline_access",
+        "response_type": "code",
+        "response_mode": "query",
+        "state": secrets.token_urlsafe(32),
+        "nonce": secrets.token_urlsafe(32),
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+        "auth0Client": platform_auth0_client,
+    }
+    return f"{auth_base}/api/accounts/authorize?{urlencode(params)}"
+
+
+def _has_codex_chatgpt_account_id(tokens: dict | None) -> bool:
+    if not tokens:
+        return False
+    account_id = str(tokens.get("chatgpt_account_id") or "").strip()
+    if account_id:
+        return True
+    id_payload = _decode_jwt_payload(str(tokens.get("id_token") or ""))
+    auth_payload = id_payload.get("https://api.openai.com/auth") if isinstance(id_payload.get("https://api.openai.com/auth"), dict) else {}
+    return bool(str(auth_payload.get("chatgpt_account_id") or "").strip())
+
+
+def exchange_codex_tokens_from_session(session: requests.Session, device_id: str, email: str) -> tuple[dict | None, str]:
+    code_verifier, code_challenge = _generate_pkce()
+    authorize_url = _build_codex_authorize_url(email, code_challenge)
+    tokens, reason = exchange_oauth_tokens(
+        session,
+        device_id,
+        code_verifier,
+        authorize_url,
+        client_id=codex_oauth_client_id,
+        redirect_uri=codex_oauth_redirect_uri,
+    )
+    if not tokens:
+        return None, reason
+    if not _has_codex_chatgpt_account_id(tokens):
+        return None, "codex_id_token_missing_chatgpt_account_id"
+    return tokens, ""
+
+
+def exchange_platform_tokens(session: requests.Session, device_id: str, code_verifier: str, consent_url: str) -> dict | None:
+    tokens, reason = exchange_oauth_tokens(
+        session,
+        device_id,
+        code_verifier,
+        consent_url,
+        client_id=platform_oauth_client_id,
+        redirect_uri=platform_oauth_redirect_uri,
+    )
+    if tokens:
+        return tokens
+    log(f"平台 token 换取失败：{reason}", "yellow")
+    return None
+
+
+def exchange_platform_tokens_from_session(session: requests.Session, device_id: str, email: str) -> tuple[dict | None, str]:
+    code_verifier, code_challenge = _generate_pkce()
+    authorize_url = _build_platform_authorize_url(email, device_id, code_challenge)
+    return exchange_oauth_tokens(
+        session,
+        device_id,
+        code_verifier,
+        authorize_url,
+        client_id=platform_oauth_client_id,
+        redirect_uri=platform_oauth_redirect_uri,
+    )
 
 class PlatformRegistrar:
     def __init__(self, proxy: str = "") -> None:
@@ -443,25 +579,8 @@ class PlatformRegistrar:
         self.session.cookies.set("oai-did", self.device_id, domain=".auth.openai.com")
         self.session.cookies.set("oai-did", self.device_id, domain="auth.openai.com")
         _, code_challenge = _generate_pkce()
-        params = {
-            "issuer": auth_base,
-            "client_id": platform_oauth_client_id,
-            "audience": platform_oauth_audience,
-            "redirect_uri": platform_oauth_redirect_uri,
-            "device_id": self.device_id,
-            "screen_hint": "login_or_signup",
-            "max_age": "0",
-            "login_hint": email,
-            "scope": "openid profile email offline_access",
-            "response_type": "code",
-            "response_mode": "query",
-            "state": secrets.token_urlsafe(32),
-            "nonce": secrets.token_urlsafe(32),
-            "code_challenge": code_challenge,
-            "code_challenge_method": "S256",
-            "auth0Client": platform_auth0_client,
-        }
-        resp, error = request_with_local_retry(self.session, "get", f"{auth_base}/api/accounts/authorize?{urlencode(params)}", headers=self._navigate_headers(f"{platform_base}/"), allow_redirects=True, verify=False)
+        authorize_url = _build_platform_authorize_url(email, self.device_id, code_challenge)
+        resp, error = request_with_local_retry(self.session, "get", authorize_url, headers=self._navigate_headers(f"{platform_base}/"), allow_redirects=True, verify=False)
         if resp is None or resp.status_code != 200:
             err = _response_json(resp).get("error", {}) if resp is not None else {}
             detail = f": {err.get('code', '')} - {err.get('message', '')}".strip(" -") if err else ""
@@ -561,7 +680,13 @@ class PlatformRegistrar:
         tokens = exchange_platform_tokens(self.session, self.device_id, code_verifier, continue_url)
         if not tokens:
             raise RuntimeError("token换取失败")
-        step(index, "token 换取完成")
+        step(index, "平台 token 换取完成")
+        codex_tokens, codex_reason = exchange_codex_tokens_from_session(self.session, self.device_id, email)
+        if codex_tokens:
+            tokens["codex"] = codex_tokens
+            step(index, "Codex CPA token 换取完成")
+        else:
+            step(index, f"Codex OAuth 回调不可用，改用 ChatGPT 账号 ID 生成 CPA/Sub2API 凭证：{codex_reason}", "yellow")
         return tokens
 
     def register(self, index: int) -> dict:
@@ -584,14 +709,36 @@ class PlatformRegistrar:
         self._validate_otp(code, index)
         self._create_account(f"{first_name} {last_name}", _random_birthdate(), index)
         tokens = self._login_and_exchange_tokens(email, password, mailbox, index)
+        codex_tokens = tokens.get("codex") if isinstance(tokens.get("codex"), dict) else {}
         return {
             "email": email,
             "password": password,
             "access_token": str(tokens.get("access_token") or "").strip(),
             "refresh_token": str(tokens.get("refresh_token") or "").strip(),
             "id_token": str(tokens.get("id_token") or "").strip(),
+            "client_id": str(tokens.get("client_id") or "").strip(),
+            "chatgpt_account_id": str(tokens.get("chatgpt_account_id") or "").strip(),
+            "chatgpt_user_id": str(tokens.get("chatgpt_user_id") or "").strip(),
+            "codex_access_token": str(codex_tokens.get("access_token") or "").strip(),
+            "codex_refresh_token": str(codex_tokens.get("refresh_token") or "").strip(),
+            "codex_id_token": str(codex_tokens.get("id_token") or "").strip(),
+            "codex_client_id": str(codex_tokens.get("client_id") or "").strip(),
+            "codex_chatgpt_account_id": str(codex_tokens.get("chatgpt_account_id") or "").strip(),
+            "codex_chatgpt_user_id": str(codex_tokens.get("chatgpt_user_id") or "").strip(),
             "created_at": datetime.now(timezone.utc).isoformat(),
         }
+
+
+def _run_auto_sync(index: int, label: str, enabled: bool, sync_fn, result: dict, local_account: dict | None) -> dict:
+    if not enabled:
+        return {"attempted": 0, "succeeded": 0, "failed": 0, "disabled": True}
+    try:
+        return sync_fn(result, local_account=local_account)
+    except Exception as exc:
+        error_text = str(exc)
+        log_service_name = label.upper()
+        step(index, f"{log_service_name} 自动同步失败: {error_text}", "yellow")
+        return {"attempted": 1, "succeeded": 0, "failed": 1, "errors": [{"error": error_text}]}
 
 
 def worker(index: int) -> dict:
@@ -604,12 +751,25 @@ def worker(index: int) -> dict:
         access_token = str(result["access_token"])
         account_service.add_accounts([access_token])
         account_service.refresh_accounts([access_token])
+        local_account = account_service.get_account(access_token)
+        cpa_sync = _run_auto_sync(index, "CPA", app_config.auto_sync_cpa, sync_registered_account_to_pools, result, local_account)
+        sub2api_sync = _run_auto_sync(index, "Sub2API", app_config.auto_sync_sub2api, sync_registered_account_to_sub2api, result, local_account)
         with stats_lock:
             stats["done"] += 1
             stats["success"] += 1
             avg = (time.time() - stats["start_time"]) / stats["success"]
-        log(f'{result["email"]} 注册成功，本次耗时{cost:.1f}s，全局平均每个号注册耗时{avg:.1f}s', "green")
-        return {"ok": True, "index": index, "result": result}
+        sync_parts: list[str] = []
+        if not cpa_sync.get("disabled") and cpa_sync.get("attempted"):
+            sync_parts.append(f'CPA {cpa_sync.get("succeeded", 0)}/{cpa_sync.get("attempted", 0)}')
+        if not sub2api_sync.get("disabled") and sub2api_sync.get("attempted"):
+            sync_parts.append(f'Sub2API {sub2api_sync.get("succeeded", 0)}/{sub2api_sync.get("attempted", 0)}')
+        sync_failed = int(cpa_sync.get("failed") or 0) + int(sub2api_sync.get("failed") or 0)
+        sync_suffix = f"，已自动同步 {'，'.join(sync_parts)}" if sync_parts else ""
+        if sync_failed:
+            sync_suffix += f"，失败 {sync_failed} 个"
+        log_color = "yellow" if sync_failed else "green"
+        log(f'{result["email"]} 注册成功，本次耗时{cost:.1f}s，全局平均每个号注册耗时{avg:.1f}s{sync_suffix}', log_color)
+        return {"ok": True, "index": index, "result": result, "sync": {"cpa": cpa_sync, "sub2api": sub2api_sync}}
     except Exception as e:
         cost = time.time() - start
         with stats_lock:

--- a/services/register_service.py
+++ b/services/register_service.py
@@ -24,6 +24,21 @@ def _default_config() -> dict:
     return {**openai_register.config, "mode": "total", "target_quota": 100, "target_available": 10, "check_interval": 5, "enabled": False, "stats": {"success": 0, "fail": 0, "done": 0, "running": 0, "threads": openai_register.config["threads"], "elapsed_seconds": 0, "avg_seconds": 0, "success_rate": 0, "current_quota": 0, "current_available": 0}}
 
 
+def _normalize_logs(raw: object) -> list[dict]:
+    if not isinstance(raw, list):
+        return []
+    logs: list[dict] = []
+    for item in raw[-300:]:
+        if not isinstance(item, dict):
+            continue
+        logs.append({
+            "time": str(item.get("time") or _now()),
+            "text": str(item.get("text") or ""),
+            "level": str(item.get("level") or "info"),
+        })
+    return logs
+
+
 def _normalize(raw: dict) -> dict:
     cfg = _default_config()
     cfg.update({k: v for k, v in raw.items() if k not in {"stats", "logs"}})
@@ -54,13 +69,16 @@ class RegisterService:
 
     def _load(self) -> dict:
         try:
-            return _normalize(json.loads(self._store_file.read_text(encoding="utf-8")))
+            raw = json.loads(self._store_file.read_text(encoding="utf-8"))
         except Exception:
-            return _normalize({})
+            raw = {}
+        self._logs = _normalize_logs(raw.get("logs") if isinstance(raw, dict) else None)
+        return _normalize(raw if isinstance(raw, dict) else {})
 
     def _save(self) -> None:
         self._store_file.parent.mkdir(parents=True, exist_ok=True)
-        self._store_file.write_text(json.dumps(self._config, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        payload = {**self._config, "logs": self._logs[-300:]}
+        self._store_file.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
     def get(self) -> dict:
         with self._lock:
@@ -113,6 +131,7 @@ class RegisterService:
         with self._lock:
             self._logs.append({"time": _now(), "text": str(text), "level": str(color or "info")})
             self._logs = self._logs[-300:]
+            self._save()
 
     def _pool_metrics(self) -> dict:
         items = account_service.list_accounts()

--- a/services/sub2api_service.py
+++ b/services/sub2api_service.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import base64
 import json
+import re
 import threading
 import time
 import uuid
@@ -10,14 +12,18 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
 from threading import Lock
+from typing import Any
 
 from curl_cffi.requests import Session
 
 from services.account_service import account_service
 from services.config import DATA_DIR
+from services.log_service import LOG_TYPE_ACCOUNT, log_service
 
 
 SUB2API_CONFIG_FILE = DATA_DIR / "sub2api_config.json"
+CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+
 
 # Cached JWT per server to avoid re-login on every list/import call.
 # Token lifetime on sub2api defaults to 24h; we refresh 5 min before expiry.
@@ -416,6 +422,288 @@ def _fetch_access_token_for_account(server: dict, account_id: str) -> tuple[str,
         "email": _clean(credentials.get("email")),
         "plan_type": _clean(credentials.get("plan_type")),
     }
+
+
+def _decode_jwt_payload(token: str) -> dict[str, Any]:
+    token = _clean(token)
+    if not token:
+        return {}
+    parts = token.split(".")
+    if len(parts) < 2:
+        return {}
+    payload = parts[1] + "=" * (-len(parts[1]) % 4)
+    try:
+        data = json.loads(base64.urlsafe_b64decode(payload.encode("utf-8")).decode("utf-8"))
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _first_text(*values: object) -> str:
+    for value in values:
+        text = _clean(value)
+        if text:
+            return text
+    return ""
+
+
+def _b64url_json(payload: dict) -> str:
+    return base64.urlsafe_b64encode(json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")).rstrip(b"=").decode("ascii")
+
+
+def _inject_codex_identity_into_id_token(id_token: str, *, email: str, chatgpt_account_id: str, chatgpt_user_id: str, plan_type: str = "") -> str:
+    id_token = str(id_token or "").strip()
+    chatgpt_account_id = str(chatgpt_account_id or "").strip()
+    if not id_token or not chatgpt_account_id:
+        return id_token
+    try:
+        parts = id_token.split(".")
+        if len(parts) != 3:
+            return id_token
+        header_segment, payload_segment, signature_segment = parts
+        payload_segment += "=" * (-len(payload_segment) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(payload_segment.encode("utf-8")).decode("utf-8"))
+        if not isinstance(payload, dict):
+            return id_token
+        payload["aud"] = [CODEX_OAUTH_CLIENT_ID]
+        payload["azp"] = CODEX_OAUTH_CLIENT_ID
+        if email:
+            payload["email"] = email
+        auth_payload = payload.get("https://api.openai.com/auth")
+        if not isinstance(auth_payload, dict):
+            auth_payload = {}
+        auth_payload["chatgpt_account_id"] = chatgpt_account_id
+        if chatgpt_user_id:
+            auth_payload["chatgpt_user_id"] = chatgpt_user_id
+            auth_payload["user_id"] = chatgpt_user_id
+        if plan_type:
+            auth_payload["chatgpt_plan_type"] = str(plan_type).lower()
+        payload["https://api.openai.com/auth"] = auth_payload
+        return f"{header_segment}.{_b64url_json(payload)}.{signature_segment or 'sig'}"
+    except Exception:
+        return id_token
+
+def _claim_from_payload(payload: dict[str, Any], *names: str) -> str:
+    if not isinstance(payload, dict):
+        return ""
+    auth = payload.get("https://api.openai.com/auth")
+    profile = payload.get("https://api.openai.com/profile")
+    for scope in (auth, profile):
+        if isinstance(scope, dict):
+            for name in names:
+                value = _first_text(scope.get(name))
+                if value:
+                    return value
+    for name in names:
+        for key in (name, f"https://api.openai.com/auth.{name}", f"https://api.openai.com/profile.{name}"):
+            value = _first_text(payload.get(key))
+            if value:
+                return value
+    return ""
+
+
+def _token_exp_epoch(*tokens: str) -> int | None:
+    for token in tokens:
+        payload = _decode_jwt_payload(token)
+        try:
+            exp = int(payload.get("exp") or 0)
+        except Exception:
+            exp = 0
+        if exp > 0:
+            return exp
+    return None
+
+
+def _is_chatgpt_account_id(value: str) -> bool:
+    return bool(re.fullmatch(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}", _clean(value)))
+
+
+def _is_chatgpt_user_id(value: str) -> bool:
+    return _clean(value).startswith("user-")
+
+
+def _extract_registered_identity(register_result: dict, local_account: dict | None = None) -> dict[str, str | int | None]:
+    local_account = local_account or {}
+    access_token = _clean(register_result.get("codex_access_token") or register_result.get("access_token"))
+    id_token = _clean(register_result.get("codex_id_token") or register_result.get("id_token"))
+    access_payload = _decode_jwt_payload(access_token)
+    id_payload = _decode_jwt_payload(id_token)
+    email = _first_text(register_result.get("email"), local_account.get("email"), _claim_from_payload(id_payload, "email"), _claim_from_payload(access_payload, "email"))
+    chatgpt_account_id = _first_text(
+        register_result.get("codex_chatgpt_account_id"),
+        register_result.get("chatgpt_account_id"),
+        local_account.get("chatgpt_account_id"),
+        _claim_from_payload(id_payload, "chatgpt_account_id"),
+        _claim_from_payload(access_payload, "chatgpt_account_id"),
+    )
+    existing_account_id = _first_text(register_result.get("account_id"), local_account.get("account_id"))
+    if not chatgpt_account_id and _is_chatgpt_account_id(existing_account_id):
+        chatgpt_account_id = existing_account_id
+    chatgpt_user_id = _first_text(
+        register_result.get("codex_chatgpt_user_id"),
+        register_result.get("chatgpt_user_id"),
+        local_account.get("chatgpt_user_id"),
+        local_account.get("user_id"),
+        _claim_from_payload(id_payload, "chatgpt_user_id", "user_id", "chatgpt_account_user_id"),
+        _claim_from_payload(access_payload, "chatgpt_user_id", "user_id", "chatgpt_account_user_id"),
+    )
+    if not chatgpt_user_id and _is_chatgpt_user_id(existing_account_id):
+        chatgpt_user_id = existing_account_id
+    client_id = _first_text(register_result.get("codex_client_id"), register_result.get("client_id"), _claim_from_payload(access_payload, "client_id"), _claim_from_payload(id_payload, "azp", "client_id"), CODEX_OAUTH_CLIENT_ID)
+    return {
+        "email": email,
+        "chatgpt_account_id": chatgpt_account_id,
+        "chatgpt_user_id": chatgpt_user_id,
+        "client_id": client_id,
+        "expires_at": _token_exp_epoch(access_token, id_token),
+    }
+
+
+def _group_ids(server: dict) -> list[int]:
+    raw = _clean(server.get("group_id"))
+    if not raw:
+        return []
+    try:
+        group_id = int(raw)
+    except (TypeError, ValueError):
+        return []
+    return [group_id] if group_id > 0 else []
+
+
+def _build_registered_account_payload(register_result: dict, local_account: dict | None = None) -> tuple[dict, str]:
+    access_token = _clean(register_result.get("codex_access_token") or register_result.get("access_token"))
+    refresh_token = _clean(register_result.get("codex_refresh_token") or register_result.get("refresh_token"))
+    id_token = _clean(register_result.get("codex_id_token") or register_result.get("id_token"))
+    if not access_token:
+        raise ValueError("missing access_token")
+    identity = _extract_registered_identity(register_result, local_account=local_account)
+    email = _clean(identity.get("email"))
+    chatgpt_account_id = _clean(identity.get("chatgpt_account_id"))
+    chatgpt_user_id = _clean(identity.get("chatgpt_user_id"))
+    client_id = CODEX_OAUTH_CLIENT_ID
+    id_token = _inject_codex_identity_into_id_token(
+        id_token,
+        email=email,
+        chatgpt_account_id=chatgpt_account_id,
+        chatgpt_user_id=chatgpt_user_id,
+        plan_type=_clean(local_account.get("chatgpt_plan_type") or local_account.get("type")),
+    )
+    id_payload = _decode_jwt_payload(id_token)
+    id_claim_account_id = _claim_from_payload(id_payload, "chatgpt_account_id")
+    if not _is_chatgpt_account_id(id_claim_account_id):
+        raise ValueError("codex_id_token_missing_chatgpt_account_id")
+    if not _is_chatgpt_account_id(chatgpt_account_id):
+        chatgpt_account_id = id_claim_account_id
+    credentials: dict[str, object] = {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "id_token": id_token,
+        "email": email,
+        "chatgpt_account_id": chatgpt_account_id,
+        "chatgpt_user_id": chatgpt_user_id,
+        "client_id": client_id,
+        "session_token": _clean(register_result.get("session_token")),
+    }
+    expires_at = identity.get("expires_at")
+    if isinstance(expires_at, int) and expires_at > 0:
+        credentials["expires_at"] = expires_at
+    credentials = {key: value for key, value in credentials.items() if value not in (None, "") or key == "session_token"}
+    extra: dict[str, object] = {}
+    if client_id == CODEX_OAUTH_CLIENT_ID:
+        extra["codex_cli_only"] = True
+    payload: dict[str, object] = {
+        "name": email or chatgpt_account_id,
+        "platform": "openai",
+        "type": "oauth",
+        "credentials": credentials,
+        "concurrency": 10,
+        "priority": 1,
+        "group_ids": [],
+        "auto_pause_on_expired": True,
+    }
+    if extra:
+        payload["extra"] = extra
+    if isinstance(expires_at, int) and expires_at > 0:
+        payload["expires_at"] = expires_at
+    return payload, email
+
+
+def _list_sync_servers() -> list[dict]:
+    seen: set[tuple[str, str, str]] = set()
+    servers: list[dict] = []
+    for server in sub2api_config.list_servers():
+        base_url = _clean(server.get("base_url")).rstrip("/")
+        auth_key = _clean(server.get("api_key")) or f"{_clean(server.get('email'))}:{_clean(server.get('password'))}"
+        group_id = _clean(server.get("group_id"))
+        if not base_url or not auth_key:
+            continue
+        key = (base_url, auth_key, group_id)
+        if key in seen:
+            continue
+        seen.add(key)
+        servers.append(server)
+    return servers
+
+
+def create_remote_account(server: dict, payload: dict) -> None:
+    base_url = _clean(server.get("base_url"))
+    if not base_url:
+        raise ValueError("invalid sub2api server config")
+    body = dict(payload)
+    body["group_ids"] = _group_ids(server)
+    headers = {**_auth_headers(server), "Content-Type": "application/json"}
+    session = Session(verify=True)
+    try:
+        response = session.post(
+            f"{base_url.rstrip('/')}/api/v1/admin/accounts",
+            headers=headers,
+            json=body,
+            timeout=60,
+        )
+        if response.status_code == 409:
+            try:
+                conflict = response.json()
+            except Exception:
+                conflict = {}
+            if isinstance(conflict, dict) and conflict.get("error") == "mixed_channel_warning":
+                body["confirm_mixed_channel_risk"] = True
+                response = session.post(
+                    f"{base_url.rstrip('/')}/api/v1/admin/accounts",
+                    headers=headers,
+                    json=body,
+                    timeout=60,
+                )
+        if not response.ok:
+            raise RuntimeError(f"sub2api create failed: HTTP {response.status_code} {response.text[:200]}")
+    finally:
+        session.close()
+
+
+def sync_registered_account_to_sub2api(register_result: dict, local_account: dict | None = None) -> dict[str, Any]:
+    servers = _list_sync_servers()
+    summary: dict[str, Any] = {
+        "attempted": len(servers),
+        "succeeded": 0,
+        "failed": 0,
+        "email": "",
+        "errors": [],
+    }
+    if not servers:
+        return summary
+    payload, email = _build_registered_account_payload(register_result, local_account=local_account)
+    summary["email"] = email
+    for server in servers:
+        server_name = _clean(server.get("name")) or _clean(server.get("base_url")) or _clean(server.get("id"))
+        try:
+            create_remote_account(server, payload)
+            summary["succeeded"] += 1
+            log_service.add(LOG_TYPE_ACCOUNT, "Sub2API自动同步成功", {"server": server_name, "email": email})
+        except Exception as exc:
+            summary["failed"] += 1
+            error_text = str(exc)
+            summary["errors"].append({"server": server_name, "error": error_text})
+            log_service.add(LOG_TYPE_ACCOUNT, "Sub2API自动同步失败", {"server": server_name, "email": email, "error": error_text})
+    return summary
 
 
 class Sub2APIImportService:

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -131,3 +131,143 @@
     display: none;
   }
 }
+
+
+@layer utilities {
+  .app-shell {
+    background:
+      radial-gradient(circle at top left, rgba(255, 255, 255, 0.92), rgba(245, 239, 231, 0.96) 42%, rgba(240, 235, 227, 0.99) 100%);
+  }
+
+  .dark {
+    color-scheme: dark;
+    --background: oklch(0.125 0.018 260);
+    --foreground: oklch(0.965 0.018 86);
+    --card: oklch(0.185 0.026 260 / 0.86);
+    --card-foreground: oklch(0.955 0.014 86);
+    --popover: oklch(0.18 0.026 260 / 0.96);
+    --popover-foreground: oklch(0.955 0.014 86);
+    --primary: oklch(0.86 0.13 82);
+    --primary-foreground: oklch(0.16 0.02 260);
+    --secondary: oklch(0.24 0.035 260 / 0.92);
+    --secondary-foreground: oklch(0.9 0.018 86);
+    --muted: oklch(0.24 0.03 260 / 0.72);
+    --muted-foreground: oklch(0.74 0.028 250);
+    --accent: oklch(0.74 0.12 210);
+    --accent-foreground: oklch(0.13 0.018 260);
+    --border: oklch(0.76 0.032 255 / 0.18);
+    --input: oklch(0.76 0.032 255 / 0.16);
+    --ring: oklch(0.79 0.11 210 / 0.55);
+  }
+
+  .dark .app-shell {
+    background:
+      radial-gradient(circle at 9% -8%, rgba(251, 191, 36, 0.16), transparent 31%),
+      radial-gradient(circle at 87% 1%, rgba(34, 211, 238, 0.14), transparent 30%),
+      radial-gradient(circle at 58% 116%, rgba(167, 139, 250, 0.13), transparent 36%),
+      linear-gradient(135deg, #070a12 0%, #0d111c 38%, #13110e 73%, #09080b 100%);
+  }
+
+  .dark body {
+    background: #070a12;
+  }
+
+  .dark header {
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.08),
+      0 24px 80px -48px rgba(56, 189, 248, 0.42),
+      0 28px 80px -54px rgba(251, 191, 36, 0.24);
+  }
+
+  .dark [data-slot="card"] {
+    background:
+      linear-gradient(145deg, rgba(24, 31, 44, 0.88), rgba(13, 17, 28, 0.82)) !important;
+    border-color: rgba(226, 232, 240, 0.13) !important;
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.07),
+      0 28px 90px -55px rgba(2, 6, 23, 0.95),
+      0 18px 70px -58px rgba(34, 211, 238, 0.38) !important;
+    backdrop-filter: blur(22px);
+  }
+
+  .dark [class*="bg-white"] {
+    background-color: rgba(18, 24, 36, 0.72) !important;
+  }
+
+  .dark [class*="bg-stone-50"],
+  .dark [class*="bg-stone-100"] {
+    background-color: rgba(21, 28, 42, 0.66) !important;
+  }
+
+  .dark [class*="border-stone-"],
+  .dark [class*="border-white"] {
+    border-color: rgba(226, 232, 240, 0.14) !important;
+  }
+
+  .dark [class*="text-stone-950"],
+  .dark [class*="text-stone-900"],
+  .dark [class*="text-stone-800"],
+  .dark [class*="text-stone-700"],
+  .dark [class*="text-stone-600"] {
+    color: rgb(236, 242, 248) !important;
+  }
+
+  .dark [class*="text-stone-500"],
+  .dark [class*="text-stone-400"] {
+    color: rgb(152, 166, 185) !important;
+  }
+
+  .dark [data-slot="input"],
+  .dark [data-slot="select-trigger"],
+  .dark input,
+  .dark textarea,
+  .dark select {
+    background:
+      linear-gradient(180deg, rgba(15, 23, 42, 0.86), rgba(10, 14, 24, 0.82)) !important;
+    border-color: rgba(148, 163, 184, 0.22) !important;
+    color: rgb(235, 242, 250) !important;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.045), 0 12px 36px -28px rgba(34, 211, 238, 0.34) !important;
+  }
+
+  .dark input:focus,
+  .dark textarea:focus,
+  .dark [data-slot="select-trigger"]:focus-visible {
+    border-color: rgba(125, 211, 252, 0.46) !important;
+    box-shadow: 0 0 0 3px rgba(14, 165, 233, 0.14), inset 0 1px 0 rgba(255, 255, 255, 0.06) !important;
+  }
+
+  .dark input::placeholder,
+  .dark textarea::placeholder {
+    color: rgba(148, 163, 184, 0.68) !important;
+  }
+
+  .dark [data-slot="button"]:not([class*="bg-stone-950"]):not([class*="bg-primary"]),
+  .dark button[class*="border-stone"] {
+    border-color: rgba(226, 232, 240, 0.14) !important;
+    background-color: rgba(15, 23, 42, 0.58) !important;
+    color: rgb(219, 229, 240) !important;
+  }
+
+  .dark [data-slot="dialog-content"],
+  .dark [data-slot="select-content"],
+  .dark [data-radix-popper-content-wrapper] [role="dialog"] {
+    background:
+      linear-gradient(145deg, rgba(20, 27, 40, 0.98), rgba(9, 13, 22, 0.98)) !important;
+    border-color: rgba(226, 232, 240, 0.14) !important;
+    box-shadow: 0 34px 120px -56px rgba(2, 6, 23, 1), 0 20px 90px -72px rgba(167, 139, 250, 0.55) !important;
+  }
+
+  .dark table,
+  .dark pre {
+    color: rgb(226, 232, 240);
+  }
+
+  .dark tr:hover {
+    background-color: rgba(51, 65, 85, 0.26) !important;
+  }
+
+  .dark ::selection {
+    background: rgba(34, 211, 238, 0.28);
+    color: rgb(248, 250, 252);
+  }
+}

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -22,8 +22,13 @@ export default function RootLayout({
             '"SF Pro Display","SF Pro Text","PingFang SC","Microsoft YaHei","Helvetica Neue",sans-serif',
         }}
       >
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `try{var t=localStorage.getItem("theme");if(t==="dark"){document.documentElement.classList.add("dark")}else{document.documentElement.classList.remove("dark")}}catch(e){}`,
+          }}
+        />
         <Toaster position="top-center" richColors offset={48} />
-        <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.92),_rgba(245,239,231,0.96)_42%,_rgba(240,235,227,0.99)_100%)] px-4 py-2 text-stone-900 sm:px-6 lg:px-8">
+        <main className="app-shell min-h-screen px-4 py-2 text-stone-900 dark:text-stone-100 sm:px-6 lg:px-8">
           <div className="mx-auto flex max-w-[1440px] flex-col gap-5">
             <TopNav />
             {children}

--- a/web/src/app/settings/components/config-card.tsx
+++ b/web/src/app/settings/components/config-card.tsx
@@ -23,6 +23,8 @@ export function ConfigCard() {
   const setImageRetentionDays = useSettingsStore((state) => state.setImageRetentionDays);
   const setAutoRemoveInvalidAccounts = useSettingsStore((state) => state.setAutoRemoveInvalidAccounts);
   const setAutoRemoveRateLimitedAccounts = useSettingsStore((state) => state.setAutoRemoveRateLimitedAccounts);
+  const setAutoSyncCPA = useSettingsStore((state) => state.setAutoSyncCPA);
+  const setAutoSyncSub2API = useSettingsStore((state) => state.setAutoSyncSub2API);
   const setLogLevel = useSettingsStore((state) => state.setLogLevel);
   const setProxy = useSettingsStore((state) => state.setProxy);
   const setBaseUrl = useSettingsStore((state) => state.setBaseUrl);
@@ -149,6 +151,20 @@ export function ConfigCard() {
               onCheckedChange={(checked) => setAutoRemoveRateLimitedAccounts(Boolean(checked))}
             />
             自动移除限流账号
+          </label>
+          <label className="flex items-center gap-3 rounded-xl border border-stone-200 bg-white px-4 py-3 text-sm text-stone-700">
+            <Checkbox
+              checked={config?.auto_sync_cpa !== false}
+              onCheckedChange={(checked) => setAutoSyncCPA(Boolean(checked))}
+            />
+            注册成功后自动上传 CPA
+          </label>
+          <label className="flex items-center gap-3 rounded-xl border border-stone-200 bg-white px-4 py-3 text-sm text-stone-700">
+            <Checkbox
+              checked={config?.auto_sync_sub2api !== false}
+              onCheckedChange={(checked) => setAutoSyncSub2API(Boolean(checked))}
+            />
+            注册成功后自动上传 Sub2API
           </label>
           <div className="space-y-3 rounded-xl border border-stone-200 bg-white px-4 py-3">
             <div>

--- a/web/src/app/settings/store.ts
+++ b/web/src/app/settings/store.ts
@@ -34,6 +34,8 @@ function normalizeConfig(config: SettingsConfig): SettingsConfig {
     image_retention_days: Number(config.image_retention_days || 30),
     auto_remove_invalid_accounts: Boolean(config.auto_remove_invalid_accounts),
     auto_remove_rate_limited_accounts: Boolean(config.auto_remove_rate_limited_accounts),
+    auto_sync_cpa: config.auto_sync_cpa !== false,
+    auto_sync_sub2api: config.auto_sync_sub2api !== false,
     log_levels: Array.isArray(config.log_levels) ? config.log_levels : [],
     proxy: typeof config.proxy === "string" ? config.proxy : "",
     base_url: typeof config.base_url === "string" ? config.base_url : "",
@@ -95,6 +97,8 @@ type SettingsStore = {
   setImageRetentionDays: (value: string) => void;
   setAutoRemoveInvalidAccounts: (value: boolean) => void;
   setAutoRemoveRateLimitedAccounts: (value: boolean) => void;
+  setAutoSyncCPA: (value: boolean) => void;
+  setAutoSyncSub2API: (value: boolean) => void;
   setLogLevel: (level: string, enabled: boolean) => void;
   setProxy: (value: string) => void;
   setBaseUrl: (value: string) => void;
@@ -200,6 +204,8 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
         image_retention_days: Math.max(1, Number(config.image_retention_days) || 30),
         auto_remove_invalid_accounts: Boolean(config.auto_remove_invalid_accounts),
         auto_remove_rate_limited_accounts: Boolean(config.auto_remove_rate_limited_accounts),
+        auto_sync_cpa: Boolean(config.auto_sync_cpa),
+        auto_sync_sub2api: Boolean(config.auto_sync_sub2api),
         proxy: config.proxy.trim(),
         base_url: String(config.base_url || "").trim(),
       });
@@ -238,6 +244,14 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
 
   setAutoRemoveRateLimitedAccounts: (value) => {
     set((state) => state.config ? { config: { ...state.config, auto_remove_rate_limited_accounts: value } } : {});
+  },
+
+  setAutoSyncCPA: (value) => {
+    set((state) => state.config ? { config: { ...state.config, auto_sync_cpa: value } } : {});
+  },
+
+  setAutoSyncSub2API: (value) => {
+    set((state) => state.config ? { config: { ...state.config, auto_sync_sub2api: value } } : {});
   },
 
   setLogLevel: (level, enabled) => {

--- a/web/src/components/top-nav.tsx
+++ b/web/src/components/top-nav.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
-import { Github } from "lucide-react";
+import { Github, Moon, Sun } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
 
 import webConfig from "@/constants/common-env";
@@ -24,6 +24,14 @@ export function TopNav() {
   const pathname = usePathname();
   const router = useRouter();
   const [session, setSession] = useState<StoredAuthSession | null | undefined>(undefined);
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+
+  useEffect(() => {
+    const stored = typeof window !== "undefined" ? window.localStorage.getItem("theme") : null;
+    const initial = stored === "dark" ? "dark" : "light";
+    setTheme(initial);
+    document.documentElement.classList.toggle("dark", initial === "dark");
+  }, []);
 
   useEffect(() => {
     let active = true;
@@ -55,6 +63,13 @@ export function TopNav() {
     router.replace("/login");
   };
 
+  const toggleTheme = () => {
+    const next = theme === "dark" ? "light" : "dark";
+    setTheme(next);
+    document.documentElement.classList.toggle("dark", next === "dark");
+    window.localStorage.setItem("theme", next);
+  };
+
   if (pathname === "/login" || session === undefined || !session) {
     return null;
   }
@@ -63,20 +78,29 @@ export function TopNav() {
   const roleLabel = session.role === "admin" ? "管理员" : "普通用户";
 
   return (
-    <header className="border-b border-stone-100/50">
+    <header className="sticky top-2 z-40 rounded-[22px] border border-white/70 bg-white/55 shadow-[0_18px_70px_-48px_rgba(28,25,23,0.45)] backdrop-blur-2xl dark:border-white/10 dark:bg-slate-950/45 dark:shadow-[0_24px_90px_-48px_rgba(2,6,23,0.95)]">
       <div className="flex min-h-12 flex-col gap-1 px-3 py-2 sm:h-12 sm:flex-row sm:items-center sm:justify-between sm:gap-3 sm:px-6 sm:py-0">
         <div className="flex items-center justify-between gap-2 sm:justify-start sm:gap-3">
           <Link
             href="/image"
-            className="shrink-0 py-1 text-[15px] font-bold tracking-tight text-stone-950 transition hover:text-stone-700"
+            className="shrink-0 py-1 text-[15px] font-bold tracking-tight text-stone-950 transition hover:text-stone-700 dark:bg-gradient-to-r dark:from-amber-200 dark:via-cyan-200 dark:to-violet-300 dark:bg-clip-text dark:text-transparent"
           >
             chatgpt2api
           </Link>
+          <button
+            type="button"
+            className="inline-flex items-center gap-1.5 rounded-full border border-transparent px-2 py-1 text-sm text-stone-400 transition hover:bg-stone-100 hover:text-stone-700 dark:border-white/10 dark:bg-white/[0.04] dark:text-amber-200 dark:hover:border-amber-300/30 dark:hover:bg-amber-300/10 dark:hover:text-amber-100"
+            onClick={toggleTheme}
+            aria-label={theme === "dark" ? "切换到亮色模式" : "切换到暗色模式"}
+          >
+            {theme === "dark" ? <Sun className="size-4" /> : <Moon className="size-4" />}
+            <span className="hidden md:inline">{theme === "dark" ? "亮色" : "暗色"}</span>
+          </button>
           <a
             href="https://github.com/basketikun/chatgpt2api"
             target="_blank"
             rel="noreferrer"
-            className="inline-flex items-center gap-1.5 py-1 text-sm text-stone-400 transition hover:text-stone-700"
+            className="inline-flex items-center gap-1.5 rounded-full px-2 py-1 text-sm text-stone-400 transition hover:bg-stone-100 hover:text-stone-700 dark:text-slate-400 dark:hover:bg-white/[0.04] dark:hover:text-cyan-200"
             aria-label="GitHub repository"
           >
             <Github className="size-4" />
@@ -84,7 +108,7 @@ export function TopNav() {
           </a>
           <button
             type="button"
-            className="ml-auto shrink-0 py-1 text-xs text-stone-400 transition hover:text-stone-700 sm:hidden"
+            className="ml-auto shrink-0 rounded-full px-2 py-1 text-xs text-stone-400 transition hover:bg-stone-100 hover:text-stone-700 dark:text-slate-400 dark:hover:bg-white/[0.05] dark:hover:text-slate-100 sm:hidden"
             onClick={() => void handleLogout()}
           >
             退出
@@ -100,26 +124,26 @@ export function TopNav() {
                 className={cn(
                   "relative shrink-0 whitespace-nowrap rounded-full px-2.5 py-1 text-[13px] font-medium transition sm:rounded-none sm:px-0 sm:text-[15px]",
                   active
-                    ? "bg-stone-950 text-white sm:bg-transparent sm:font-semibold sm:text-stone-950"
-                    : "text-stone-500 hover:text-stone-900",
+                    ? "bg-stone-950 text-white shadow-[0_12px_32px_-20px_rgba(28,25,23,0.55)] sm:bg-transparent sm:font-semibold sm:text-stone-950 sm:shadow-none dark:bg-gradient-to-r dark:from-amber-300 dark:via-cyan-300 dark:to-violet-300 dark:text-slate-950 dark:shadow-[0_16px_40px_-24px_rgba(34,211,238,0.85)] sm:dark:bg-clip-text sm:dark:text-transparent sm:dark:shadow-none"
+                    : "text-stone-500 hover:text-stone-900 dark:text-slate-400 dark:hover:text-slate-100",
                 )}
               >
                 {item.label}
-                {active ? <span className="absolute inset-x-0 -bottom-[1px] hidden h-0.5 bg-stone-950 sm:block" /> : null}
+                {active ? <span className="absolute inset-x-0 -bottom-[1px] hidden h-0.5 bg-stone-950 dark:bg-gradient-to-r dark:from-amber-300 dark:via-cyan-300 dark:to-violet-300 sm:block" /> : null}
               </Link>
             );
           })}
         </nav>
         <div className="hidden items-center justify-end gap-2 sm:flex sm:gap-3">
-          <span className="hidden rounded-md bg-stone-100 px-2 py-1 text-[10px] font-medium text-stone-500 sm:inline-block sm:text-[11px]">
+          <span className="hidden rounded-md bg-stone-100 px-2 py-1 text-[10px] font-medium text-stone-500 dark:border dark:border-white/10 dark:bg-white/[0.055] dark:text-slate-300 sm:inline-block sm:text-[11px]">
             {roleLabel}
           </span>
-          <span className="hidden rounded-md bg-stone-100 px-2 py-1 text-[10px] font-medium text-stone-500 sm:inline-block sm:text-[11px]">
+          <span className="hidden rounded-md bg-stone-100 px-2 py-1 text-[10px] font-medium text-stone-500 dark:border dark:border-white/10 dark:bg-white/[0.055] dark:text-slate-300 sm:inline-block sm:text-[11px]">
             v{webConfig.appVersion}
           </span>
           <button
             type="button"
-            className="py-1 text-xs text-stone-400 transition hover:text-stone-700 sm:text-sm"
+            className="rounded-full px-2 py-1 text-xs text-stone-400 transition hover:bg-stone-100 hover:text-stone-700 dark:text-slate-400 dark:hover:bg-white/[0.05] dark:hover:text-slate-100 sm:text-sm"
             onClick={() => void handleLogout()}
           >
             退出

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -57,6 +57,8 @@ export type SettingsConfig = {
   image_retention_days?: number | string;
   auto_remove_invalid_accounts?: boolean;
   auto_remove_rate_limited_accounts?: boolean;
+  auto_sync_cpa?: boolean;
+  auto_sync_sub2api?: boolean;
   log_levels?: string[];
   [key: string]: unknown;
 };


### PR DESCRIPTION

*自动将新注册的账号同步上传到已配置的 CPA / Sub2API 
* 自动上传分别新增独立的开关
* 持久化最近的注册任务日志
* 新增深色模式
* 修复由于 Codex 凭据缺少真实 ChatGPT 账号 ID，导致 配额/认证文件失败的问题
* 账号刷新现在会请求 /backend-api/accounts/check/v4-2023-04-27，并在可用时存储 chatgpt_account_id、chatgpt_account_user_id 和 chatgpt_plan_type
* CPA multipart 上传改用 curl_cffi.CurlMime 测试

**已部署运行环境验证**
1. 真实注册流程已完成，并且 CPA 自动同步显示 已自动同步 CPA / Sub2API 
2. 最新的 auth 文件不再报告缺少 ChatGPT 账号 ID