### PR TITLE
fix: improve image count UX and add YYDS Mail

### DIFF
--- a/services/register/mail_provider.py
+++ b/services/register/mail_provider.py
@@ -391,6 +391,177 @@ class GptMailProvider(BaseMailProvider):
         self.session.close()
 
 
+class YydsMailProvider(BaseMailProvider):
+    name = "yyds_mail"
+
+    def __init__(self, entry: dict, conf: dict):
+        super().__init__(conf, str(entry.get("provider_ref") or ""))
+        self.api_base = str(entry.get("api_base") or "https://maliapi.215.im/v1").rstrip("/")
+        self.api_key = str(entry.get("api_key") or "").strip()
+        raw_domains = entry.get("domain") or []
+        if isinstance(raw_domains, list):
+            self.domain = [str(item).strip() for item in raw_domains if str(item).strip()]
+        else:
+            self.domain = [str(raw_domains).strip()] if str(raw_domains).strip() else []
+        self.session = curl_requests.Session(impersonate="chrome")
+
+    @staticmethod
+    def _unwrap(data: Any) -> Any:
+        if isinstance(data, dict) and "data" in data:
+            return data["data"]
+        return data
+
+    @staticmethod
+    def _first_text(data: dict[str, Any], *keys: str) -> str:
+        for key in keys:
+            value = data.get(key)
+            if isinstance(value, dict):
+                nested = YydsMailProvider._first_text(value, "address", "email", "name", "value", "token", "jwt")
+                if nested:
+                    return nested
+            text = str(value or "").strip()
+            if text:
+                return text
+        return ""
+
+    def _headers(self, token: str = "") -> dict[str, str]:
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "User-Agent": self.conf["user_agent"],
+            "X-API-Key": self.api_key,
+        }
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        return headers
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        token: str = "",
+        params: dict | None = None,
+        payload: dict | None = None,
+        expected: tuple[int, ...] = (200, 201, 204),
+    ):
+        resp = self.session.request(
+            method.upper(),
+            f"{self.api_base}{path}",
+            headers=self._headers(token),
+            params=params,
+            json=payload,
+            timeout=self.conf["request_timeout"],
+            verify=False,
+        )
+        if resp.status_code not in expected:
+            raise RuntimeError(f"YYDS Mail 请求失败: {method} {path}, HTTP {resp.status_code}, body={resp.text[:300]}")
+        if resp.status_code == 204 or not resp.text.strip():
+            return {}
+        data = resp.json()
+        if isinstance(data, dict) and data.get("success") is False:
+            raise RuntimeError(f"YYDS Mail 请求失败: {data.get('errorCode') or data.get('error') or data}")
+        return self._unwrap(data)
+
+    @staticmethod
+    def _resolve_domain(domain: str) -> tuple[str, bool]:
+        text = str(domain or "").strip().lower()
+        if text.startswith("*.") and len(text) > 2:
+            return text[2:], True
+        return text, False
+
+    @staticmethod
+    def _items(data: Any) -> list[dict[str, Any]]:
+        data = YydsMailProvider._unwrap(data)
+        if isinstance(data, list):
+            return [item for item in data if isinstance(item, dict)]
+        if isinstance(data, dict):
+            for key in ("messages", "items", "emails", "results", "data"):
+                value = data.get(key)
+                if isinstance(value, list):
+                    return [item for item in value if isinstance(item, dict)]
+        return []
+
+    def create_mailbox(self, username: str | None = None) -> dict[str, Any]:
+        if not self.api_key:
+            raise RuntimeError("YYDS Mail 需要 api_key")
+        payload: dict[str, Any] = {"localPart": username or _random_mailbox_name()}
+        endpoint = "/accounts"
+        if self.domain:
+            domain, use_wildcard = self._resolve_domain(_next_domain(self.domain))
+            payload["domain"] = domain
+            if use_wildcard:
+                endpoint = "/accounts/wildcard"
+        data = self._request("POST", endpoint, payload=payload)
+        if not isinstance(data, dict):
+            raise RuntimeError("YYDS Mail 创建邮箱返回结构不是对象")
+        address = self._first_text(data, "address", "email")
+        token = self._first_text(data, "temp_token", "tempToken", "token", "access_token", "jwt")
+        account_id = self._first_text(data, "id", "account_id", "accountId")
+        if not address:
+            raise RuntimeError("YYDS Mail 缺少 address")
+        return {
+            "provider": self.name,
+            "provider_ref": self.provider_ref,
+            "address": address,
+            "token": token,
+            "account_id": account_id,
+        }
+
+    def fetch_latest_message(self, mailbox: dict[str, Any]) -> dict[str, Any] | None:
+        address = str(mailbox.get("address") or "").strip()
+        token = str(mailbox.get("token") or "").strip()
+        data = self._request("GET", "/messages", token=token, params={"address": address})
+        messages = [item for item in self._items(data) if _message_matches_email(item, address)]
+        if not messages:
+            return None
+        item = max(
+            messages,
+            key=lambda value: (
+                (
+                    _parse_received_at(
+                        value.get("createdAt")
+                        or value.get("created_at")
+                        or value.get("receivedAt")
+                        or value.get("date")
+                        or value.get("timestamp")
+                    )
+                    or datetime.fromtimestamp(0, tz=timezone.utc)
+                ).timestamp(),
+                str(value.get("id") or ""),
+            ),
+        )
+        message_id = str(item.get("id") or item.get("_id") or item.get("message_id") or "").strip()
+        if message_id:
+            detail = self._request("GET", f"/messages/{message_id}", token=token, params={"address": address})
+            if isinstance(detail, dict):
+                item = detail.get("message") if isinstance(detail.get("message"), dict) else detail
+        text_content, html_content = _extract_content(item)
+        sender = item.get("from") or item.get("sender") or item.get("from_address") or ""
+        if isinstance(sender, dict):
+            sender = sender.get("address") or sender.get("email") or sender.get("name") or ""
+        return {
+            "provider": self.name,
+            "mailbox": address,
+            "message_id": message_id,
+            "subject": str(item.get("subject") or ""),
+            "sender": str(sender),
+            "text_content": text_content,
+            "html_content": html_content,
+            "received_at": _parse_received_at(
+                item.get("createdAt")
+                or item.get("created_at")
+                or item.get("receivedAt")
+                or item.get("date")
+                or item.get("timestamp")
+            ),
+            "raw": item,
+        }
+
+    def close(self) -> None:
+        self.session.close()
+
+
 class MoEmailProvider(BaseMailProvider):
     name = "moemail"
 
@@ -480,6 +651,8 @@ def _create_provider(mail_config: dict, provider: str = "", provider_ref: str = 
         return DuckMailProvider(entry, conf)
     if entry["type"] == "gptmail":
         return GptMailProvider(entry, conf)
+    if entry["type"] == "yyds_mail":
+        return YydsMailProvider(entry, conf)
     if entry["type"] == "moemail":
         return MoEmailProvider(entry, conf)
     raise RuntimeError(f"不支持的 mail.provider: {entry['type']}")

--- a/web/src/app/image/components/image-composer.tsx
+++ b/web/src/app/image/components/image-composer.tsx
@@ -195,10 +195,14 @@ export function ImageComposer({
                       type="number"
                       inputMode="numeric"
                       min="1"
-                      max="10"
                       step="1"
                       value={imageCount}
                       onChange={(event) => onImageCountChange(event.target.value)}
+                      onBlur={() => {
+                        if (!imageCount.trim() || Number(imageCount) < 1) {
+                          onImageCountChange("1");
+                        }
+                      }}
                       className="h-7 w-[40px] border-0 bg-transparent px-0 text-center text-xs font-medium text-stone-700 shadow-none focus-visible:ring-0 sm:h-8 sm:w-[64px] sm:text-sm"
                     />
                   </div>
@@ -260,4 +264,3 @@ export function ImageComposer({
     </div>
   );
 }
-

--- a/web/src/app/image/page.tsx
+++ b/web/src/app/image/page.tsx
@@ -43,6 +43,7 @@ import {
 
 const ACTIVE_CONVERSATION_STORAGE_KEY = "chatgpt2api:image_active_conversation_id";
 const IMAGE_SIZE_STORAGE_KEY = "chatgpt2api:image_last_size";
+const IMAGE_COUNT_STORAGE_KEY = "chatgpt2api:image_last_count";
 const activeConversationQueueIds = new Set<string>();
 
 function buildConversationTitle(prompt: string) {
@@ -76,6 +77,16 @@ function createId() {
     return crypto.randomUUID();
   }
   return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function normalizeImageCount(value: string) {
+  const count = Math.floor(Number(value));
+  return Number.isFinite(count) && count > 0 ? count : 1;
+}
+
+function normalizeImageCountInput(value: string) {
+  const digits = value.replace(/[^\d]/g, "").replace(/^0+(?=\d)/, "");
+  return digits;
 }
 
 function readFileAsDataUrl(file: File) {
@@ -351,7 +362,7 @@ function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
   const [lightboxIndex, setLightboxIndex] = useState(0);
   const [deleteConfirm, setDeleteConfirm] = useState<{ type: "one"; id: string } | { type: "all" } | null>(null);
 
-  const parsedCount = useMemo(() => Math.max(1, Math.min(10, Number(imageCount) || 1)), [imageCount]);
+  const parsedCount = useMemo(() => normalizeImageCount(imageCount), [imageCount]);
   const selectedConversation = useMemo(
     () => conversations.find((item) => item.id === selectedConversationId) ?? null,
     [conversations, selectedConversationId],
@@ -382,7 +393,11 @@ function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
     const loadHistory = async () => {
       try {
         const storedSize = typeof window !== "undefined" ? window.localStorage.getItem(IMAGE_SIZE_STORAGE_KEY) : null;
+        const storedCount = typeof window !== "undefined" ? window.localStorage.getItem(IMAGE_COUNT_STORAGE_KEY) : null;
         setImageSize(storedSize || "");
+        if (storedCount) {
+          setImageCount(String(normalizeImageCount(storedCount)));
+        }
 
         const items = await listImageConversations();
         const normalizedItems = await recoverConversationHistory(items);
@@ -473,6 +488,14 @@ function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
       return;
     }
 
+    window.localStorage.setItem(IMAGE_COUNT_STORAGE_KEY, String(parsedCount));
+  }, [parsedCount]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
     if (imageSize) {
       window.localStorage.setItem(IMAGE_SIZE_STORAGE_KEY, imageSize);
       return;
@@ -519,12 +542,15 @@ function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
 
   const clearComposerInputs = useCallback(() => {
     setImagePrompt("");
-    setImageCount("1");
     setReferenceImageFiles([]);
     setReferenceImages([]);
     if (fileInputRef.current) {
       fileInputRef.current.value = "";
     }
+  }, []);
+
+  const handleImageCountChange = useCallback((value: string) => {
+    setImageCount(normalizeImageCountInput(value));
   }, []);
 
   const resetComposer = useCallback(() => {
@@ -1016,7 +1042,7 @@ function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
             textareaRef={textareaRef}
             fileInputRef={fileInputRef}
             onPromptChange={setImagePrompt}
-            onImageCountChange={setImageCount}
+            onImageCountChange={handleImageCountChange}
             onImageSizeChange={setImageSize}
             onSubmit={handleSubmit}
             onPickReferenceImage={() => fileInputRef.current?.click()}

--- a/web/src/app/logs/page.tsx
+++ b/web/src/app/logs/page.tsx
@@ -20,6 +20,8 @@ const LogType = {
   Account: "account",
 } as const;
 
+type LogTypeValue = (typeof LogType)[keyof typeof LogType];
+
 const typeLabels: Record<string, string> = {
   [LogType.Call]: "调用日志",
   [LogType.Account]: "账号管理日志",
@@ -49,7 +51,7 @@ function getStatus(item: SystemLog) {
 
 function LogsContent() {
   const [items, setItems] = useState<SystemLog[]>([]);
-  const [type, setType] = useState(LogType.Call);
+  const [type, setType] = useState<LogTypeValue>(LogType.Call);
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
   const [detailLog, setDetailLog] = useState<SystemLog | null>(null);
@@ -101,7 +103,7 @@ function LogsContent() {
           <h1 className="text-2xl font-semibold tracking-tight">日志管理</h1>
         </div>
         <div className="flex flex-wrap gap-2">
-          <Select value={type} onValueChange={setType}>
+          <Select value={type} onValueChange={(value) => setType(value as LogTypeValue)}>
             <SelectTrigger className="h-10 w-[150px] rounded-xl border-stone-200 bg-white"><SelectValue /></SelectTrigger>
             <SelectContent>
               <SelectItem value={LogType.Call}>调用日志</SelectItem>

--- a/web/src/app/register/components/register-card.tsx
+++ b/web/src/app/register/components/register-card.tsx
@@ -52,6 +52,7 @@ export function RegisterCard() {
       ...(type === "moemail" ? { api_base: "", api_key: "", domain: [] } : {}),
       ...(type === "duckmail" ? { api_key: "", default_domain: "duckmail.sbs" } : {}),
       ...(type === "gptmail" ? { api_key: "", default_domain: "" } : {}),
+      ...(type === "yyds_mail" ? { api_base: "https://maliapi.215.im/v1", api_key: "", domain: [] } : {}),
     });
   };
 
@@ -169,14 +170,15 @@ export function RegisterCard() {
                             <SelectItem value="moemail">moemail</SelectItem>
                             <SelectItem value="duckmail">duckmail</SelectItem>
                             <SelectItem value="gptmail">gptmail(未测试)</SelectItem>
+                            <SelectItem value="yyds_mail">yyds_mail</SelectItem>
                           </SelectContent>
                         </Select>
                       </div>
-                      {type === "cloudflare_temp_email" || type === "moemail" ? (
+                      {type === "cloudflare_temp_email" || type === "moemail" || type === "yyds_mail" ? (
                         <>
                           <div className="space-y-2">
                             <label className="text-sm text-stone-700">API Base</label>
-                            <Input value={String(provider.api_base || "")} onChange={(event) => updateProvider(index, { api_base: event.target.value })} className="h-10 rounded-xl border-stone-200 bg-white" disabled={config.enabled} />
+                            <Input value={String(provider.api_base || "")} onChange={(event) => updateProvider(index, { api_base: event.target.value })} placeholder={type === "yyds_mail" ? "https://maliapi.215.im/v1" : ""} className="h-10 rounded-xl border-stone-200 bg-white" disabled={config.enabled} />
                           </div>
                           {type === "cloudflare_temp_email" ? (
                             <div className="space-y-2">
@@ -186,7 +188,7 @@ export function RegisterCard() {
                           ) : null}
                         </>
                       ) : null}
-                      {type === "tempmail_lol" || type === "moemail" || type === "duckmail" || type === "gptmail" ? (
+                      {type === "tempmail_lol" || type === "moemail" || type === "duckmail" || type === "gptmail" || type === "yyds_mail" ? (
                         <div className="space-y-2">
                           <label className="text-sm text-stone-700">API Key</label>
                           <Input value={String(provider.api_key || "")} onChange={(event) => updateProvider(index, { api_key: event.target.value })} className="h-10 rounded-xl border-stone-200 bg-white" disabled={config.enabled} />
@@ -200,10 +202,14 @@ export function RegisterCard() {
                       ) : null}
                     </div>
 
-                    {type === "tempmail_lol" || type === "cloudflare_temp_email" || type === "moemail" ? (
+                    {type === "tempmail_lol" || type === "cloudflare_temp_email" || type === "moemail" || type === "yyds_mail" ? (
                       <div className="space-y-2">
                         <label className="text-sm text-stone-700">Domain</label>
-                        <Textarea value={domains} onChange={(event) => updateProvider(index, { domain: event.target.value.split(/[\n,]/).map((item) => item.trim()).filter(Boolean) })} placeholder={type === "moemail" ? "每行一个域名" : "每行一个域名，留空则使用服务默认域名"} className="min-h-20 rounded-xl border-stone-200 bg-white font-mono text-xs" disabled={config.enabled} />
+                        <Textarea value={domains} onChange={(event) => updateProvider(index, { domain: event.target.value.split(/[\n,]/).map((item) => item.trim()).filter(Boolean) })} placeholder={type === "moemail" ? "每行一个域名" : type === "yyds_mail" ? "每行一个域名；*.example.com 表示使用 YYDS 泛子域接口" : "每行一个域名，留空则使用服务默认域名"} className="min-h-20 rounded-xl border-stone-200 bg-white font-mono text-xs" disabled={config.enabled} />
+                        <p className="text-xs leading-5 text-stone-500">
+                          域名必须先在对应邮箱服务商后台/API Key 权限里可用，不能随便填未配置的自有域名。
+                          {type === "yyds_mail" ? " YYDS Mail 支持填写共享域名；以 *. 开头时会调用 /v1/accounts/wildcard。" : null}
+                        </p>
                       </div>
                     ) : null}
                   </div>


### PR DESCRIPTION
## Summary

Fixes the first three actionable issues from the current issue list:

- Fixes #84 by remembering the last image count, keeping it after submit/new draft, allowing direct numeric input, and removing the previous hard `10` max in the image workspace UI.
- Adds #83 support for `yyds_mail` as a register mail provider using the public YYDS Mail API surface.
- Improves #82 by clarifying in the register UI that provider domains must already be available/configured in the corresponding mail provider/API key, and that arbitrary unconfigured custom domains cannot just be typed in.

Also fixes a small existing TypeScript issue in the logs page Select state so full `tsc --noEmit` passes locally.

## Details

### Image count UX

- Adds `chatgpt2api:image_last_count` localStorage persistence.
- Restores the last image count on page load.
- Stops resetting image count to `1` after submit/new draft.
- Sanitizes manual input to positive integer digits.
- Removes the `max="10"` input limit.

### YYDS Mail provider

- Adds `YydsMailProvider` with default API base `https://maliapi.215.im/v1`.
- Supports `X-API-Key` authentication.
- Creates mailboxes through:
  - `POST /accounts`
  - `POST /accounts/wildcard` when the configured domain starts with `*.`
- Reads messages through:
  - `GET /messages?address=...`
  - `GET /messages/{id}?address=...`
- Handles common YYDS response envelopes and temp-token style mailbox state.

## Testing

```bash
python3 -m py_compile services/register/mail_provider.py
git diff --check
cd web
npx tsc --noEmit
NEXT_PUBLIC_APP_VERSION="$(cat ../VERSION)" npm run build
```

All checks pass locally.

## Notes

- The YYDS Mail implementation follows the public docs/LLM integration surface at `https://vip.215.im/docs` and `https://maliapi.215.im/v1/llms.txt`.
- I did not include any API keys, runtime data, or local generated assets.
