### PR TITLE
feat: 新增图片管理标签功能

### DIFF
--- a/api/system.py
+++ b/api/system.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, ConfigDict
 from api.support import require_admin, require_identity, resolve_image_base_url
 from services.config import config
 from services.image_service import delete_images, get_thumbnail_response, list_images
+from services.image_tags_service import delete_tag, get_all_tags, set_tags
 from services.log_service import log_service
 from services.proxy_service import test_proxy
 
@@ -24,6 +25,11 @@ class ImageDeleteRequest(BaseModel):
     start_date: str = ""
     end_date: str = ""
     all_matching: bool = False
+
+
+class ImageTagsRequest(BaseModel):
+    path: str
+    tags: list[str]
 
 
 def create_router(app_version: str) -> APIRouter:
@@ -89,5 +95,25 @@ def create_router(app_version: str) -> APIRouter:
             "backend": storage.get_backend_info(),
             "health": storage.health_check(),
         }
+
+    @router.get("/api/images/tags")
+    async def list_image_tags(authorization: str | None = Header(default=None)):
+        require_admin(authorization)
+        return {"tags": get_all_tags()}
+
+    @router.post("/api/images/tags")
+    async def update_image_tags(body: ImageTagsRequest, authorization: str | None = Header(default=None)):
+        require_admin(authorization)
+        rel = body.path.strip().lstrip("/")
+        if not rel:
+            raise HTTPException(status_code=400, detail={"error": "path is required"})
+        tags = set_tags(rel, body.tags)
+        return {"ok": True, "tags": tags}
+
+    @router.delete("/api/images/tags/{tag}")
+    async def delete_image_tag(tag: str, authorization: str | None = Header(default=None)):
+        require_admin(authorization)
+        count = delete_tag(tag)
+        return {"ok": True, "removed_from": count}
 
     return router

--- a/services/image_service.py
+++ b/services/image_service.py
@@ -8,6 +8,7 @@ from fastapi.responses import FileResponse
 from PIL import Image, ImageOps
 
 from services.config import config
+from services.image_tags_service import load_tags, remove_tags
 
 THUMBNAIL_SIZE = (320, 320)
 
@@ -116,6 +117,7 @@ def _image_items(start_date: str = "", end_date: str = "") -> list[dict[str, obj
             continue
         dimensions = _image_dimensions(path)
         items.append({
+            "rel": rel,
             "path": rel,
             "name": path.name,
             "date": day,
@@ -130,11 +132,13 @@ def _image_items(start_date: str = "", end_date: str = "") -> list[dict[str, obj
 def list_images(base_url: str, start_date: str = "", end_date: str = "") -> dict[str, object]:
     config.cleanup_old_images()
     cleanup_image_thumbnails()
+    all_tags = load_tags()
     items = [
         {
             **item,
             "url": f"{base_url.rstrip('/')}/images/{item['path']}",
             "thumbnail_url": thumbnail_url(base_url, str(item["path"])),
+            "tags": all_tags.get(str(item["path"]), []),
         }
         for item in _image_items(start_date, end_date)
     ]
@@ -159,6 +163,7 @@ def delete_images(paths: list[str] | None = None, start_date: str = "", end_date
             for thumbnail in (_thumbnail_path(item), config.image_thumbnails_dir / _safe_relative_path(item)):
                 if thumbnail.is_file():
                     thumbnail.unlink()
+            remove_tags(item)
             removed += 1
     _cleanup_empty_dirs(root)
     _cleanup_empty_dirs(config.image_thumbnails_dir)

--- a/services/image_tags_service.py
+++ b/services/image_tags_service.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from services.config import DATA_DIR
+
+TAGS_FILE = DATA_DIR / "image_tags.json"
+
+
+def _ensure_file() -> None:
+    TAGS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    if not TAGS_FILE.exists():
+        TAGS_FILE.write_text("{}", encoding="utf-8")
+
+
+def load_tags() -> dict[str, list[str]]:
+    _ensure_file()
+    try:
+        data = json.loads(TAGS_FILE.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def save_tags(data: dict[str, list[str]]) -> None:
+    _ensure_file()
+    TAGS_FILE.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def get_tags(image_rel: str) -> list[str]:
+    return load_tags().get(image_rel, [])
+
+
+def set_tags(image_rel: str, tags: list[str]) -> list[str]:
+    data = load_tags()
+    cleaned = list(dict.fromkeys(t.strip() for t in tags if t.strip()))
+    if cleaned:
+        data[image_rel] = cleaned
+    else:
+        data.pop(image_rel, None)
+    save_tags(data)
+    return cleaned
+
+
+def remove_tags(image_rel: str) -> None:
+    data = load_tags()
+    if data.pop(image_rel, None) is not None:
+        save_tags(data)
+
+
+def delete_tag(tag: str) -> int:
+    """从所有图片中删除指定标签，返回受影响的图片数。"""
+    data = load_tags()
+    count = 0
+    for rel in list(data):
+        if tag in data[rel]:
+            data[rel] = [t for t in data[rel] if t != tag]
+            if not data[rel]:
+                del data[rel]
+            count += 1
+    if count > 0:
+        save_tags(data)
+    return count
+
+
+def get_all_tags() -> list[str]:
+    data = load_tags()
+    seen: set[str] = set()
+    result: list[str] = []
+    for tags in data.values():
+        for t in tags:
+            if t not in seen:
+                seen.add(t)
+                result.append(t)
+    return result

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -131,3 +131,8 @@
     display: none;
   }
 }
+
+@keyframes grow {
+  from { transform: scaleX(0); }
+  to { transform: scaleX(1); }
+}

--- a/web/src/app/image-manager/page.tsx
+++ b/web/src/app/image-manager/page.tsx
@@ -1,29 +1,59 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import { CalendarDays, ChevronLeft, ChevronRight, Copy, ImageIcon, LoaderCircle, Maximize2, RefreshCw, Search, Trash2 } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { CalendarDays, ChevronLeft, ChevronRight, Copy, ImageIcon, LoaderCircle, Maximize2, Plus, RefreshCw, Search, Tag, Trash2, X } from "lucide-react";
 import { toast } from "sonner";
 
 import { DateRangeFilter } from "@/components/date-range-filter";
 import { ImageLightbox } from "@/components/image-lightbox";
-import { ImageThumbnail } from "@/components/image-thumbnail";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { deleteManagedImages, fetchManagedImages, type ManagedImage } from "@/lib/api";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { deleteImageTag, deleteManagedImages, fetchImageTags, fetchManagedImages, setImageTags, type ManagedImage } from "@/lib/api";
 import { useAuthGuard } from "@/lib/use-auth-guard";
+
+const LONG_PRESS_MS = 800;
 
 function formatSize(size: number) {
   return size > 1024 * 1024 ? `${(size / 1024 / 1024).toFixed(2)} MB` : `${Math.ceil(size / 1024)} KB`;
 }
 
 function imageKey(item: ManagedImage) {
-  return item.path || item.url;
+  return item.rel || item.url;
 }
 
-function imageDimensions(item: ManagedImage) {
-  return item.width && item.height ? `${item.width} x ${item.height}` : "-";
+function useLongPress(onLongPress: () => void, ms = LONG_PRESS_MS) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const activeRef = useRef(false);
+
+  const start = useCallback((e: React.MouseEvent | React.TouchEvent) => {
+    activeRef.current = true;
+    timerRef.current = setTimeout(() => {
+      if (activeRef.current) {
+        onLongPress();
+      }
+    }, ms);
+  }, [onLongPress, ms]);
+
+  const stop = useCallback(() => {
+    activeRef.current = false;
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  return {
+    onMouseDown: start,
+    onMouseUp: stop,
+    onMouseLeave: stop,
+    onTouchStart: start,
+    onTouchEnd: stop,
+  };
 }
 
 function ImageManagerContent() {
@@ -34,19 +64,31 @@ function ImageManagerContent() {
   const [lightboxOpen, setLightboxOpen] = useState(false);
   const [page, setPage] = useState(1);
   const [isLoading, setIsLoading] = useState(true);
+  const [deleteTarget, setDeleteTarget] = useState<ManagedImage | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [allTags, setAllTags] = useState<string[]>([]);
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [tagEditTarget, setTagEditTarget] = useState<ManagedImage | null>(null);
+  const [tagInput, setTagInput] = useState("");
+  const [dialogVisible, setDialogVisible] = useState(false);
+  const deleteTargetRef = useRef<ManagedImage | null>(null);
   const [selectedPaths, setSelectedPaths] = useState<string[]>([]);
   const [deleteMode, setDeleteMode] = useState<"selected" | "filtered" | null>(null);
-  const lightboxImages = items.map((item) => ({
-    id: imageKey(item),
+
+  const filteredItems = selectedTags.length > 0
+    ? items.filter((item) => selectedTags.every((t) => (item.tags ?? []).includes(t)))
+    : items;
+
+  const lightboxImages = filteredItems.map((item) => ({
+    id: item.name,
     src: item.url,
     sizeLabel: formatSize(item.size),
-    dimensions: imageDimensions(item),
+    dimensions: item.width && item.height ? `${item.width} x ${item.height}` : undefined,
   }));
   const pageSize = 12;
-  const pageCount = Math.max(1, Math.ceil(items.length / pageSize));
+  const pageCount = Math.max(1, Math.ceil(filteredItems.length / pageSize));
   const safePage = Math.min(page, pageCount);
-  const currentRows = items.slice((safePage - 1) * pageSize, safePage * pageSize);
+  const currentRows = filteredItems.slice((safePage - 1) * pageSize, safePage * pageSize);
   const selectedSet = useMemo(() => new Set(selectedPaths), [selectedPaths]);
   const selectedCount = deleteMode === "filtered" ? items.length : selectedPaths.length;
   const currentPageSelected = currentRows.length > 0 && currentRows.every((item) => selectedSet.has(imageKey(item)));
@@ -55,8 +97,12 @@ function ImageManagerContent() {
   const loadImages = async () => {
     setIsLoading(true);
     try {
-      const data = await fetchManagedImages({ start_date: startDate, end_date: endDate });
+      const [data, tagsData] = await Promise.all([
+        fetchManagedImages({ start_date: startDate, end_date: endDate }),
+        fetchImageTags(),
+      ]);
       setItems(data.items);
+      setAllTags(tagsData.tags);
       setSelectedPaths((current) => current.filter((path) => data.items.some((item) => imageKey(item) === path)));
       setPage(1);
     } catch (error) {
@@ -66,9 +112,104 @@ function ImageManagerContent() {
     }
   };
 
+  const closeDialog = useCallback(() => {
+    setDialogVisible(false);
+    setTimeout(() => setDeleteTarget(null), 200);
+  }, []);
+
+  const openDeleteDialog = useCallback((item: ManagedImage) => {
+    deleteTargetRef.current = item;
+    setDeleteTarget(item);
+    setDialogVisible(true);
+  }, []);
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    setIsDeleting(true);
+    try {
+      await deleteManagedImages({ paths: [deleteTarget.rel] });
+      setItems((prev) => prev.filter((item) => item.rel !== deleteTarget.rel));
+      setSelectedPaths((prev) => prev.filter((p) => p !== imageKey(deleteTarget)));
+      toast.success("图片已删除");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "删除失败");
+    } finally {
+      setIsDeleting(false);
+      closeDialog();
+    }
+  };
+
+  const handleSetTags = async (item: ManagedImage, tags: string[]) => {
+    try {
+      const result = await setImageTags(item.rel, tags);
+      setItems((prev) => prev.map((i) => i.rel === item.rel ? { ...i, tags: result.tags } : i));
+      const tagsData = await fetchImageTags();
+      setAllTags(tagsData.tags);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "设置标签失败");
+    }
+  };
+
+  const handleAddTag = (item: ManagedImage) => {
+    const tag = tagInput.trim();
+    if (!tag) return;
+    const current = item.tags ?? [];
+    if (current.includes(tag)) {
+      toast.error("标签已存在");
+      return;
+    }
+    void handleSetTags(item, [...current, tag]);
+    setTagInput("");
+  };
+
+  const handleRemoveTag = (item: ManagedImage, tag: string) => {
+    void handleSetTags(item, (item.tags ?? []).filter((t) => t !== tag));
+  };
+
+  const toggleFilterTag = (tag: string) => {
+    setSelectedTags((prev) => prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]);
+    setPage(1);
+  };
+
+  const [pressingTag, setPressingTag] = useState<string | null>(null);
+  const pressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [tagDeleteTarget, setTagDeleteTarget] = useState<string | null>(null);
+
+  const handleDeleteTag = async (tag: string) => {
+    try {
+      const result = await deleteImageTag(tag);
+      setAllTags((prev) => prev.filter((t) => t !== tag));
+      setSelectedTags((prev) => prev.filter((t) => t !== tag));
+      setItems((prev) => prev.map((item) => ({
+        ...item,
+        tags: (item.tags ?? []).filter((t) => t !== tag),
+      })));
+      toast.success(`标签"${tag}"已删除，影响 ${result.removed_from} 张图片`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "删除标签失败");
+    }
+  };
+
+  const startTagPress = useCallback((tag: string) => {
+    setPressingTag(tag);
+    pressTimerRef.current = setTimeout(() => {
+      setPressingTag(null);
+      setTagDeleteTarget(tag);
+    }, LONG_PRESS_MS);
+  }, []);
+
+  const stopTagPress = useCallback(() => {
+    setPressingTag(null);
+    if (pressTimerRef.current) {
+      clearTimeout(pressTimerRef.current);
+      pressTimerRef.current = null;
+    }
+  }, []);
+
   const clearFilters = () => {
     setStartDate("");
     setEndDate("");
+    setSelectedTags([]);
   };
 
   const togglePaths = (paths: string[], checked: boolean) => {
@@ -118,12 +259,61 @@ function ImageManagerContent() {
         </div>
       </div>
 
+      {allTags.length > 0 ? (
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-xs font-medium text-stone-500">
+            <Tag className="mr-1 inline size-3.5" />
+            标签筛选：
+          </span>
+          {allTags.map((tag) => {
+            const isPressing = pressingTag === tag;
+            return (
+              <span
+                key={tag}
+                className="relative inline-flex items-center"
+                onMouseDown={() => startTagPress(tag)}
+                onMouseUp={stopTagPress}
+                onMouseLeave={stopTagPress}
+                onTouchStart={() => startTagPress(tag)}
+                onTouchEnd={stopTagPress}
+              >
+                <button
+                  type="button"
+                  onClick={() => toggleFilterTag(tag)}
+                >
+                  <Badge
+                    variant={selectedTags.includes(tag) ? "default" : "outline"}
+                    className={`cursor-pointer rounded-md transition-all hover:opacity-80 ${isPressing ? "ring-2 ring-red-400 ring-offset-1" : ""}`}
+                  >
+                    {tag}
+                  </Badge>
+                </button>
+                {isPressing ? (
+                  <span className="pointer-events-none absolute inset-0 overflow-hidden rounded-md">
+                    <span className="absolute inset-0 animate-[grow_800ms_linear_forwards] rounded-md bg-red-400/20" />
+                  </span>
+                ) : null}
+              </span>
+            );
+          })}
+          {selectedTags.length > 0 ? (
+            <button type="button" onClick={() => setSelectedTags([])}>
+              <Badge variant="secondary" className="cursor-pointer rounded-md">
+                <X className="mr-0.5 size-3" />
+                清除
+              </Badge>
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+
       <Card className="rounded-2xl border-white/80 bg-white/90 shadow-sm">
         <CardContent className="p-0">
           <div className="flex flex-wrap items-center justify-between gap-3 border-b border-stone-100 px-5 py-4">
             <div className="flex flex-wrap items-center gap-3 text-sm text-stone-600">
               <ImageIcon className="size-4" />
-              共 {items.length} 张
+              共 {filteredItems.length} 张
+              {selectedTags.length > 0 ? <span className="text-stone-400">（筛选自 {items.length} 张）</span> : null}
               <label className="flex items-center gap-2">
                 <Checkbox checked={currentPageSelected} onCheckedChange={(checked) => togglePaths(currentRows.map(imageKey), Boolean(checked))} />
                 本页全选
@@ -150,29 +340,45 @@ function ImageManagerContent() {
           </div>
           <div className="grid gap-0 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
             {currentRows.map((item) => {
-              const imageIndex = items.findIndex((row) => row.url === item.url);
+              const imageIndex = filteredItems.findIndex((row) => row.url === item.url);
               return (
-              <div key={item.url} className="group border-r border-b border-stone-100 p-4 transition hover:bg-stone-50">
-                <button
-                  type="button"
-                  className="relative block aspect-square w-full cursor-zoom-in overflow-hidden rounded-lg bg-stone-100 text-left"
-                  onClick={() => {
-                    setLightboxIndex(imageIndex);
-                    setLightboxOpen(true);
-                  }}
-                >
-                  <ImageThumbnail
-                    src={item.url}
-                    thumbnailSrc={item.thumbnail_url}
-                    alt={item.name}
-                    className="h-full w-full"
-                    imageClassName="transition group-hover:scale-[1.02]"
-                  />
-                  <span className="absolute right-2 bottom-2 rounded-full bg-black/50 p-2 text-white opacity-0 transition group-hover:opacity-100">
-                    <Maximize2 className="size-4" />
-                  </span>
-                </button>
-                <div className="mt-3 space-y-1 text-xs text-stone-500">
+              <div key={item.rel} className="group border-r border-b border-stone-100 p-4 transition hover:bg-stone-50">
+                <div className="relative">
+                  <button
+                    type="button"
+                    className="relative block aspect-square w-full cursor-zoom-in overflow-hidden rounded-lg bg-stone-100 text-left"
+                    onClick={() => {
+                      setLightboxIndex(imageIndex);
+                      setLightboxOpen(true);
+                    }}
+                  >
+                    <img
+                      src={item.thumbnail_url || item.url}
+                      alt={item.name}
+                      className="h-full w-full object-cover transition group-hover:scale-[1.02]"
+                      onError={(event) => {
+                        if (event.currentTarget.src !== item.url) {
+                          event.currentTarget.src = item.url;
+                        }
+                      }}
+                    />
+                    <span className="absolute right-2 bottom-2 rounded-full bg-black/50 p-2 text-white opacity-100 transition sm:opacity-0 sm:group-hover:opacity-100">
+                      <Maximize2 className="size-4" />
+                    </span>
+                  </button>
+                  <button
+                    type="button"
+                    className="absolute top-2 right-2 z-10 inline-flex size-7 items-center justify-center rounded-full bg-black/50 text-white opacity-100 transition hover:bg-red-600 sm:opacity-0 sm:group-hover:opacity-100"
+                    title="删除图片"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      openDeleteDialog(item);
+                    }}
+                  >
+                    <Trash2 className="size-3.5" />
+                  </button>
+                </div>
+                <div className="mt-3 space-y-2 text-xs text-stone-500">
                   <div className="flex items-center justify-between gap-2">
                     <div className="flex items-center gap-1 font-medium text-stone-700">
                       <CalendarDays className="size-3.5" />
@@ -195,14 +401,84 @@ function ImageManagerContent() {
                   </div>
                   <div className="flex items-center justify-between gap-2">
                     <span>{formatSize(item.size)}</span>
-                    <span>{imageDimensions(item)}</span>
+                    <span>{item.width && item.height ? `${item.width} x ${item.height}` : "-"}</span>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-1">
+                    {(item.tags ?? []).map((tag) => (
+                      <Badge key={tag} variant="secondary" className="gap-0.5 rounded-md py-0 pr-0.5 text-[10px]">
+                        {tag}
+                        <button
+                          type="button"
+                          className="inline-flex size-3.5 items-center justify-center rounded-full hover:bg-stone-300"
+                          onClick={() => handleRemoveTag(item, tag)}
+                        >
+                          <X className="size-2.5" />
+                        </button>
+                      </Badge>
+                    ))}
+                    <Popover open={tagEditTarget?.rel === item.rel} onOpenChange={(open) => { setTagEditTarget(open ? item : null); setTagInput(""); }}>
+                      <PopoverTrigger asChild>
+                        <button
+                          type="button"
+                          className="inline-flex size-5 items-center justify-center rounded-full border border-dashed border-stone-300 text-stone-400 hover:border-stone-500 hover:text-stone-600"
+                          title="添加标签"
+                        >
+                          <Plus className="size-3" />
+                        </button>
+                      </PopoverTrigger>
+                      <PopoverContent align="start" className="w-56 p-2">
+                        <div className="space-y-2">
+                          <div className="text-xs font-medium text-stone-500">添加标签</div>
+                          <div className="flex gap-1">
+                            <Input
+                              value={tagInput}
+                              onChange={(e) => setTagInput(e.target.value)}
+                              placeholder="输入标签名"
+                              className="h-8 text-xs"
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter") {
+                                  e.preventDefault();
+                                  handleAddTag(item);
+                                }
+                              }}
+                            />
+                            <Button
+                              size="icon"
+                              variant="outline"
+                              className="size-8 shrink-0"
+                              onClick={() => handleAddTag(item)}
+                            >
+                              <Plus className="size-3.5" />
+                            </Button>
+                          </div>
+                          {allTags.filter((t) => !(item.tags ?? []).includes(t)).length > 0 ? (
+                            <div className="flex flex-wrap gap-1 border-t border-stone-100 pt-2">
+                              {allTags.filter((t) => !(item.tags ?? []).includes(t)).map((tag) => (
+                                <button
+                                  key={tag}
+                                  type="button"
+                                  onClick={() => {
+                                    void handleSetTags(item, [...(item.tags ?? []), tag]);
+                                    setTagEditTarget(null);
+                                  }}
+                                >
+                                  <Badge variant="outline" className="cursor-pointer rounded-md text-[10px] hover:bg-stone-100">
+                                    {tag}
+                                  </Badge>
+                                </button>
+                              ))}
+                            </div>
+                          ) : null}
+                        </div>
+                      </PopoverContent>
+                    </Popover>
                   </div>
                 </div>
               </div>
             )})}
           </div>
           <div className="flex items-center justify-end gap-2 border-t border-stone-100 px-4 py-3 text-sm text-stone-500">
-            <span>第 {safePage} / {pageCount} 页，共 {items.length} 张</span>
+            <span>第 {safePage} / {pageCount} 页，共 {filteredItems.length} 张</span>
             <Button variant="outline" size="icon" className="size-9 rounded-lg border-stone-200 bg-white" disabled={safePage <= 1} onClick={() => setPage((value) => Math.max(1, value - 1))}>
               <ChevronLeft className="size-4" />
             </Button>
@@ -210,9 +486,45 @@ function ImageManagerContent() {
               <ChevronRight className="size-4" />
             </Button>
           </div>
-          {!isLoading && items.length === 0 ? <div className="px-6 py-14 text-center text-sm text-stone-500">没有找到图片</div> : null}
+          {!isLoading && filteredItems.length === 0 ? <div className="px-6 py-14 text-center text-sm text-stone-500">没有找到图片</div> : null}
         </CardContent>
       </Card>
+
+      <Dialog open={dialogVisible} onOpenChange={(open) => { if (!open) closeDialog(); }}>
+        <DialogContent className="max-w-sm overflow-hidden rounded-2xl">
+          <DialogHeader>
+            <DialogTitle className="pr-8">确认删除</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-stone-600">
+            确定要删除这张图片吗？此操作不可恢复。
+          </p>
+          {deleteTarget ? (
+            <div className="flex items-center gap-3 overflow-hidden rounded-xl border border-stone-200 bg-stone-50 p-3">
+              <img
+                src={deleteTarget.thumbnail_url || deleteTarget.url}
+                alt=""
+                className="size-16 shrink-0 rounded-lg object-cover"
+                onError={(e) => { if (e.currentTarget.src !== deleteTarget.url) e.currentTarget.src = deleteTarget.url; }}
+              />
+              <div className="min-w-0 overflow-hidden text-xs text-stone-500">
+                <div className="truncate font-medium text-stone-700">{deleteTarget.name}</div>
+                <div className="truncate">{deleteTarget.created_at}</div>
+                <div>{formatSize(deleteTarget.size)}</div>
+              </div>
+            </div>
+          ) : null}
+          <DialogFooter>
+            <Button variant="outline" onClick={closeDialog} className="rounded-xl">
+              取消
+            </Button>
+            <Button variant="destructive" onClick={() => void handleDelete()} disabled={isDeleting} className="rounded-xl">
+              {isDeleting ? <LoaderCircle className="mr-1 size-4 animate-spin" /> : <Trash2 className="mr-1 size-4" />}
+              删除
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
       <ImageLightbox
         images={lightboxImages}
         currentIndex={lightboxIndex}
@@ -224,16 +536,41 @@ function ImageManagerContent() {
         <DialogContent showCloseButton={false} className="rounded-2xl p-6">
           <DialogHeader className="gap-2">
             <DialogTitle>{deleteMode === "filtered" ? "删除匹配日期的图片" : "删除所选图片"}</DialogTitle>
-            <DialogDescription className="text-sm leading-6">
-              确认删除 {selectedCount} 张图片吗？删除后无法恢复。
-            </DialogDescription>
           </DialogHeader>
+          <p className="text-sm text-stone-600">
+            确认删除 {selectedCount} 张图片吗？删除后无法恢复。
+          </p>
           <DialogFooter>
             <Button variant="outline" className="rounded-xl" onClick={() => setDeleteMode(null)} disabled={isDeleting}>
               取消
             </Button>
             <Button className="rounded-xl bg-rose-600 text-white hover:bg-rose-700" onClick={() => void confirmDelete()} disabled={isDeleting || selectedCount === 0}>
               {isDeleting ? <LoaderCircle className="size-4 animate-spin" /> : null}
+              确认删除
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <Dialog open={Boolean(tagDeleteTarget)} onOpenChange={(open) => { if (!open) setTagDeleteTarget(null); }}>
+        <DialogContent className="max-w-sm rounded-2xl">
+          <DialogHeader>
+            <DialogTitle>删除标签</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-stone-600">
+            确定要删除标签 <span className="font-semibold">"{tagDeleteTarget}"</span> 吗？将从所有图片中移除该标签。
+          </p>
+          <DialogFooter>
+            <Button variant="outline" className="rounded-xl" onClick={() => setTagDeleteTarget(null)}>
+              取消
+            </Button>
+            <Button
+              variant="destructive"
+              className="rounded-xl"
+              onClick={() => {
+                if (tagDeleteTarget) void handleDeleteTag(tagDeleteTarget);
+                setTagDeleteTarget(null);
+              }}
+            >
               确认删除
             </Button>
           </DialogFooter>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -71,6 +71,7 @@ export type SettingsConfig = {
 };
 
 export type ManagedImage = {
+  rel: string;
   path?: string;
   name: string;
   date: string;
@@ -80,6 +81,7 @@ export type ManagedImage = {
   created_at: string;
   width?: number;
   height?: number;
+  tags?: string[];
 };
 
 export type SystemLog = {
@@ -332,6 +334,23 @@ export async function fetchManagedImages(filters: { start_date?: string; end_dat
 
 export async function deleteManagedImages(body: { paths?: string[]; start_date?: string; end_date?: string; all_matching?: boolean }) {
   return httpRequest<{ removed: number }>("/api/images/delete", { method: "POST", body });
+}
+
+export async function fetchImageTags() {
+  return httpRequest<{ tags: string[] }>("/api/images/tags");
+}
+
+export async function setImageTags(path: string, tags: string[]) {
+  return httpRequest<{ ok: boolean; tags: string[] }>("/api/images/tags", {
+    method: "POST",
+    body: { path, tags },
+  });
+}
+
+export async function deleteImageTag(tag: string) {
+  return httpRequest<{ ok: boolean; removed_from: number }>(`/api/images/tags/${encodeURIComponent(tag)}`, {
+    method: "DELETE",
+  });
 }
 
 export async function fetchSystemLogs(filters: { type?: string; start_date?: string; end_date?: string }) {


### PR DESCRIPTION
## Summary
- 新增图片标签管理功能，支持对图片添加、删除、筛选标签
- 标签数据存储在 `data/image_tags.json`
- 支持长按删除标签（带确认对话框）

## 变更内容

### 后端
- **新增** `services/image_tags_service.py` — 标签 CRUD 操作
- **修改** `api/system.py` — 新增 `GET/POST/DELETE /api/images/tags` 端点
- **修改** `services/image_service.py` — `list_images` 返回中包含 `tags` 和 `rel` 字段，删除图片时自动清理标签

### 前端
- **修改** `web/src/lib/api.ts` — `ManagedImage` 类型新增 `rel`、`tags` 字段，新增标签 API 函数
- **修改** `web/src/app/image-manager/page.tsx` — 标签筛选栏、每图标签编辑、长按删除确认、移动端按钮可见性优化
- **修改** `web/src/app/globals.css` — 长按动画 keyframes

## Test plan
- [ ] 图片管理页面加载后显示所有标签
- [ ] 点击标签可筛选图片
- [ ] 每张图片可添加/删除标签
- [ ] 长按标签弹出确认对话框后可删除
- [ ] 删除图片时自动清理关联标签

🤖 Generated with [Claude Code](https://claude.com/claude-code)