### PR TITLE
feat(chat): chat completions 支持图片输入(多模态)

### DIFF
--- a/services/openai_backend_api.py
+++ b/services/openai_backend_api.py
@@ -198,13 +198,71 @@ class OpenAIBackendAPI:
         """把标准 chat messages 转成 web conversation 所需的 messages。"""
         conversation_messages = []
         for item in messages:
+            role = item.get("role", "user")
             content = item.get("content", "")
-            if not isinstance(content, str):
-                raise RuntimeError("only string message content is supported")
+            if isinstance(content, str):
+                conversation_messages.append({
+                    "id": new_uuid(),
+                    "author": {"role": role},
+                    "content": {"content_type": "text", "parts": [content]},
+                })
+                continue
+            if not isinstance(content, list):
+                raise RuntimeError("only string or list message content is supported")
+            text_parts: list[str] = []
+            image_inputs: list[tuple[bytes, str]] = []
+            for part in content:
+                if not isinstance(part, dict):
+                    continue
+                part_type = str(part.get("type") or "")
+                if part_type == "text":
+                    text_parts.append(str(part.get("text") or ""))
+                elif part_type == "image":
+                    data = part.get("data")
+                    mime = str(part.get("mime") or "image/png")
+                    if isinstance(data, (bytes, bytearray)):
+                        image_inputs.append((bytes(data), mime))
+            if not image_inputs:
+                conversation_messages.append({
+                    "id": new_uuid(),
+                    "author": {"role": role},
+                    "content": {"content_type": "text", "parts": ["".join(text_parts)]},
+                })
+                continue
+            if not self.access_token:
+                raise RuntimeError("authenticated upstream account required for image input")
+            uploaded: list[Dict[str, Any]] = []
+            for idx, (data, mime) in enumerate(image_inputs, start=1):
+                ext_part = mime.split("/", 1)[1].split("+")[0] if "/" in mime else "png"
+                extension = "jpg" if ext_part == "jpeg" else (ext_part or "png")
+                b64 = base64.b64encode(data).decode("ascii")
+                uploaded.append(self._upload_image(f"data:{mime};base64,{b64}", f"image_{idx}.{extension}"))
+            parts: list[Any] = []
+            for ref in uploaded:
+                parts.append({
+                    "content_type": "image_asset_pointer",
+                    "asset_pointer": f"file-service://{ref['file_id']}",
+                    "width": ref["width"],
+                    "height": ref["height"],
+                    "size_bytes": ref["file_size"],
+                })
+            text = "".join(text_parts)
+            if text:
+                parts.append(text)
             conversation_messages.append({
                 "id": new_uuid(),
-                "author": {"role": item.get("role", "user")},
-                "content": {"content_type": "text", "parts": [content]},
+                "author": {"role": role},
+                "content": {"content_type": "multimodal_text", "parts": parts},
+                "metadata": {
+                    "attachments": [{
+                        "id": ref["file_id"],
+                        "mimeType": ref["mime_type"],
+                        "name": ref["file_name"],
+                        "size": ref["file_size"],
+                        "width": ref["width"],
+                        "height": ref["height"],
+                    } for ref in uploaded],
+                },
             })
         return conversation_messages
 

--- a/services/protocol/conversation.py
+++ b/services/protocol/conversation.py
@@ -14,7 +14,7 @@ import tiktoken
 from services.account_service import account_service
 from services.config import config
 from services.openai_backend_api import OpenAIBackendAPI
-from utils.helper import IMAGE_MODELS
+from utils.helper import IMAGE_MODELS, extract_image_from_message_content
 from utils.log import logger
 
 
@@ -98,8 +98,30 @@ def normalize_messages(messages: object, system: Any = None) -> list[dict[str, A
         normalized.append({"role": "system", "content": system_text})
     if isinstance(messages, list):
         for message in messages:
-            if isinstance(message, dict):
-                normalized.append({"role": message.get("role", "user"), "content": message_text(message.get("content", ""))})
+            if not isinstance(message, dict):
+                continue
+            role = message.get("role", "user")
+            content = message.get("content", "")
+            text = message_text(content)
+            images: list[tuple[bytes, str]] = []
+            if role == "user":
+                images.extend(extract_image_from_message_content(content))
+                if isinstance(content, list):
+                    for part in content:
+                        if not isinstance(part, dict) or part.get("type") != "image":
+                            continue
+                        data = part.get("data")
+                        if isinstance(data, (bytes, bytearray)):
+                            images.append((bytes(data), str(part.get("mime") or "image/png")))
+            if images:
+                parts: list[Any] = []
+                if text:
+                    parts.append({"type": "text", "text": text})
+                for data, mime in images:
+                    parts.append({"type": "image", "data": data, "mime": mime})
+                normalized.append({"role": role, "content": parts})
+            else:
+                normalized.append({"role": role, "content": text})
     return normalized
 
 


### PR DESCRIPTION
## 改动原因

OpenAI 官方 chat completions 接受 list 形式的 `content`(混合 text 和 image),但当前实现遇到非字符串 `content` 时直接报 `"only string message content is supported"`,客户端发来的多模态请求(例如要求模型描述或分析一张图片)无法转发到上游。

## 改动内容

- `_chat_messages_to_conversation_messages` 接受 list 形式 content,支持 `{"type": "text", ...}` 和 `{"type": "image", "data": bytes, "mime": str}` 两种类型
- 图片通过 `_upload_image()` 上传到 ChatGPT,得到 `file-service://` 引用,组装成上游 `multimodal_text` payload 和 attachment 元数据
- `normalize_messages` 保留 user 消息的多模态 content,下游可读取到完整的 text 和 image
- 纯文本路径行为不变

## 测试方案

- [ ] 纯文本请求行为不变(回归)
- [ ] `content: [{"type": "text", ...}, {"type": "image", "data": ..., "mime": "image/png"}]` 请求 → 上游接收到 multimodal 格式
- [ ] 未授权上游账号时返回明确错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)