### PR TITLE
feat: add DDG email provider with CF relay for registration

### DIFF
--- a/services/image_task_service.py
+++ b/services/image_task_service.py
@@ -230,7 +230,11 @@ class ImageTaskService:
                 raise RuntimeError("image task returned streaming result unexpectedly")
             data = result.get("data")
             if not isinstance(data, list) or not data:
-                message = _clean(result.get("message")) or "image task returned no image data"
+                upstream = _clean(result.get("message"))
+                if upstream:
+                    message = upstream
+                else:
+                    message = "号池中没有可用账号或所有账号均被限流，请检查号池状态（账号额度、是否被封禁、是否到达生图上限）"
                 raise RuntimeError(message)
             self._update_task(key, status=TASK_STATUS_SUCCESS, data=data, error="")
             self._log_call(

--- a/services/openai_backend_api.py
+++ b/services/openai_backend_api.py
@@ -24,6 +24,11 @@ class InvalidAccessTokenError(RuntimeError):
     pass
 
 
+class ImagePollTimeoutError(RuntimeError):
+    pass
+    pass
+
+
 @dataclass
 class ChatRequirements:
     """保存一次对话请求所需的 sentinel token。"""
@@ -668,7 +673,11 @@ class OpenAIBackendAPI:
                           "elapsed_secs": round(time.time() - start, 1)})
             time.sleep(4)
         logger.info({"event": "image_poll_timeout", "conversation_id": conversation_id, "timeout_secs": timeout_secs})
-        return [], []
+        raise ImagePollTimeoutError(
+            f"ChatGPT 生图超时（已等待 {timeout_secs} 秒）。"
+            f"当前超时阈值可在 config.json 中调大 image_poll_timeout_secs，"
+            f"也可能是账号被限流或生图队列拥堵导致。"
+        )
 
     def _get_file_download_url(self, file_id: str) -> str:
         """获取文件下载地址。"""

--- a/services/protocol/conversation.py
+++ b/services/protocol/conversation.py
@@ -13,7 +13,7 @@ import tiktoken
 
 from services.account_service import account_service
 from services.config import config
-from services.openai_backend_api import OpenAIBackendAPI
+from services.openai_backend_api import ImagePollTimeoutError, OpenAIBackendAPI
 from utils.helper import IMAGE_MODELS, extract_image_from_message_content
 from utils.log import logger
 
@@ -624,6 +624,8 @@ def stream_image_outputs_with_pool(request: ConversationRequest) -> Iterator[Ima
                     return
                 account_service.mark_image_result(token, True)
                 break
+            except ImagePollTimeoutError:
+                raise
             except ImageGenerationError:
                 account_service.mark_image_result(token, False)
                 raise

--- a/services/protocol/conversation.py
+++ b/services/protocol/conversation.py
@@ -637,6 +637,8 @@ def stream_image_outputs_with_pool(request: ConversationRequest) -> Iterator[Ima
                 raise ImageGenerationError(image_stream_error_message(last_error)) from exc
 
     if not emitted:
+        if not last_error:
+            last_error = "no account in the pool could generate images — check account quota and rate-limit status"
         raise ImageGenerationError(image_stream_error_message(last_error))
 
 

--- a/services/register/mail_provider.py
+++ b/services/register/mail_provider.py
@@ -70,6 +70,7 @@ def _config(mail_config: dict) -> dict:
         "wait_timeout": float(mail_config.get("wait_timeout") or 30),
         "wait_interval": float(mail_config.get("wait_interval") or 2),
         "user_agent": str(mail_config.get("user_agent") or "Mozilla/5.0"),
+        "proxy": str(mail_config.get("proxy") or "").strip(),
     }
 
 
@@ -297,7 +298,10 @@ class DDGMailProvider(BaseMailProvider):
         self.cf_domain = entry.get("cf_domain") or []
         self.cf_create_path = str(entry.get("cf_create_path") or "/api/new_address").strip()
         self.cf_messages_path = str(entry.get("cf_messages_path") or "/api/mails").strip()
+        self.proxy = str(conf.get("proxy") or "").strip()
         self.session = curl_requests.Session(impersonate="chrome")
+        if self.proxy:
+            self.session.proxies = {"http": self.proxy, "https": self.proxy}
 
     def _cf_build_headers(self, content_type: bool = False) -> dict:
         headers = {"Content-Type": "application/json"} if content_type else {}

--- a/services/register/mail_provider.py
+++ b/services/register/mail_provider.py
@@ -349,19 +349,10 @@ class DDGMailProvider(BaseMailProvider):
 
         _record_ddg_alias(ddg_address)
 
-        if self.cf_inbox_jwt:
-            return {"provider": self.name, "provider_ref": self.provider_ref, "address": ddg_address, "token": self.cf_inbox_jwt}
+        if not self.cf_inbox_jwt:
+            raise RuntimeError("DDGMail 需要 cf_inbox_jwt（DDG 转发目标的固定收件箱 JWT），请在邮箱配置中填写 CF Inbox JWT")
 
-        cf_payload: dict[str, Any] = {"enablePrefix": True, "name": username or _random_mailbox_name()}
-        if self.cf_domain:
-            cf_payload["domain"] = _next_domain(self.cf_domain)
-        cf_create_path = "/admin/new_address" if self.cf_admin_password else self.cf_create_path
-        cf_data = self._cf_request("POST", cf_create_path, payload=cf_payload, expected=(200, 201))
-        cf_address = str(cf_data.get("address") or "").strip()
-        cf_jwt = str(cf_data.get("jwt") or "").strip()
-        if not cf_address or not cf_jwt:
-            raise RuntimeError("DDGMail CF 缺少 address 或 jwt")
-        return {"provider": self.name, "provider_ref": self.provider_ref, "address": ddg_address, "token": cf_jwt, "cf_address": cf_address}
+        return {"provider": self.name, "provider_ref": self.provider_ref, "address": ddg_address, "token": self.cf_inbox_jwt}
 
     def _parse_raw_recipient(self, raw_text: str) -> str:
         if not raw_text:

--- a/services/register/mail_provider.py
+++ b/services/register/mail_provider.py
@@ -289,6 +289,7 @@ class DDGMailProvider(BaseMailProvider):
 
     def __init__(self, entry: dict, conf: dict):
         super().__init__(conf, str(entry.get("provider_ref") or ""))
+        self.label = str(entry.get("label") or self.provider_ref)
         self.ddg_token = str(entry["ddg_token"]).strip()
         self.cf_api_base = str(entry.get("api_base") or entry.get("cf_api_base") or "").rstrip("/")
         self.cf_inbox_jwt = str(entry.get("cf_inbox_jwt") or "").strip()
@@ -349,14 +350,14 @@ class DDGMailProvider(BaseMailProvider):
         ddg_address = f"{ddg_address_part}@duck.com"
 
         if _is_ddg_alias_duplicate(ddg_address):
-            raise RuntimeError(f"DDG日上限已达，别名 {ddg_address} 已存在，自动切换邮箱提供商")
+            raise RuntimeError(f"[{self.label}] DDG日上限已达，别名 {ddg_address} 已存在，自动切换邮箱提供商")
 
         _record_ddg_alias(ddg_address)
 
         if not self.cf_inbox_jwt:
             raise RuntimeError("DDGMail 需要 cf_inbox_jwt（DDG 转发目标的固定收件箱 JWT），请在邮箱配置中填写 CF Inbox JWT")
 
-        return {"provider": self.name, "provider_ref": self.provider_ref, "address": ddg_address, "token": self.cf_inbox_jwt}
+        return {"provider": self.name, "provider_ref": self.provider_ref, "address": ddg_address, "token": self.cf_inbox_jwt, "label": self.label}
 
     def _parse_raw_recipient(self, raw_text: str) -> str:
         if not raw_text:
@@ -777,7 +778,16 @@ class YydsMailProvider(BaseMailProvider):
 
 
 def _entries(mail_config: dict) -> list[dict]:
-    return [{**item, "provider_ref": f"{item['type']}#{index + 1}"} for index, item in enumerate(mail_config["providers"])]
+    result: list[dict] = []
+    counters: dict[str, int] = {}
+    for item in mail_config["providers"]:
+        idx = len(result) + 1
+        t = item.get("type", "")
+        cnt = counters.get(t, 0) + 1
+        counters[t] = cnt
+        label = f"DDG-{cnt}" if t == "ddg_mail" else f"{t}#{idx}"
+        result.append({**item, "provider_ref": f"{item['type']}#{idx}", "label": label})
+    return result
 
 
 def _enabled_entries(mail_config: dict) -> list[dict]:

--- a/services/register/mail_provider.py
+++ b/services/register/mail_provider.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import random
 import re
 import string
@@ -13,6 +14,47 @@ from typing import Any, Callable, TypeVar
 
 import requests
 from curl_cffi import requests as curl_requests
+
+
+from services.config import DATA_DIR
+
+DDG_ALIASES_FILE = DATA_DIR / "ddg_aliases.json"
+_ddg_aliases_lock = Lock()
+
+
+def _load_ddg_aliases() -> set[str]:
+    try:
+        if DDG_ALIASES_FILE.exists():
+            data = json.loads(DDG_ALIASES_FILE.read_text(encoding="utf-8"))
+            if isinstance(data, list):
+                return {str(item).strip().lower() for item in data if str(item).strip()}
+    except Exception:
+        pass
+    return set()
+
+
+def _save_ddg_aliases(aliases: set[str]) -> None:
+    DDG_ALIASES_FILE.parent.mkdir(parents=True, exist_ok=True)
+    DDG_ALIASES_FILE.write_text(json.dumps(sorted(aliases), ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _is_ddg_alias_duplicate(address: str) -> bool:
+    target = str(address or "").strip().lower()
+    if not target:
+        return False
+    with _ddg_aliases_lock:
+        used = _load_ddg_aliases()
+        return target in used
+
+
+def _record_ddg_alias(address: str) -> None:
+    target = str(address or "").strip().lower()
+    if not target:
+        return
+    with _ddg_aliases_lock:
+        used = _load_ddg_aliases()
+        used.add(target)
+        _save_ddg_aliases(used)
 
 
 ResultT = TypeVar("ResultT")
@@ -236,6 +278,136 @@ class CloudflareTempMailProvider(BaseMailProvider):
         if isinstance(sender, dict):
             sender = sender.get("address") or sender.get("email") or sender.get("name") or ""
         return {"provider": self.name, "mailbox": mailbox["address"], "message_id": str(item.get("id") or item.get("_id") or ""), "subject": str(item.get("subject") or ""), "sender": str(sender), "text_content": text_content, "html_content": html_content, "received_at": _parse_received_at(item.get("createdAt") or item.get("created_at") or item.get("receivedAt") or item.get("date") or item.get("timestamp")), "raw": item}
+
+    def close(self) -> None:
+        self.session.close()
+
+
+class DDGMailProvider(BaseMailProvider):
+    name = "ddg_mail"
+
+    def __init__(self, entry: dict, conf: dict):
+        super().__init__(conf, str(entry.get("provider_ref") or ""))
+        self.ddg_token = str(entry["ddg_token"]).strip()
+        self.cf_api_base = str(entry.get("api_base") or entry.get("cf_api_base") or "").rstrip("/")
+        self.cf_inbox_jwt = str(entry.get("cf_inbox_jwt") or "").strip()
+        self.cf_admin_password = str(entry.get("admin_password") or "").strip()
+        self.cf_api_key = str(entry.get("cf_api_key") or "").strip()
+        self.cf_auth_mode = str(entry.get("cf_auth_mode") or "none").strip().lower()
+        self.cf_domain = entry.get("cf_domain") or []
+        self.cf_create_path = str(entry.get("cf_create_path") or "/api/new_address").strip()
+        self.cf_messages_path = str(entry.get("cf_messages_path") or "/api/mails").strip()
+        self.session = curl_requests.Session(impersonate="chrome")
+
+    def _cf_build_headers(self, content_type: bool = False) -> dict:
+        headers = {"Content-Type": "application/json"} if content_type else {}
+        if self.cf_api_key:
+            if self.cf_auth_mode == "x-api-key":
+                headers["X-API-Key"] = self.cf_api_key
+            elif self.cf_auth_mode != "none":
+                headers["Authorization"] = f"Bearer {self.cf_api_key}"
+        return headers
+
+    def _cf_request(self, method: str, path: str, headers: dict | None = None, params: dict | None = None, payload: dict | None = None, expected: tuple[int, ...] = (200,)) -> dict:
+        merged_headers = {**self._cf_build_headers(True), **(headers or {}), "User-Agent": self.conf["user_agent"]}
+        if self.cf_admin_password and method.upper() in ("POST",):
+            merged_headers["x-admin-auth"] = self.cf_admin_password
+        if self.cf_api_key and self.cf_auth_mode == "query-key":
+            params = {**(params or {}), "key": self.cf_api_key}
+        resp = self.session.request(method.upper(), f"{self.cf_api_base}{path}", headers=merged_headers, params=params, json=payload, timeout=self.conf["request_timeout"], verify=False)
+        if resp.status_code not in expected:
+            raise RuntimeError(f"DDGMail CF请求失败: {method} {path}, HTTP {resp.status_code}, body={resp.text[:300]}")
+        return {} if resp.status_code == 204 else resp.json()
+
+    def _ddg_request(self, method: str, path: str, payload: dict | None = None) -> dict:
+        resp = self.session.request(method.upper(), f"https://quack.duckduckgo.com{path}", headers={"Authorization": f"Bearer {self.ddg_token}", "Content-Type": "application/json", "User-Agent": self.conf["user_agent"]}, json=payload, timeout=self.conf["request_timeout"], verify=False)
+        if resp.status_code not in (200, 201):
+            raise RuntimeError(f"DDG API请求失败: {method} {path}, HTTP {resp.status_code}, body={resp.text[:300]}")
+        return resp.json()
+
+    def _cf_list_payload(self, data: Any) -> list:
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict):
+            for key in ("results", "hydra:member", "data", "messages"):
+                value = data.get(key)
+                if isinstance(value, list):
+                    return value
+                if isinstance(value, dict) and isinstance(value.get("messages"), list):
+                    return value["messages"]
+        return []
+
+    def create_mailbox(self, username: str | None = None) -> dict[str, Any]:
+        ddg_data = self._ddg_request("POST", "/api/email/addresses", payload={})
+        ddg_address_part = str(ddg_data.get("address") or "").strip()
+        if not ddg_address_part:
+            raise RuntimeError("DDG API 返回无 address 字段")
+        ddg_address = f"{ddg_address_part}@duck.com"
+
+        if _is_ddg_alias_duplicate(ddg_address):
+            raise RuntimeError(f"DDG日上限已达，别名 {ddg_address} 已存在，自动切换邮箱提供商")
+
+        _record_ddg_alias(ddg_address)
+
+        if self.cf_inbox_jwt:
+            return {"provider": self.name, "provider_ref": self.provider_ref, "address": ddg_address, "token": self.cf_inbox_jwt}
+
+        cf_payload: dict[str, Any] = {"enablePrefix": True, "name": username or _random_mailbox_name()}
+        if self.cf_domain:
+            cf_payload["domain"] = _next_domain(self.cf_domain)
+        cf_create_path = "/admin/new_address" if self.cf_admin_password else self.cf_create_path
+        cf_data = self._cf_request("POST", cf_create_path, payload=cf_payload, expected=(200, 201))
+        cf_address = str(cf_data.get("address") or "").strip()
+        cf_jwt = str(cf_data.get("jwt") or "").strip()
+        if not cf_address or not cf_jwt:
+            raise RuntimeError("DDGMail CF 缺少 address 或 jwt")
+        return {"provider": self.name, "provider_ref": self.provider_ref, "address": ddg_address, "token": cf_jwt, "cf_address": cf_address}
+
+    def _parse_raw_recipient(self, raw_text: str) -> str:
+        if not raw_text:
+            return ""
+        match = re.search(r"^To:\s*(.+?)$", raw_text, re.MULTILINE | re.IGNORECASE)
+        if match:
+            addr = match.group(1).strip()
+            addr = re.sub(r"\s*<[^>]*>", "", addr)
+            return addr.strip().lower()
+        try:
+            parsed = message_from_string(raw_text, policy=policy.default)
+            return str(parsed.get("To") or "").strip().lower()
+        except Exception:
+            return ""
+
+    def fetch_latest_message(self, mailbox: dict[str, Any]) -> dict[str, Any] | None:
+        target_address = str(mailbox.get("address") or "").strip().lower()
+        data = self._cf_request("GET", self.cf_messages_path, headers={"Authorization": f"Bearer {mailbox['token']}"}, params={"limit": 30, "offset": 0})
+        raw_list = self._cf_list_payload(data)
+        messages = [item for item in raw_list if isinstance(item, dict)]
+        if not messages:
+            return None
+
+        for item in messages:
+            message_id = str(item.get("id") or item.get("msgid") or item.get("_id") or "")
+            raw_text = str(item.get("raw") or "")
+            raw_recipient = self._parse_raw_recipient(raw_text)
+            if target_address and raw_recipient and target_address not in raw_recipient:
+                continue
+            text_content, html_content = _extract_content(item)
+            subject = str(item.get("subject") or "")
+            sender = item.get("from") or item.get("sender") or item.get("source") or ""
+            if isinstance(sender, dict):
+                sender = sender.get("address") or sender.get("email") or sender.get("name") or ""
+            if raw_text and (not subject or not sender or subject == sender == ""):
+                try:
+                    parsed = message_from_string(raw_text, policy=policy.default)
+                    if not subject:
+                        subject = str(parsed.get("Subject") or "")
+                    if not sender:
+                        sender = str(parsed.get("From") or "")
+                except Exception:
+                    pass
+            return {"provider": self.name, "mailbox": mailbox["address"], "message_id": message_id, "subject": subject, "sender": str(sender), "text_content": text_content, "html_content": html_content, "received_at": _parse_received_at(item.get("createdAt") or item.get("created_at") or item.get("receivedAt") or item.get("date") or item.get("timestamp")), "raw": item}
+
+        return None
 
     def close(self) -> None:
         self.session.close()
@@ -637,6 +809,8 @@ def _create_provider(mail_config: dict, provider: str = "", provider_ref: str = 
     conf = _config(mail_config)
     if entry["type"] == "cloudflare_temp_email":
         return CloudflareTempMailProvider(entry, conf)
+    if entry["type"] == "ddg_mail":
+        return DDGMailProvider(entry, conf)
     if entry["type"] == "tempmail_lol":
         return TempMailLolProvider(entry, conf)
     if entry["type"] == "duckmail":
@@ -653,11 +827,25 @@ def _create_provider(mail_config: dict, provider: str = "", provider_ref: str = 
 
 
 def create_mailbox(mail_config: dict, username: str | None = None) -> dict:
-    provider = _create_provider(mail_config)
-    try:
-        return provider.create_mailbox(username)
-    finally:
-        provider.close()
+    enabled = _enabled_entries(mail_config)
+    tried: set[str] = set()
+    last_error = ""
+    for _ in range(len(enabled)):
+        provider = _create_provider(mail_config)
+        provider_key = f"{provider.name}#{provider.provider_ref}"
+        try:
+            if provider_key in tried:
+                continue
+            tried.add(provider_key)
+            mailbox = provider.create_mailbox(username)
+            return mailbox
+        except RuntimeError as error:
+            last_error = str(error)
+            if "DDG日上限已达" not in last_error:
+                raise
+        finally:
+            provider.close()
+    raise RuntimeError(last_error or "所有启用的邮箱提供商均无法创建邮箱")
 
 
 def wait_for_code(mail_config: dict, mailbox: dict) -> str | None:

--- a/services/register/openai_register.py
+++ b/services/register/openai_register.py
@@ -501,7 +501,12 @@ class PlatformRegistrar:
         step(index, f"开始校验验证码 {code}")
         resp, error = validate_otp(self.session, self.device_id, code)
         if resp is None or resp.status_code != 200:
-            raise RuntimeError(error or f"validate_otp_http_{getattr(resp, 'status_code', 'unknown')}")
+            body = ""
+            try:
+                body = (resp.text or "")[:500] if resp is not None else ""
+            except Exception:
+                pass
+            raise RuntimeError(error or f"validate_otp_http_{getattr(resp, 'status_code', 'unknown')}_body={body}")
         step(index, "验证码校验完成")
 
     def _create_account(self, name: str, birthdate: str, index: int) -> None:
@@ -519,13 +524,17 @@ class PlatformRegistrar:
 
     def _login_and_exchange_tokens(self, email: str, password: str, mailbox: dict, index: int) -> dict:
         step(index, "开始独立登录换 token")
+        login_session = create_session("")
+        login_device_id = str(uuid.uuid4())
+        login_session.cookies.set("oai-did", login_device_id, domain=".auth.openai.com")
+        login_session.cookies.set("oai-did", login_device_id, domain="auth.openai.com")
         code_verifier, code_challenge = _generate_pkce()
         params = {
             "issuer": auth_base,
             "client_id": platform_oauth_client_id,
             "audience": platform_oauth_audience,
             "redirect_uri": platform_oauth_redirect_uri,
-            "device_id": self.device_id,
+            "device_id": login_device_id,
             "screen_hint": "login_or_signup",
             "max_age": "0",
             "login_hint": email,
@@ -538,15 +547,34 @@ class PlatformRegistrar:
             "code_challenge_method": "S256",
             "auth0Client": platform_auth0_client,
         }
-        resp, error = request_with_local_retry(self.session, "get", f"{auth_base}/api/accounts/authorize?{urlencode(params)}", headers=self._navigate_headers(f"{platform_base}/"), allow_redirects=True, verify=False)
+
+        def _login_nav_headers(referer: str = "") -> dict[str, str]:
+            h = dict(navigate_headers)
+            if referer:
+                h["referer"] = referer
+            return h
+
+        def _login_json_headers(referer: str) -> dict[str, str]:
+            h = dict(common_headers)
+            h["referer"] = referer
+            h["oai-device-id"] = login_device_id
+            h.update(_make_trace_headers())
+            return h
+
+        resp, error = request_with_local_retry(login_session, "get", f"{auth_base}/api/accounts/authorize?{urlencode(params)}", headers=_login_nav_headers(f"{platform_base}/"), allow_redirects=True, verify=False)
         if resp is None:
             raise RuntimeError(error or "platform_login_authorize_failed")
         step(index, "登录 authorize 完成")
-        headers = self._json_headers(f"{auth_base}/log-in/password")
-        headers["openai-sentinel-token"] = build_sentinel_token(self.session, self.device_id, "password_verify")
-        resp, error = request_with_local_retry(self.session, "post", f"{auth_base}/api/accounts/password/verify", json={"password": password}, headers=headers, allow_redirects=False, verify=False)
+        headers = _login_json_headers(f"{auth_base}/log-in/password")
+        headers["openai-sentinel-token"] = build_sentinel_token(login_session, login_device_id, "password_verify")
+        resp, error = request_with_local_retry(login_session, "post", f"{auth_base}/api/accounts/password/verify", json={"password": password}, headers=headers, allow_redirects=False, verify=False)
         if resp is None or resp.status_code != 200:
-            raise RuntimeError(error or f"password_verify_http_{getattr(resp, 'status_code', 'unknown')}")
+            body = ""
+            try:
+                body = (resp.text or "")[:500] if resp is not None else ""
+            except Exception:
+                pass
+            raise RuntimeError(error or f"password_verify_http_{getattr(resp, 'status_code', 'unknown')}_body={body}")
         step(index, "密码校验完成")
         payload = _response_json(resp)
         continue_url = str(payload.get("continue_url") or "").strip()
@@ -555,19 +583,22 @@ class PlatformRegistrar:
             step(index, "独立登录需要邮箱验证码")
             code = wait_for_code(mailbox)
             if not code:
+                login_session.close()
                 raise RuntimeError("独立登录等待验证码超时")
-            resp, reason = validate_otp(self.session, self.device_id, code)
+            resp, reason = validate_otp(login_session, login_device_id, code)
             if resp is None or resp.status_code != 200:
                 print("独立登录验证码校验失败响应:", resp.text if resp is not None else "None")
                 data = _response_json(resp) if resp is not None else {}
                 message = str((data.get("error") or {}).get("message") or data.get("message") or "").strip()
+                login_session.close()
                 raise RuntimeError(reason or f"独立登录验证码校验失败{': ' + message if message else ''}")
             otp_payload = _response_json(resp)
             continue_url = str(otp_payload.get("continue_url") or continue_url).strip()
             step(index, "独立登录验证码校验完成")
         if not continue_url:
             continue_url = f"{auth_base}/sign-in-with-chatgpt/codex/consent"
-        tokens = exchange_platform_tokens(self.session, self.device_id, code_verifier, continue_url)
+        tokens = exchange_platform_tokens(login_session, login_device_id, code_verifier, continue_url)
+        login_session.close()
         if not tokens:
             raise RuntimeError("token换取失败")
         step(index, "token 换取完成")

--- a/services/register/openai_register.py
+++ b/services/register/openai_register.py
@@ -610,7 +610,8 @@ class PlatformRegistrar:
         email = str(mailbox.get("address") or "").strip()
         if not email:
             raise RuntimeError("邮箱服务未返回 address")
-        step(index, f"邮箱创建完成: {email}")
+        label = str(mailbox.get("label") or "")
+        step(index, f"邮箱创建完成[{label}]: {email}")
         password = _random_password()
         first_name, last_name = _random_name()
         self._platform_authorize(email, index)

--- a/services/register_service.py
+++ b/services/register_service.py
@@ -66,9 +66,15 @@ class RegisterService:
         with self._lock:
             return json.loads(json.dumps({**self._config, "logs": self._logs[-300:]}, ensure_ascii=False))
 
+    def _inject_proxy_to_mail(self) -> None:
+        proxy = str(self._config.get("proxy") or "").strip()
+        if proxy and isinstance(self._config.get("mail"), dict):
+            self._config["mail"]["proxy"] = proxy
+
     def update(self, updates: dict) -> dict:
         with self._lock:
             self._config = _normalize({**self._config, **updates})
+            self._inject_proxy_to_mail()
             openai_register.config.update({k: self._config[k] for k in ("mail", "proxy", "total", "threads")})
             self._save()
             return self.get()
@@ -80,6 +86,7 @@ class RegisterService:
                 self._save()
                 return self.get()
             self._config["enabled"] = True
+            self._inject_proxy_to_mail()
             self._logs = []
             metrics = self._pool_metrics()
             self._config["stats"] = {"job_id": uuid.uuid4().hex, "success": 0, "fail": 0, "done": 0, "running": 0, "threads": self._config["threads"], **metrics, "started_at": _now(), "updated_at": _now()}

--- a/web/src/app/register/components/register-card.tsx
+++ b/web/src/app/register/components/register-card.tsx
@@ -54,6 +54,7 @@ export function RegisterCard() {
       ...(type === "duckmail" ? { api_key: "", default_domain: "duckmail.sbs" } : {}),
       ...(type === "gptmail" ? { api_key: "", default_domain: "" } : {}),
       ...(type === "yyds_mail" ? { api_base: "https://maliapi.215.im/v1", api_key: "", domain: [], subdomain: "", wildcard: false } : {}),
+      ...(type === "ddg_mail" ? { ddg_token: "", cf_inbox_jwt: "", cf_domain: [], admin_password: "" } : {}),
     });
   };
 
@@ -173,21 +174,34 @@ export function RegisterCard() {
                             <SelectItem value="duckmail">duckmail</SelectItem>
                             <SelectItem value="gptmail">gptmail(未测试)</SelectItem>
                             <SelectItem value="yyds_mail">yyds_mail</SelectItem>
+                            <SelectItem value="ddg_mail">ddg_mail (DDG邮箱+CF中转)</SelectItem>
                           </SelectContent>
                         </Select>
                       </div>
-                      {type === "cloudflare_temp_email" || type === "moemail" || type === "inbucket" || type === "yyds_mail" ? (
+                      {type === "cloudflare_temp_email" || type === "moemail" || type === "inbucket" || type === "yyds_mail" || type === "ddg_mail" ? (
                         <>
                           <div className="space-y-2">
                             <label className="text-sm text-stone-700">API Base</label>
                             <Input value={String(provider.api_base || "")} onChange={(event) => updateProvider(index, { api_base: event.target.value })} className="h-10 rounded-xl border-stone-200 bg-white" disabled={config.enabled} />
                           </div>
-                          {type === "cloudflare_temp_email" ? (
+                          {type === "cloudflare_temp_email" || type === "ddg_mail" ? (
                             <div className="space-y-2">
                               <label className="text-sm text-stone-700">Admin Password</label>
                               <Input value={String(provider.admin_password || "")} onChange={(event) => updateProvider(index, { admin_password: event.target.value })} className="h-10 rounded-xl border-stone-200 bg-white" disabled={config.enabled} />
                             </div>
                           ) : null}
+                        </>
+                      ) : null}
+                      {type === "ddg_mail" ? (
+                        <>
+                        <div className="space-y-2">
+                          <label className="text-sm text-stone-700">DDG Token</label>
+                          <Input value={String(provider.ddg_token || "")} onChange={(event) => updateProvider(index, { ddg_token: event.target.value })} className="h-10 rounded-xl border-stone-200 bg-white" disabled={config.enabled} placeholder="DuckDuckGo Bearer Token" />
+                        </div>
+                        <div className="space-y-2">
+                          <label className="text-sm text-stone-700">CF Inbox JWT <span className="text-stone-400">(可选，固定收件箱)</span></label>
+                          <Input value={String(provider.cf_inbox_jwt || "")} onChange={(event) => updateProvider(index, { cf_inbox_jwt: event.target.value })} className="h-10 rounded-xl border-stone-200 bg-white" disabled={config.enabled} placeholder="填写后使用固定收件箱而非动态创建" />
+                        </div>
                         </>
                       ) : null}
                       {type === "inbucket" ? (
@@ -222,7 +236,7 @@ export function RegisterCard() {
                       ) : null}
                     </div>
 
-                    {type === "tempmail_lol" || type === "cloudflare_temp_email" || type === "moemail" || type === "inbucket" || type === "yyds_mail" ? (
+                    {type === "tempmail_lol" || type === "cloudflare_temp_email" || type === "moemail" || type === "inbucket" || type === "yyds_mail" || type === "ddg_mail" ? (
                       <div className="space-y-2">
                         <label className="text-sm text-stone-700">{type === "inbucket" ? "基础域名列表" : "Domain"}</label>
                         <Textarea value={domains} onChange={(event) => updateProvider(index, { domain: event.target.value.split(/[\n,]/).map((item) => item.trim()).filter(Boolean) })} placeholder={type === "inbucket" ? "每行一个基础域名，系统会自动生成随机子域名" : type === "moemail" ? "每行一个域名" : "每行一个域名，留空则使用服务默认域名"} className="min-h-20 rounded-xl border-stone-200 bg-white font-mono text-xs" disabled={config.enabled} />

--- a/web/src/app/register/components/register-card.tsx
+++ b/web/src/app/register/components/register-card.tsx
@@ -195,12 +195,21 @@ export function RegisterCard() {
                       {type === "ddg_mail" ? (
                         <>
                         <div className="space-y-2">
-                          <label className="text-sm text-stone-700">DDG Token</label>
-                          <Input value={String(provider.ddg_token || "")} onChange={(event) => updateProvider(index, { ddg_token: event.target.value })} className="h-10 rounded-xl border-stone-200 bg-white" disabled={config.enabled} placeholder="DuckDuckGo Bearer Token" />
+                          <label className="text-sm text-stone-700">DDG Token <span className="text-red-400">*</span></label>
+                          <Input value={String(provider.ddg_token || "")} onChange={(event) => updateProvider(index, { ddg_token: event.target.value })} className="h-10 rounded-xl border-stone-200 bg-white" disabled={config.enabled} placeholder="DuckDuckGo Email Protection 的 Bearer Token" />
                         </div>
                         <div className="space-y-2">
-                          <label className="text-sm text-stone-700">CF Inbox JWT <span className="text-stone-400">(可选，固定收件箱)</span></label>
-                          <Input value={String(provider.cf_inbox_jwt || "")} onChange={(event) => updateProvider(index, { cf_inbox_jwt: event.target.value })} className="h-10 rounded-xl border-stone-200 bg-white" disabled={config.enabled} placeholder="填写后使用固定收件箱而非动态创建" />
+                          <label className="text-sm text-stone-700">CF Inbox JWT <span className="text-red-400">*</span></label>
+                          <Input value={String(provider.cf_inbox_jwt || "")} onChange={(event) => updateProvider(index, { cf_inbox_jwt: event.target.value })} className="h-10 rounded-xl border-stone-200 bg-white" disabled={config.enabled} placeholder="CF 临时邮箱后端的固定收件箱 JWT（DDG 转发目标）" />
+                        </div>
+                        <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs text-amber-800">
+                          <p className="font-medium mb-1">使用说明</p>
+                          <ol className="list-decimal list-inside space-y-0.5">
+                            <li>先在 <a href="https://duckduckgo.com/email/" target="_blank" className="underline">DuckDuckGo Email Protection</a> 登录并设置转发目标为 CF 收件箱地址</li>
+                            <li>DDG Token 从浏览器 DevTools → Network → quack.duckduckgo.com 请求中获取 <code className="bg-amber-100 px-1 rounded">Authorization: Bearer</code></li>
+                            <li>CF Inbox JWT 从 CF 临时邮箱后端创建固定收件箱后获取</li>
+                            <li>所有 @duck.com 别名收到的邮件会转发到同一个 CF 收件箱，系统按 To: 头自动匹配</li>
+                          </ol>
                         </div>
                         </>
                       ) : null}


### PR DESCRIPTION
- Add DDGMailProvider: creates @duck.com aliases via DuckDuckGo API, uses Cloudflare temp email inbox to receive forwarded verification codes
- Fix frontend register-card.tsx to show ddg_mail type in provider dropdown
- Fix field name mismatch: Python reads api_base (shared UI field) instead of cf_api_base to match what the web panel stores
- Add raw email To: header parsing to filter recipient in shared CF inbox (prevents reading OTP codes meant for other aliases)
- Use fresh login session in _login_and_exchange_tokens to avoid "invalid_state" 409 error after registration
- Add global DDG alias deduplication: auto-switch to next provider when DDG daily alias limit is reached