### PR TITLE
feat: support image_url references in image edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ curl http://localhost:8000/v1/images/generations \
 <summary><code>POST /v1/images/edits</code></summary>
 <br>
 
-OpenAI 兼容图片编辑接口，用于上传图片并生成编辑结果。
+OpenAI 兼容图片编辑接口，可上传图片文件，也可按官方 JSON 格式传入图片链接并生成编辑结果。
 
 ```bash
 curl http://localhost:8000/v1/images/edits \
@@ -213,6 +213,21 @@ curl http://localhost:8000/v1/images/edits \
   -F "prompt=把这张图改成赛博朋克夜景风格" \
   -F "n=1" \
   -F "image=@./input.png"
+```
+
+也可以直接传图片 URL：
+
+```bash
+curl http://localhost:8000/v1/images/edits \
+  -H "Authorization: Bearer <auth-key>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-image-2",
+    "prompt": "把这张图改成赛博朋克夜景风格",
+    "images": [
+      {"image_url": "https://example.com/input.png"}
+    ]
+  }'
 ```
 
 <details>
@@ -225,6 +240,8 @@ curl http://localhost:8000/v1/images/edits \
 | `prompt` | 图片编辑提示词                             |
 | `n`      | 生成数量，当前后端限制为 `1-4`                  |
 | `image`  | 需要编辑的图片文件，使用 multipart/form-data 上传 |
+| `images` | JSON 图片引用数组，支持 `{"image_url": "https://..."}` |
+| `image_url` | 表单模式下也可直接传图片链接，支持重复字段传多张图          |
 
 <br>
 </details>

--- a/api/ai.py
+++ b/api/ai.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, File, Form, Header, HTTPException, Request, UploadFile
+from fastapi import APIRouter, Header, HTTPException, Request
 from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, ConfigDict, Field
 
+from api.image_inputs import parse_image_edit_request, read_image_sources
 from api.support import require_identity, resolve_image_base_url
 from services.content_filter import check_request, request_text
 from services.log_service import LoggedCall
@@ -90,39 +91,15 @@ def create_router() -> APIRouter:
     async def edit_images(
             request: Request,
             authorization: str | None = Header(default=None),
-            image: list[UploadFile] | None = File(default=None),
-            image_list: list[UploadFile] | None = File(default=None, alias="image[]"),
-            prompt: str = Form(...),
-            model: str = Form(default="gpt-image-2"),
-            n: int = Form(default=1),
-            size: str | None = Form(default=None),
-            response_format: str = Form(default="b64_json"),
-            stream: bool | None = Form(default=None),
     ):
         identity = require_identity(authorization)
+        payload, image_sources = await parse_image_edit_request(request)
+        prompt = str(payload["prompt"])
+        model = str(payload["model"])
         call = LoggedCall(identity, "/v1/images/edits", model, "图生图", request_text=prompt)
-        if n < 1 or n > 4:
-            raise HTTPException(status_code=400, detail={"error": "n must be between 1 and 4"})
         await filter_or_log(call, prompt)
-        uploads = [*(image or []), *(image_list or [])]
-        if not uploads:
-            raise HTTPException(status_code=400, detail={"error": "image file is required"})
-        images: list[tuple[bytes, str, str]] = []
-        for upload in uploads:
-            image_data = await upload.read()
-            if not image_data:
-                raise HTTPException(status_code=400, detail={"error": "image file is empty"})
-            images.append((image_data, upload.filename or "image.png", upload.content_type or "image/png"))
-        payload = {
-            "prompt": prompt,
-            "images": images,
-            "model": model,
-            "n": n,
-            "size": size,
-            "response_format": response_format,
-            "stream": stream,
-            "base_url": resolve_image_base_url(request),
-        }
+        payload["images"] = await read_image_sources(image_sources)
+        payload["base_url"] = resolve_image_base_url(request)
         return await call.run(openai_v1_image_edit.handle, payload)
 
     @router.post("/v1/chat/completions")

--- a/api/image_inputs.py
+++ b/api/image_inputs.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import mimetypes
+import re
+from pathlib import PurePosixPath
+from typing import Any, TypeGuard
+from urllib.parse import unquote, unquote_to_bytes, urlparse
+
+from curl_cffi import requests
+from fastapi import HTTPException, Request
+from fastapi.concurrency import run_in_threadpool
+from starlette.datastructures import UploadFile
+
+from services.proxy_service import proxy_settings
+
+ImageInput = tuple[bytes, str, str]
+ImageSource = str | UploadFile
+
+MAX_IMAGE_REFERENCE_BYTES = 50 * 1024 * 1024
+IMAGE_REFERENCE_FIELDS = {"image", "image[]", "images", "images[]", "image_url", "image_url[]"}
+
+
+def _clean(value: object, default: str = "") -> str:
+    """清理字符串：转换为字符串并去掉首尾空白。"""
+    text = str(value if value is not None else default).strip()
+    return text or default
+
+
+def _is_upload(value: object) -> TypeGuard[UploadFile]:
+    """识别上传文件：兼容 Starlette 表单返回的 UploadFile。"""
+    return isinstance(value, UploadFile)
+
+
+def _parse_bool(value: object) -> bool | None:
+    """解析布尔字段：兼容 JSON 布尔值和表单字符串。"""
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        return value
+    text = _clean(value).lower()
+    if text in {"true", "1", "yes", "y", "on"}:
+        return True
+    if text in {"false", "0", "no", "n", "off"}:
+        return False
+    raise HTTPException(status_code=400, detail={"error": "stream must be a boolean"})
+
+
+def _parse_count(value: object) -> int:
+    """解析生成数量：保持图片接口的 1 到 4 限制。"""
+    try:
+        count = int(value or 1)
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail={"error": "n must be an integer"}) from exc
+    if count < 1 or count > 4:
+        raise HTTPException(status_code=400, detail={"error": "n must be between 1 and 4"})
+    return count
+
+
+def _payload_from_fields(fields: dict[str, Any]) -> dict[str, Any]:
+    """构造图片编辑载荷：从表单或 JSON 字段提取通用参数。"""
+    prompt = _clean(fields.get("prompt"))
+    if not prompt:
+        raise HTTPException(status_code=400, detail={"error": "prompt is required"})
+    payload = {
+        "prompt": prompt,
+        "model": _clean(fields.get("model"), "gpt-image-2"),
+        "n": _parse_count(fields.get("n")),
+        "size": _clean(fields.get("size")) or None,
+        "response_format": _clean(fields.get("response_format"), "b64_json"),
+        "stream": _parse_bool(fields.get("stream")),
+    }
+    if "client_task_id" in fields:
+        payload["client_task_id"] = _clean(fields.get("client_task_id"))
+    return payload
+
+
+def _json_reference_value(value: object) -> object:
+    """解析表单图片引用：支持把 images 字段写成 JSON 字符串。"""
+    if not isinstance(value, str):
+        return value
+    text = value.strip()
+    if not text or text[0] not in "[{":
+        return value
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return value
+
+
+def _source_from_object(value: dict[str, Any]) -> list[ImageSource]:
+    """提取图片引用对象：支持 image_url 或 url，明确拒绝 file_id。"""
+    has_url = "image_url" in value or "url" in value
+    if value.get("file_id"):
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "file_id image references are not supported; use image_url instead"},
+        )
+    if not has_url:
+        raise HTTPException(status_code=400, detail={"error": "image reference must include image_url"})
+    image_url = value.get("image_url", value.get("url"))
+    if isinstance(image_url, dict):
+        image_url = image_url.get("url")
+    return _sources_from_value(image_url)
+
+
+def _sources_from_value(value: object) -> list[ImageSource]:
+    """展开图片引用：把字符串、数组和对象统一成图片来源列表。"""
+    value = _json_reference_value(value)
+    if _is_upload(value):
+        return [value]
+    if isinstance(value, str):
+        text = value.strip()
+        return [text] if text else []
+    if isinstance(value, list):
+        sources: list[ImageSource] = []
+        for item in value:
+            sources.extend(_sources_from_value(item))
+        return sources
+    if isinstance(value, dict):
+        return _source_from_object(value)
+    if value is None:
+        return []
+    raise HTTPException(status_code=400, detail={"error": "invalid image reference"})
+
+
+def _json_image_sources(body: dict[str, Any]) -> list[ImageSource]:
+    """读取 JSON 图片引用：优先支持官方 images 数组字段。"""
+    sources: list[ImageSource] = []
+    for key in ("images", "image", "image_url"):
+        if key in body:
+            sources.extend(_sources_from_value(body.get(key)))
+    return sources
+
+
+async def parse_image_edit_request(request: Request) -> tuple[dict[str, Any], list[ImageSource]]:
+    """解析图片编辑请求：同时支持 multipart 上传和官方 JSON 图片 URL。"""
+    content_type = request.headers.get("content-type", "").split(";", 1)[0].strip().lower()
+    if content_type == "application/json":
+        try:
+            body = await request.json()
+        except json.JSONDecodeError as exc:
+            raise HTTPException(status_code=400, detail={"error": "invalid JSON body"}) from exc
+        if not isinstance(body, dict):
+            raise HTTPException(status_code=400, detail={"error": "JSON body must be an object"})
+        return _payload_from_fields(body), _json_image_sources(body)
+
+    form = await request.form()
+    fields: dict[str, Any] = {}
+    for key in ("client_task_id", "prompt", "model", "n", "size", "response_format", "stream"):
+        value = form.get(key)
+        if isinstance(value, str):
+            fields[key] = value
+    sources: list[ImageSource] = []
+    for key, value in form.multi_items():
+        if key in IMAGE_REFERENCE_FIELDS:
+            sources.extend(_sources_from_value(value))
+    return _payload_from_fields(fields), sources
+
+
+def _extension_from_mime(mime_type: str) -> str:
+    """推导图片扩展名：把 MIME 类型转换为常见文件后缀。"""
+    subtype = mime_type.split("/", 1)[1].split("+", 1)[0] if "/" in mime_type else "png"
+    if subtype == "jpeg":
+        return "jpg"
+    return re.sub(r"[^a-z0-9]+", "", subtype.lower()) or "png"
+
+
+def _safe_filename(name: str, mime_type: str, fallback: str) -> str:
+    """生成安全文件名：清理 URL 文件名并补齐扩展名。"""
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "_", name).strip("._")
+    if not cleaned:
+        cleaned = fallback
+    if "." not in cleaned:
+        cleaned = f"{cleaned}.{_extension_from_mime(mime_type)}"
+    return cleaned
+
+
+def _decode_data_url(url: str) -> ImageInput:
+    """解码 data URL：把内联图片转成标准图片输入元组。"""
+    header, separator, payload = url.partition(",")
+    if not separator:
+        raise HTTPException(status_code=400, detail={"error": "invalid data image URL"})
+    mime_type = header.split(";", 1)[0].removeprefix("data:") or "image/png"
+    if not mime_type.startswith("image/"):
+        raise HTTPException(status_code=400, detail={"error": "image_url must point to an image"})
+    try:
+        data = base64.b64decode(payload, validate=True) if ";base64" in header else unquote_to_bytes(payload)
+    except (binascii.Error, ValueError) as exc:
+        raise HTTPException(status_code=400, detail={"error": "invalid data image URL"}) from exc
+    if not data:
+        raise HTTPException(status_code=400, detail={"error": "image URL is empty"})
+    if len(data) > MAX_IMAGE_REFERENCE_BYTES:
+        raise HTTPException(status_code=400, detail={"error": "image URL exceeds 50MB limit"})
+    return data, f"image_url.{_extension_from_mime(mime_type)}", mime_type
+
+
+def _response_mime_type(response: requests.Response, parsed_path: str) -> str:
+    """识别下载图片类型：优先响应头，必要时按 URL 后缀推断。"""
+    header_type = str(response.headers.get("content-type") or "").split(";", 1)[0].strip().lower()
+    guessed_type = mimetypes.guess_type(parsed_path)[0] or ""
+    if header_type.startswith("image/"):
+        return header_type
+    if header_type and header_type not in {"application/octet-stream", "binary/octet-stream"}:
+        raise HTTPException(status_code=400, detail={"error": "image_url must point to an image"})
+    if guessed_type.startswith("image/"):
+        return guessed_type
+    if not header_type or header_type in {"application/octet-stream", "binary/octet-stream"}:
+        return "image/png"
+    raise HTTPException(status_code=400, detail={"error": "image_url must point to an image"})
+
+
+def _filename_from_url(parsed_path: str, mime_type: str) -> str:
+    """生成 URL 图片文件名：从链接路径提取名称并做安全化。"""
+    raw_name = PurePosixPath(unquote(parsed_path)).name
+    return _safe_filename(raw_name, mime_type, "image_url")
+
+
+def _download_image_url(url: str) -> ImageInput:
+    """下载远程图片：把 http/https 图片链接转成标准图片输入元组。"""
+    source = _clean(url)
+    if source.startswith("data:"):
+        return _decode_data_url(source)
+    parsed = urlparse(source)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise HTTPException(status_code=400, detail={"error": "image_url must be an http or https URL"})
+    try:
+        response = requests.get(
+            source,
+            headers={"Accept": "image/*,*/*;q=0.8", "User-Agent": "chatgpt2api image fetcher"},
+            timeout=60,
+            allow_redirects=True,
+            **proxy_settings.build_session_kwargs(),
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail={"error": f"image_url fetch failed: {exc}"}) from exc
+    if not 200 <= response.status_code < 300:
+        raise HTTPException(status_code=400, detail={"error": f"image_url fetch failed: HTTP {response.status_code}"})
+    content_length = _clean(response.headers.get("content-length"))
+    if content_length and content_length.isdigit() and int(content_length) > MAX_IMAGE_REFERENCE_BYTES:
+        raise HTTPException(status_code=400, detail={"error": "image_url exceeds 50MB limit"})
+    data = response.content
+    if not data:
+        raise HTTPException(status_code=400, detail={"error": "image_url returned empty content"})
+    if len(data) > MAX_IMAGE_REFERENCE_BYTES:
+        raise HTTPException(status_code=400, detail={"error": "image_url exceeds 50MB limit"})
+    mime_type = _response_mime_type(response, parsed.path)
+    return data, _filename_from_url(parsed.path, mime_type), mime_type
+
+
+async def read_image_sources(sources: list[ImageSource]) -> list[ImageInput]:
+    """读取图片来源：上传文件直接读取，URL 下载后统一返回图片元组。"""
+    images: list[ImageInput] = []
+    for source in sources:
+        if _is_upload(source):
+            try:
+                image_data = await source.read()
+            finally:
+                await source.close()
+            if not image_data:
+                raise HTTPException(status_code=400, detail={"error": "image file is empty"})
+            images.append((image_data, source.filename or "image.png", source.content_type or "image/png"))
+            continue
+        images.append(await run_in_threadpool(_download_image_url, source))
+    if not images:
+        raise HTTPException(status_code=400, detail={"error": "image file or image_url is required"})
+    return images

--- a/api/image_tasks.py
+++ b/api/image_tasks.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, File, Form, Header, HTTPException, Query, Request, UploadFile
+from fastapi import APIRouter, Header, HTTPException, Query, Request
 from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field
 
+from api.image_inputs import parse_image_edit_request, read_image_sources
 from api.support import require_identity, resolve_image_base_url
 from services.content_filter import check_request
 from services.image_task_service import image_task_service
@@ -65,24 +66,16 @@ def create_router() -> APIRouter:
     async def create_edit_task(
         request: Request,
         authorization: str | None = Header(default=None),
-        image: list[UploadFile] | None = File(default=None),
-        image_list: list[UploadFile] | None = File(default=None, alias="image[]"),
-        client_task_id: str = Form(...),
-        prompt: str = Form(...),
-        model: str = Form(default="gpt-image-2"),
-        size: str | None = Form(default=None),
     ):
         identity = require_identity(authorization)
+        payload, image_sources = await parse_image_edit_request(request)
+        client_task_id = str(payload.get("client_task_id") or "").strip()
+        if not client_task_id:
+            raise HTTPException(status_code=400, detail={"error": "client_task_id is required"})
+        prompt = str(payload["prompt"])
+        model = str(payload["model"])
         await filter_or_log(LoggedCall(identity, "/api/image-tasks/edits", model, "图生图任务", request_text=prompt), prompt)
-        uploads = [*(image or []), *(image_list or [])]
-        if not uploads:
-            raise HTTPException(status_code=400, detail={"error": "image file is required"})
-        images: list[tuple[bytes, str, str]] = []
-        for upload in uploads:
-            image_data = await upload.read()
-            if not image_data:
-                raise HTTPException(status_code=400, detail={"error": "image file is empty"})
-            images.append((image_data, upload.filename or "image.png", upload.content_type or "image/png"))
+        images = await read_image_sources(image_sources)
         try:
             return await run_in_threadpool(
                 image_task_service.submit_edit,
@@ -90,7 +83,7 @@ def create_router() -> APIRouter:
                 client_task_id=client_task_id,
                 prompt=prompt,
                 model=model,
-                size=size,
+                size=payload["size"],
                 base_url=resolve_image_base_url(request),
                 images=images,
             )

--- a/test/test_image_tasks_api.py
+++ b/test/test_image_tasks_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import unittest
 from unittest import mock
 
@@ -10,6 +11,8 @@ import api.image_tasks as image_tasks_module
 
 
 AUTH_HEADERS = {"Authorization": "Bearer chatgpt2api"}
+PNG_BYTES = b"\x89PNG\r\n\x1a\n"
+DATA_IMAGE_URL = f"data:image/png;base64,{base64.b64encode(PNG_BYTES).decode('ascii')}"
 
 
 class FakeImageTaskService:
@@ -80,6 +83,7 @@ class ImageTasksApiTests(unittest.TestCase):
         self.assertEqual(len(self.fake_service.generation_calls), 1)
 
     def test_create_edit_task_accepts_multiple_images(self):
+        """测试图片编辑任务接口支持多个上传图片。"""
         response = self.client.post(
             "/api/image-tasks/edits",
             headers=AUTH_HEADERS,
@@ -95,6 +99,24 @@ class ImageTasksApiTests(unittest.TestCase):
         self.assertEqual(len(self.fake_service.edit_calls), 1)
         images = self.fake_service.edit_calls[0][1]["images"]
         self.assertEqual(len(images), 2)
+
+    def test_create_edit_task_accepts_image_url(self):
+        """测试图片编辑任务接口支持表单 image_url 引用。"""
+        response = self.client.post(
+            "/api/image-tasks/edits",
+            headers=AUTH_HEADERS,
+            data={
+                "client_task_id": "edit-url-1",
+                "prompt": "edit",
+                "model": "gpt-image-2",
+                "image_url": DATA_IMAGE_URL,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(len(self.fake_service.edit_calls), 1)
+        images = self.fake_service.edit_calls[0][1]["images"]
+        self.assertEqual(images, [(PNG_BYTES, "image_url.png", "image/png")])
 
     def test_list_tasks_reports_missing_ids(self):
         response = self.client.get("/api/image-tasks?ids=task-1,missing", headers=AUTH_HEADERS)

--- a/test/test_v1_images_edits_api.py
+++ b/test/test_v1_images_edits_api.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import base64
+import unittest
+from unittest import mock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import api.ai as ai_module
+
+
+AUTH_HEADERS = {"Authorization": "Bearer chatgpt2api"}
+PNG_BYTES = b"\x89PNG\r\n\x1a\n"
+DATA_IMAGE_URL = f"data:image/png;base64,{base64.b64encode(PNG_BYTES).decode('ascii')}"
+
+
+class ImagesEditsApiTests(unittest.TestCase):
+    def setUp(self):
+        self.handle_calls = []
+
+        def fake_handle(payload):
+            self.handle_calls.append(payload)
+            return {"created": 1, "data": [{"b64_json": base64.b64encode(b"out").decode("ascii")}]}
+
+        self.handler_patcher = mock.patch.object(ai_module.openai_v1_image_edit, "handle", fake_handle)
+        self.handler_patcher.start()
+        self.addCleanup(self.handler_patcher.stop)
+        app = FastAPI()
+        app.include_router(ai_module.create_router())
+        self.client = TestClient(app)
+
+    def test_edit_accepts_json_image_url(self):
+        """测试图片编辑接口支持官方 JSON image_url 引用。"""
+        response = self.client.post(
+            "/v1/images/edits",
+            headers=AUTH_HEADERS,
+            json={
+                "model": "gpt-image-2",
+                "prompt": "edit",
+                "images": [{"image_url": DATA_IMAGE_URL}],
+                "n": 1,
+                "response_format": "b64_json",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(len(self.handle_calls), 1)
+        payload = self.handle_calls[0]
+        self.assertEqual(payload["prompt"], "edit")
+        self.assertEqual(payload["n"], 1)
+        self.assertEqual(payload["images"], [(PNG_BYTES, "image_url.png", "image/png")])
+
+    def test_edit_rejects_file_id_reference(self):
+        """测试图片编辑接口对暂不支持的 file_id 返回明确错误。"""
+        response = self.client.post(
+            "/v1/images/edits",
+            headers=AUTH_HEADERS,
+            json={
+                "model": "gpt-image-2",
+                "prompt": "edit",
+                "images": [{"file_id": "file-abc123"}],
+            },
+        )
+
+        self.assertEqual(response.status_code, 400, response.text)
+        self.assertIn("file_id image references are not supported", response.text)
+        self.assertEqual(self.handle_calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

  - Add JSON image URL support for `/v1/images/edits`
  - Keep existing multipart `image` / `image[]` upload compatibility
  - Share the same parsing path with `/api/image-tasks/edits`
  - Document JSON `images: [{ "image_url": "..." }]` usage in README

  ## Tests

  - `uv run python -m unittest test.test_v1_images_edits_api test.test_image_tasks_api`
  - `uv run python -m compileall api services utils`

  Note: full integration tests that require external/local services were not run.

  ## Related Issue

  Closes #143 