### PR TITLE
feat(image-task): 异步图片任务补全调用日志

### DIFF
--- a/services/image_task_service.py
+++ b/services/image_task_service.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from services.config import DATA_DIR, config
+from services.log_service import LOG_TYPE_CALL, log_service
 from services.protocol import openai_v1_image_edit, openai_v1_image_generations
 
 TASK_STATUS_QUEUED = "queued"
@@ -47,6 +48,16 @@ def _owner_id(identity: dict[str, object]) -> str:
 
 def _task_key(owner_id: str, task_id: str) -> str:
     return f"{owner_id}:{task_id}"
+
+
+def _collect_image_urls(data: list[Any]) -> list[str]:
+    urls: list[str] = []
+    for item in data:
+        if isinstance(item, dict):
+            url = item.get("url")
+            if isinstance(url, str) and url:
+                urls.append(url)
+    return urls
 
 
 def _public_task(task: dict[str, Any]) -> dict[str, Any]:
@@ -194,14 +205,22 @@ class ImageTaskService:
         if should_start:
             thread = threading.Thread(
                 target=self._run_task,
-                args=(key, mode, payload),
+                args=(key, mode, payload, dict(identity), _clean(payload.get("model"), "gpt-image-2")),
                 name=f"image-task-{task_id[:16]}",
                 daemon=True,
             )
             thread.start()
         return _public_task(task)
 
-    def _run_task(self, key: str, mode: str, payload: dict[str, Any]) -> None:
+    def _run_task(
+        self,
+        key: str,
+        mode: str,
+        payload: dict[str, Any],
+        identity: dict[str, object],
+        model: str,
+    ) -> None:
+        started = time.time()
         self._update_task(key, status=TASK_STATUS_RUNNING, error="")
         try:
             handler = self.edit_handler if mode == "edit" else self.generation_handler
@@ -213,8 +232,45 @@ class ImageTaskService:
                 message = _clean(result.get("message")) or "image task returned no image data"
                 raise RuntimeError(message)
             self._update_task(key, status=TASK_STATUS_SUCCESS, data=data, error="")
+            self._log_call(identity, mode, model, started, "调用完成", urls=_collect_image_urls(data))
         except Exception as exc:
-            self._update_task(key, status=TASK_STATUS_ERROR, error=str(exc) or "image task failed", data=[])
+            error_message = str(exc) or "image task failed"
+            self._update_task(key, status=TASK_STATUS_ERROR, error=error_message, data=[])
+            self._log_call(identity, mode, model, started, "调用失败", status="failed", error=error_message)
+
+    def _log_call(
+        self,
+        identity: dict[str, object],
+        mode: str,
+        model: str,
+        started: float,
+        suffix: str,
+        *,
+        status: str = "success",
+        error: str = "",
+        urls: list[str] | None = None,
+    ) -> None:
+        endpoint = "/v1/images/edits" if mode == "edit" else "/v1/images/generations"
+        summary_prefix = "图生图" if mode == "edit" else "文生图"
+        detail = {
+            "key_id": identity.get("id"),
+            "key_name": identity.get("name"),
+            "role": identity.get("role"),
+            "endpoint": endpoint,
+            "model": model,
+            "started_at": datetime.fromtimestamp(started).strftime("%Y-%m-%d %H:%M:%S"),
+            "ended_at": _now_iso(),
+            "duration_ms": int((time.time() - started) * 1000),
+            "status": status,
+        }
+        if error:
+            detail["error"] = error
+        if urls:
+            detail["urls"] = list(dict.fromkeys(urls))
+        try:
+            log_service.add(LOG_TYPE_CALL, f"{summary_prefix}{suffix}", detail)
+        except Exception:
+            pass
 
     def _update_task(self, key: str, **updates: Any) -> None:
         with self._lock:


### PR DESCRIPTION
## 改动原因

同步图片接口(`/v1/images/generations`、`/v1/images/edits`)通过 `LoggedCall` 在每次调用时写入一条 `call` 类型日志。**异步**图片任务绕开这条路径,执行完成后没有日志记录,导致:

- 调用日志面板看不到异步任务的记录
- 无法按 key 审计用量
- 失败的异步任务无法在日志中定位

## 改动内容

- `ImageTaskService` 新增 `_log_call()`,异步任务结束时通过 `log_service` 写入与同步接口格式一致的 `LOG_TYPE_CALL` 日志
- 日志字段包括: key id / name / role、endpoint、model、started_at / ended_at / duration_ms、status (success / failed)、error、生成的图片 URL 列表
- `_run_task` 增加 identity 和 model 参数,用于日志归属
- 任务生命周期行为不变

## 测试方案

- [ ] 网页 UI 触发一个异步图片任务 → 调用日志页出现对应记录
- [ ] 触发一个失败的异步任务 → 日志显示 status: failed 和错误信息
- [ ] 同步图片接口不受影响(回归)

🤖 Generated with [Claude Code](https://claude.com/claude-code)