### PR TITLE
fix(register): respect live config updates in running runner

### DIFF
--- a/services/register_service.py
+++ b/services/register_service.py
@@ -156,12 +156,12 @@ class RegisterService:
             self._save()
 
     def _run(self) -> None:
-        cfg = self.get()
-        threads = int(cfg["threads"])
+        threads = int(self.get()["threads"])
         submitted, done, success, fail = 0, 0, 0, 0
         with ThreadPoolExecutor(max_workers=threads) as executor:
             futures = set()
             while True:
+                cfg = self.get()
                 while self.get()["enabled"] and not self._target_reached(cfg, submitted) and len(futures) < threads:
                     submitted += 1
                     futures.add(executor.submit(openai_register.worker, submitted))


### PR DESCRIPTION
在前端依次「停止注册机 → 修改配置 → 启动注册机」之后，新配置没有生效，仍然按旧配置在跑。

原因是点「启动」时旧的注册任务还没完全退出（可能正在等当前批账号注册完成），界面上虽然又开始了，但底层是同一个旧任务在继续跑，它读的是上一次启动时的配置快照。

具体表现：把模式从「按账号数」切到「按剩余额度」、目标账号从 10 改到 20，前端配置都已保存，日志里仍然按旧的「按账号数 / 目标=10」做判断。

修复：让运行中的注册任务在每次循环里重新读一次配置，而不是只在启动时读一次。开销可忽略。

具体在 services/register_service.py 的 _run()：把 cfg = self.get() 从函数开头移到外层 while 循环内。这样即使 start() 因为旧 runner is_alive 走了快路径（services/register_service.py:78）只翻 enabled、复用线程，下一轮循环也能读到最新的 mode / target_quota / target_available / check_interval。