### PR TITLE
fix(text-stream): token 失效时自动轮询切换账号

### DIFF
--- a/services/account_service.py
+++ b/services/account_service.py
@@ -278,13 +278,37 @@ class AccountService:
                 f"status={account.get('status') if account else 'unknown'}"
             )
 
-    def get_text_access_token(self) -> str:
+    def get_text_access_token(self, excluded_tokens: set[str] | None = None) -> str:
+        excluded = {self._clean_token(token) for token in (excluded_tokens or set()) if self._clean_token(token)}
         with self._lock:
-            for account in self._accounts:
-                status = self._clean_token(account.get("status"))
-                if status not in {"禁用", "异常"}:
-                    return self._clean_token(account.get("access_token"))
-        return ""
+            candidates = [
+                token
+                for account in self._accounts
+                if self._clean_token(account.get("status")) not in {"禁用", "异常", "限流"}
+                   and (token := self._clean_token(account.get("access_token")))
+                   and token not in excluded
+            ]
+            if not candidates:
+                return ""
+            access_token = candidates[self._index % len(candidates)]
+            self._index += 1
+            return access_token
+
+    def mark_text_used(self, access_token: str) -> None:
+        access_token = self._clean_token(access_token)
+        if not access_token:
+            return
+        with self._lock:
+            index = self._find_account_index(access_token)
+            if index < 0:
+                return
+            next_item = dict(self._accounts[index])
+            next_item["last_used_at"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            account = self._normalize_account(next_item)
+            if account is None:
+                return
+            self._accounts[index] = account
+            self._save_accounts()
 
     def remove_invalid_token(self, access_token: str, event: str) -> bool:
         if not config.auto_remove_invalid_accounts:

--- a/services/protocol/conversation.py
+++ b/services/protocol/conversation.py
@@ -451,12 +451,32 @@ def text_backend() -> OpenAIBackendAPI:
 
 
 def stream_text_deltas(backend: OpenAIBackendAPI, request: ConversationRequest) -> Iterator[str]:
-    for event in conversation_events(backend, messages=request.messages, model=request.model, prompt=request.prompt):
-        if event.get("type") != "conversation.delta":
-            continue
-        delta = str(event.get("delta") or "")
-        if delta:
-            yield delta
+    attempted_tokens: set[str] = set()
+    emitted = False
+    while True:
+        token = account_service.get_text_access_token(attempted_tokens)
+        if not token:
+            token = getattr(backend, "access_token", "")
+        if not token or token in attempted_tokens:
+            raise RuntimeError("no available text account")
+        attempted_tokens.add(token)
+        try:
+            active_backend = OpenAIBackendAPI(access_token=token)
+            for event in conversation_events(active_backend, messages=request.messages, model=request.model, prompt=request.prompt):
+                if event.get("type") != "conversation.delta":
+                    continue
+                delta = str(event.get("delta") or "")
+                if delta:
+                    emitted = True
+                    yield delta
+            account_service.mark_text_used(token)
+            return
+        except Exception as exc:
+            error_message = str(exc)
+            if not emitted and is_token_invalid_error(error_message):
+                account_service.remove_invalid_token(token, "text_stream")
+                continue
+            raise
 
 
 def collect_text(backend: OpenAIBackendAPI, request: ConversationRequest) -> str:


### PR DESCRIPTION
## 改动原因

之前 `stream_text_deltas` 使用单一的 backend/token,这个 token 一旦在流的中途失效,整个响应会直接以 502 返回客户端,**即使号池里还有其他可用账号也用不上**,无法做容错降级。

## 改动内容

- 通过 `get_text_access_token(excluded)` 在可用账号池中轮询取号
- 通过 `remove_invalid_token()` 自动剔除失效 token(由配置开关控制)
- **仅在尚未 yield 任何内容前**才换账号,避免拼接来自不同账号的 delta 导致输出错乱
- 通过 `mark_text_used()` 记录账号最后使用时间,方便号池按时间轮询

`account_service.get_text_access_token()` 增加 `excluded_tokens` 参数,允许调用方跳过已尝试过的 token,同时把 `限流` 状态加入过滤(原来只过滤 `禁用`、`异常`)。

## 测试方案

- [ ] 配置含 1 个无效 + 1 个有效账号的池,调用 `/v1/chat/completions` 流式接口 → 自动跳到有效账号正常输出
- [ ] 全部账号无效的池 → 干脆失败 `no available text account`(而不是中途 502)

🤖 Generated with [Claude Code](https://claude.com/claude-code)