### PR TITLE
feat: 图片下载、会话重命名及比例选择修复，fix #119

### DIFF
--- a/api/system.py
+++ b/api/system.py
@@ -4,13 +4,13 @@ from urllib.parse import quote
 
 from fastapi import APIRouter, Header, HTTPException, Request
 from fastapi.concurrency import run_in_threadpool
-from fastapi.responses import Response
+from fastapi.responses import Response, StreamingResponse
 from pydantic import BaseModel, ConfigDict
 
 from api.support import require_admin, require_identity, resolve_image_base_url
 from services.backup_service import BackupError, backup_service
 from services.config import config
-from services.image_service import delete_images, get_thumbnail_response, list_images
+from services.image_service import delete_images, download_images_zip, get_image_download_response, get_thumbnail_response, list_images
 from services.image_tags_service import delete_tag, get_all_tags, set_tags
 from services.log_service import log_service
 from services.proxy_service import test_proxy
@@ -29,6 +29,9 @@ class ImageDeleteRequest(BaseModel):
     start_date: str = ""
     end_date: str = ""
     all_matching: bool = False
+
+class ImageDownloadRequest(BaseModel):
+    paths: list[str]
 
 class ImageTagsRequest(BaseModel):
     path: str
@@ -81,6 +84,21 @@ def create_router(app_version: str) -> APIRouter:
     async def delete_images_endpoint(body: ImageDeleteRequest, authorization: str | None = Header(default=None)):
         require_admin(authorization)
         return delete_images(body.paths, start_date=body.start_date.strip(), end_date=body.end_date.strip(), all_matching=body.all_matching)
+
+    @router.post("/api/images/download")
+    async def download_images_endpoint(body: ImageDownloadRequest, authorization: str | None = Header(default=None)):
+        require_admin(authorization)
+        buf = download_images_zip(body.paths)
+        return StreamingResponse(
+            buf,
+            media_type="application/zip",
+            headers={"Content-Disposition": 'attachment; filename="images.zip"'},
+        )
+
+    @router.get("/api/images/download/{image_path:path}")
+    async def download_single_image_endpoint(image_path: str, authorization: str | None = Header(default=None)):
+        require_admin(authorization)
+        return get_image_download_response(image_path)
 
     @router.get("/api/logs")
     async def get_logs(type: str = "", start_date: str = "", end_date: str = "", authorization: str | None = Header(default=None)):

--- a/services/image_service.py
+++ b/services/image_service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import io
+import zipfile
 from datetime import datetime
 from pathlib import Path
 
@@ -87,6 +89,11 @@ def get_thumbnail_response(relative_path: str) -> FileResponse:
     return FileResponse(ensure_thumbnail(relative_path))
 
 
+def get_image_download_response(relative_path: str) -> FileResponse:
+    path = _safe_image_path(relative_path)
+    return FileResponse(path, filename=path.name)
+
+
 def cleanup_image_thumbnails() -> int:
     thumbnails_root = config.image_thumbnails_dir
     images_root = config.images_dir
@@ -168,3 +175,35 @@ def delete_images(paths: list[str] | None = None, start_date: str = "", end_date
     _cleanup_empty_dirs(root)
     _cleanup_empty_dirs(config.image_thumbnails_dir)
     return {"removed": removed}
+
+
+def download_images_zip(paths: list[str]) -> io.BytesIO:
+    root = config.images_dir.resolve()
+    buf = io.BytesIO()
+    added = 0
+    used_names: set[str] = set()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for item in paths:
+            rel = _safe_relative_path(item)
+            path = (root / rel).resolve()
+            try:
+                path.relative_to(root)
+            except ValueError:
+                continue
+            if not path.is_file():
+                continue
+            name = path.name
+            if name in used_names:
+                stem = path.stem
+                suffix = path.suffix
+                counter = 2
+                while f"{stem}_{counter}{suffix}" in used_names:
+                    counter += 1
+                name = f"{stem}_{counter}{suffix}"
+            used_names.add(name)
+            zf.write(path, name)
+            added += 1
+    if added == 0:
+        raise HTTPException(status_code=404, detail="no images found")
+    buf.seek(0)
+    return buf

--- a/web/src/app/image-manager/page.tsx
+++ b/web/src/app/image-manager/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { CalendarDays, ChevronLeft, ChevronRight, Copy, ImageIcon, LoaderCircle, Maximize2, Plus, RefreshCw, Search, Tag, Trash2, X } from "lucide-react";
+import { CalendarDays, ChevronLeft, ChevronRight, Copy, Download, ImageIcon, LoaderCircle, Maximize2, Plus, RefreshCw, Search, Tag, Trash2, X } from "lucide-react";
 import { toast } from "sonner";
 
 import { DateRangeFilter } from "@/components/date-range-filter";
@@ -13,7 +13,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { deleteImageTag, deleteManagedImages, fetchImageTags, fetchManagedImages, setImageTags, type ManagedImage } from "@/lib/api";
+import { deleteImageTag, deleteManagedImages, downloadImages, downloadSingleImage, fetchImageTags, fetchManagedImages, setImageTags, type ManagedImage } from "@/lib/api";
 import { useAuthGuard } from "@/lib/use-auth-guard";
 
 const LONG_PRESS_MS = 800;
@@ -74,6 +74,7 @@ function ImageManagerContent() {
   const deleteTargetRef = useRef<ManagedImage | null>(null);
   const [selectedPaths, setSelectedPaths] = useState<string[]>([]);
   const [deleteMode, setDeleteMode] = useState<"selected" | "filtered" | null>(null);
+  const [isDownloading, setIsDownloading] = useState(false);
 
   const filteredItems = selectedTags.length > 0
     ? items.filter((item) => selectedTags.every((t) => (item.tags ?? []).includes(t)))
@@ -232,6 +233,24 @@ function ImageManagerContent() {
     }
   };
 
+  const handleBatchDownload = async () => {
+    const paths = deleteMode === "filtered" ? items.map((item) => item.rel) : selectedPaths;
+    if (paths.length === 0) return;
+    setIsDownloading(true);
+    try {
+      await downloadImages(paths);
+      toast.success(`已下载 ${paths.length} 张图片`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "下载失败");
+    } finally {
+      setIsDownloading(false);
+    }
+  };
+
+  const handleSingleDownload = async (item: ManagedImage) => {
+    await downloadSingleImage(item.rel);
+  };
+
   useEffect(() => {
     void loadImages();
   }, [startDate, endDate]);
@@ -332,6 +351,10 @@ function ImageManagerContent() {
               <button type="button" className="text-sm text-stone-500 hover:text-stone-900 disabled:text-stone-300" onClick={() => setSelectedPaths([])} disabled={selectedPaths.length === 0 || isDeleting}>
                 取消选择
               </button>
+              <Button variant="outline" className="h-8 rounded-lg border-stone-200 bg-white px-3 text-stone-600 hover:bg-stone-50" onClick={() => void handleBatchDownload()} disabled={selectedPaths.length === 0 || isDownloading || isDeleting}>
+                {isDownloading ? <LoaderCircle className="size-4 animate-spin" /> : <Download className="size-4" />}
+                下载所选
+              </Button>
               <Button variant="outline" className="h-8 rounded-lg border-rose-200 bg-white px-3 text-rose-600 hover:bg-rose-50" onClick={() => setDeleteMode("selected")} disabled={selectedPaths.length === 0 || isDeleting}>
                 <Trash2 className="size-4" />
                 删除所选
@@ -385,6 +408,15 @@ function ImageManagerContent() {
                       {item.created_at}
                     </div>
                     <div className="flex items-center gap-1">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="size-8 rounded-lg text-stone-400 hover:bg-stone-100 hover:text-stone-700"
+                        onClick={() => void handleSingleDownload(item)}
+                        title="下载图片"
+                      >
+                        <Download className="size-4" />
+                      </Button>
                       <Button
                         variant="ghost"
                         size="icon"

--- a/web/src/app/image/components/image-composer.tsx
+++ b/web/src/app/image/components/image-composer.tsx
@@ -46,7 +46,9 @@ export function ImageComposer({
   const [lightboxOpen, setLightboxOpen] = useState(false);
   const [lightboxIndex, setLightboxIndex] = useState(0);
   const [isSizeMenuOpen, setIsSizeMenuOpen] = useState(false);
+  const [sizeMenuPos, setSizeMenuPos] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
   const sizeMenuRef = useRef<HTMLDivElement>(null);
+  const sizeMenuBtnRef = useRef<HTMLButtonElement>(null);
   const lightboxImages = useMemo(
     () => referenceImages.map((image, index) => ({ id: `${image.name}-${index}`, src: image.dataUrl })),
     [referenceImages],
@@ -203,20 +205,35 @@ export function ImageComposer({
                     />
                   </div>
                   <div
-                    ref={sizeMenuRef}
                     className="relative flex h-9 shrink-0 items-center gap-1.5 rounded-full border border-stone-200 bg-white px-2 py-0.5 text-[11px] sm:h-auto sm:gap-2 sm:px-3 sm:py-1 sm:text-[13px]"
                   >
                     <span className="font-medium text-stone-700 sm:text-sm">比例</span>
                     <button
+                      ref={sizeMenuBtnRef}
                       type="button"
                       className="flex h-7 w-[78px] items-center justify-between bg-transparent text-left text-xs font-bold text-stone-700 min-[390px]:w-[96px] sm:h-8 sm:w-[132px]"
-                      onClick={() => setIsSizeMenuOpen((open) => !open)}
+                      onClick={() => {
+                        if (!isSizeMenuOpen && sizeMenuBtnRef.current) {
+                          const rect = sizeMenuBtnRef.current.getBoundingClientRect();
+                          setSizeMenuPos({ top: rect.top - 8, left: rect.left });
+                        }
+                        setIsSizeMenuOpen((open) => !open);
+                      }}
                     >
                       <span className="truncate">{imageSizeLabel}</span>
                       <ChevronDown className={cn("size-4 shrink-0 opacity-60 transition", isSizeMenuOpen && "rotate-180")} />
                     </button>
                     {isSizeMenuOpen ? (
-                      <div className="fixed inset-x-4 bottom-[calc(env(safe-area-inset-bottom)+5.75rem)] z-[80] max-h-[45dvh] overflow-y-auto rounded-3xl border border-white/80 bg-white p-2 shadow-[0_24px_80px_-32px_rgba(15,23,42,0.35)] sm:absolute sm:inset-x-auto sm:bottom-[calc(100%+10px)] sm:left-0 sm:w-[186px]">
+                      <div
+                        ref={sizeMenuRef}
+                        className="fixed z-[80] max-h-[45dvh] overflow-y-auto rounded-3xl border border-white/80 bg-white p-2 shadow-[0_24px_80px_-32px_rgba(15,23,42,0.35)]"
+                        style={{
+                          top: sizeMenuPos.top,
+                          left: sizeMenuPos.left,
+                          transform: "translateY(-100%)",
+                          width: "min(186px, calc(100vw - 2rem))",
+                        }}
+                      >
                         {imageSizeOptions.map((option) => {
                           const active = option.value === imageSize;
                           return (

--- a/web/src/app/image/components/image-results.tsx
+++ b/web/src/app/image/components/image-results.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Clock3, LoaderCircle, RotateCcw, Sparkles, Trash2 } from "lucide-react";
+import { Clock3, Download, LoaderCircle, RotateCcw, Sparkles, Trash2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -31,6 +31,29 @@ function getStoredImageSrc(image: StoredImage) {
     return `data:image/png;base64,${image.b64_json}`;
   }
   return image.url || "";
+}
+
+async function downloadStoredImage(image: StoredImage, index: number) {
+  let blob: Blob;
+  if (image.b64_json) {
+    const binary = atob(image.b64_json);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    blob = new Blob([bytes], { type: "image/png" });
+  } else if (image.url) {
+    const res = await fetch(image.url);
+    blob = await res.blob();
+  } else {
+    return;
+  }
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `image-${index + 1}.png`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
 }
 
 export function ImageResults({
@@ -218,15 +241,26 @@ export function ImageResults({
                                 <span>结果 {index + 1}</span>
                                 {imageMeta ? <span className="block text-stone-400 sm:ml-2 sm:inline">{imageMeta}</span> : null}
                               </div>
-                              <Button
-                                variant="outline"
-                                size="sm"
-                                className="h-7 w-fit rounded-full border-stone-200 bg-white px-2 text-[10px] text-stone-700 hover:bg-stone-50 sm:h-8 sm:px-3 sm:text-xs"
-                                onClick={() => onContinueEdit(selectedConversation.id, image)}
-                              >
-                                <Sparkles className="size-3 sm:size-4" />
-                                加入编辑
-                              </Button>
+                              <div className="flex items-center gap-1.5">
+                                <Button
+                                  variant="outline"
+                                  size="sm"
+                                  className="h-7 w-fit rounded-full border-stone-200 bg-white px-2 text-[10px] text-stone-700 hover:bg-stone-50 sm:h-8 sm:px-3 sm:text-xs"
+                                  onClick={() => onContinueEdit(selectedConversation.id, image)}
+                                >
+                                  <Sparkles className="size-3 sm:size-4" />
+                                  加入编辑
+                                </Button>
+                                <Button
+                                  variant="outline"
+                                  size="sm"
+                                  className="h-7 w-fit rounded-full border-stone-200 bg-white px-2 text-[10px] text-stone-700 hover:bg-stone-50 sm:h-8 sm:px-3 sm:text-xs"
+                                  onClick={() => void downloadStoredImage(image, index)}
+                                >
+                                  <Download className="size-3 sm:size-4" />
+                                  下载
+                                </Button>
+                              </div>
                             </div>
                           </div>
                         );

--- a/web/src/app/image/components/image-sidebar.tsx
+++ b/web/src/app/image/components/image-sidebar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { LoaderCircle, MessageSquarePlus, Trash2 } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { LoaderCircle, MessageSquarePlus, Pencil, Trash2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -14,6 +15,7 @@ type ImageSidebarProps = {
   onClearHistory: () => void | Promise<void>;
   onSelectConversation: (id: string) => void;
   onDeleteConversation: (id: string) => void | Promise<void>;
+  onRenameConversation: (id: string, title: string) => void | Promise<void>;
   formatConversationTime: (value: string) => string;
   hideActionButtons?: boolean;
 };
@@ -26,9 +28,40 @@ export function ImageSidebar({
   onClearHistory,
   onSelectConversation,
   onDeleteConversation,
+  onRenameConversation,
   formatConversationTime,
   hideActionButtons = false,
 }: ImageSidebarProps) {
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingTitle, setEditingTitle] = useState("");
+  const editInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editingId && editInputRef.current) {
+      editInputRef.current.focus();
+      editInputRef.current.select();
+    }
+  }, [editingId]);
+
+  const startRename = useCallback((conversation: ImageConversation, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setEditingId(conversation.id);
+    setEditingTitle(conversation.title);
+  }, []);
+
+  const commitRename = useCallback(() => {
+    const trimmed = editingTitle.trim();
+    if (editingId && trimmed) {
+      void onRenameConversation(editingId, trimmed);
+    }
+    setEditingId(null);
+    setEditingTitle("");
+  }, [editingId, editingTitle, onRenameConversation]);
+
+  const cancelRename = useCallback(() => {
+    setEditingId(null);
+    setEditingTitle("");
+  }, []);
   return (
     <aside className="h-full min-h-0 overflow-hidden">
       <div className="flex h-full min-h-0 flex-col gap-2 py-1 sm:gap-3 sm:py-2">
@@ -80,10 +113,25 @@ export function ImageSidebar({
                   <button
                     type="button"
                     onClick={() => onSelectConversation(conversation.id)}
-                    className={cn("block w-full text-left", hideActionButtons ? "pr-0" : "pr-8")}
+                    className="block w-full pr-8 text-left"
                   >
                     <div className={cn("truncate font-semibold", hideActionButtons ? "text-base" : "text-sm")}>
-                      <span className="truncate">{conversation.title}</span>
+                      {editingId === conversation.id ? (
+                        <input
+                          ref={editInputRef}
+                          value={editingTitle}
+                          onChange={(e) => setEditingTitle(e.target.value)}
+                          onBlur={commitRename}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter") commitRename();
+                            if (e.key === "Escape") cancelRename();
+                          }}
+                          onClick={(e) => e.stopPropagation()}
+                          className="w-full truncate rounded border border-stone-300 bg-white px-1 py-0.5 text-sm outline-none focus:border-stone-500"
+                        />
+                      ) : (
+                        <span className="truncate">{conversation.title}</span>
+                      )}
                     </div>
                     <div className={cn("mt-1 text-xs", active ? "text-stone-500" : "text-stone-400")}>
                       {conversation.turns.length} 轮 · {formatConversationTime(conversation.updatedAt)}
@@ -99,16 +147,24 @@ export function ImageSidebar({
                       </div>
                     ) : null}
                   </button>
-                  {!hideActionButtons ? (
+                  <div className="absolute top-2.5 right-1.5 flex items-center gap-0.5 opacity-100 transition sm:opacity-0 sm:group-hover:opacity-100">
+                    <button
+                      type="button"
+                      onClick={(e) => startRename(conversation, e)}
+                      className="inline-flex size-7 items-center justify-center rounded-md text-stone-400 hover:bg-stone-100 hover:text-stone-600"
+                      aria-label="重命名会话"
+                    >
+                      <Pencil className="size-3.5" />
+                    </button>
                     <button
                       type="button"
                       onClick={() => void onDeleteConversation(conversation.id)}
-                      className="absolute top-3 right-2 inline-flex size-7 items-center justify-center rounded-md text-stone-400 opacity-0 transition hover:bg-stone-100 hover:text-rose-500 group-hover:opacity-100"
+                      className="inline-flex size-7 items-center justify-center rounded-md text-stone-400 hover:bg-stone-100 hover:text-rose-500"
                       aria-label="删除会话"
                     >
                       <Trash2 className="size-4" />
                     </button>
-                  ) : null}
+                  </div>
                 </div>
               );
             })

--- a/web/src/app/image/page.tsx
+++ b/web/src/app/image/page.tsx
@@ -31,6 +31,7 @@ import {
   deleteImageConversation,
   getImageConversationStats,
   listImageConversations,
+  renameImageConversation,
   saveImageConversation,
   saveImageConversations,
   type ImageConversation,
@@ -643,6 +644,20 @@ function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
     }
   };
 
+  const handleRenameConversation = async (id: string, title: string) => {
+    const nextConversations = conversations.map((item) =>
+      item.id === id ? { ...item, title, updatedAt: new Date().toISOString() } : item,
+    );
+    conversationsRef.current = sortImageConversations(nextConversations);
+    setConversations(conversationsRef.current);
+    try {
+      await renameImageConversation(id, title);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "重命名失败";
+      toast.error(message);
+    }
+  };
+
   const openDeleteConversationConfirm = (id: string) => {
     setIsHistoryOpen(false);
     setDeleteConfirm({ type: "one", id });
@@ -1125,6 +1140,7 @@ function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
             onClearHistory={openClearHistoryConfirm}
             onSelectConversation={setSelectedConversationId}
             onDeleteConversation={openDeleteConversationConfirm}
+            onRenameConversation={handleRenameConversation}
             formatConversationTime={formatConversationTime}
           />
         </div>
@@ -1152,6 +1168,7 @@ function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
                   setIsHistoryOpen(false);
                 }}
                 onDeleteConversation={openDeleteConversationConfirm}
+                onRenameConversation={handleRenameConversation}
                 formatConversationTime={formatConversationTime}
                 hideActionButtons
               />

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { httpRequest } from "@/lib/request";
+import { httpRequest, request } from "@/lib/request";
 
 export type AccountType = string;
 export type AccountStatus = "正常" | "限流" | "异常" | "禁用";
@@ -440,6 +440,32 @@ export async function fetchManagedImages(filters: { start_date?: string; end_dat
 
 export async function deleteManagedImages(body: { paths?: string[]; start_date?: string; end_date?: string; all_matching?: boolean }) {
   return httpRequest<{ removed: number }>("/api/images/delete", { method: "POST", body });
+}
+
+export async function downloadImages(paths: string[]) {
+  const response = await request.post("/api/images/download", { paths }, { responseType: "blob" });
+  const blob = response.data as Blob;
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "images.zip";
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+export async function downloadSingleImage(path: string) {
+  const response = await request.get(`/api/images/download/${path}`, { responseType: "blob" });
+  const blob = response.data as Blob;
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = path.split("/").pop() || "image.png";
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
 }
 
 export async function fetchImageTags() {

--- a/web/src/lib/request.ts
+++ b/web/src/lib/request.ts
@@ -28,7 +28,7 @@ function errorMessageFromValue(value: unknown): string {
     return errorMessageFromValue(item.error);
 }
 
-const request = axios.create({
+export const request = axios.create({
     baseURL: webConfig.apiUrl.replace(/\/$/, ""),
 });
 

--- a/web/src/store/image-conversations.ts
+++ b/web/src/store/image-conversations.ts
@@ -246,6 +246,20 @@ export async function saveImageConversation(conversation: ImageConversation): Pr
   });
 }
 
+export async function renameImageConversation(id: string, title: string): Promise<void> {
+  await queueImageConversationWrite(async () => {
+    const items = await readStoredImageConversations();
+    const target = items.find((item) => item.id === id);
+    if (!target) return;
+    const updated = { ...target, title, updatedAt: new Date().toISOString() };
+    const nextItems = sortImageConversations([
+      updated,
+      ...items.filter((item) => item.id !== id),
+    ]);
+    await imageConversationStorage.setItem(IMAGE_CONVERSATIONS_KEY, nextItems);
+  });
+}
+
 export async function deleteImageConversation(id: string): Promise<void> {
   await queueImageConversationWrite(async () => {
     const items = await readStoredImageConversations();


### PR DESCRIPTION
## Summary

- **图片批量下载**: 图片管理页面新增单张下载和批量 ZIP 下载功能，生图页面每张图片添加下载按钮
- **图片会话重命名**: 生图页面支持重命名图片会话
- **比例选择框修复**: 修复生图页面比例选择下拉框被 `overflow-hidden` 容器遮挡的问题（fix #119）

## Changes

| 文件 | 改动 |
|------|------|
| `api/system.py` | 新增批量 ZIP 下载和单图下载端点 |
| `services/image_service.py` | 新增 `download_images_zip` 和 `get_image_download_response` |
| `web/src/lib/api.ts` | 新增 `downloadImages`、`downloadSingleImage` |
| `web/src/lib/request.ts` | 导出 axios 实例供 blob 下载 |
| `web/src/app/image-manager/page.tsx` | 图片管理页下载按钮 |
| `web/src/app/image/components/image-results.tsx` | 生图结果下载按钮 |
| `web/src/app/image/components/image-composer.tsx` | 修复比例选择框遮挡 (#119) |
| `web/src/app/image/components/image-sidebar.tsx` | 会话重命名 |
| `web/src/store/image-conversations.ts` | 重命名存储支持 |

## Test plan

- [ ] 图片管理：单张下载、批量 ZIP 下载
- [ ] 生图页面：图片下载按钮
- [ ] 生图页面：比例选择框正常显示 (fix #119)
- [ ] 生图页面：会话重命名