### PR TITLE
feat: add cloudmail provider and privacy masking UI

### DIFF
--- a/services/register/mail_provider.py
+++ b/services/register/mail_provider.py
@@ -20,6 +20,8 @@ domain_lock = Lock()
 provider_lock = Lock()
 domain_index = 0
 provider_index = 0
+cloudmail_token_lock = Lock()
+cloudmail_token_cache: dict[str, tuple[str, float]] = {}
 
 
 def _config(mail_config: dict) -> dict:
@@ -50,6 +52,13 @@ def _next_domain(domains: list[str]) -> str:
         value = domains[domain_index % len(domains)]
         domain_index = (domain_index + 1) % len(domains)
         return value
+
+
+def _normalize_string_list(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    text = str(value or "").strip()
+    return [text] if text else []
 
 
 def _parse_received_at(value: Any) -> datetime | None:
@@ -236,6 +245,125 @@ class CloudflareTempMailProvider(BaseMailProvider):
         if isinstance(sender, dict):
             sender = sender.get("address") or sender.get("email") or sender.get("name") or ""
         return {"provider": self.name, "mailbox": mailbox["address"], "message_id": str(item.get("id") or item.get("_id") or ""), "subject": str(item.get("subject") or ""), "sender": str(sender), "text_content": text_content, "html_content": html_content, "received_at": _parse_received_at(item.get("createdAt") or item.get("created_at") or item.get("receivedAt") or item.get("date") or item.get("timestamp")), "raw": item}
+
+    def close(self) -> None:
+        self.session.close()
+
+
+class CloudMailGenProvider(BaseMailProvider):
+    name = "cloudmail_gen"
+
+    def __init__(self, entry: dict, conf: dict):
+        super().__init__(conf, str(entry.get("provider_ref") or ""))
+        self.api_base = str(entry["api_base"]).rstrip("/")
+        self.admin_email = str(entry.get("admin_email") or "").strip()
+        self.admin_password = str(entry.get("admin_password") or "").strip()
+        self.domain = _normalize_string_list(entry.get("domain"))
+        self.subdomain = _normalize_string_list(entry.get("subdomain"))
+        self.email_prefix = str(entry.get("email_prefix") or "").strip()
+        self.session = curl_requests.Session(impersonate="chrome")
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        headers: dict | None = None,
+        params: dict | None = None,
+        payload: dict | None = None,
+        expected: tuple[int, ...] = (200,),
+    ):
+        resp = self.session.request(
+            method.upper(),
+            f"{self.api_base}{path}",
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent": self.conf["user_agent"],
+                **(headers or {}),
+            },
+            params=params,
+            json=payload,
+            timeout=self.conf["request_timeout"],
+            verify=False,
+        )
+        if resp.status_code not in expected:
+            raise RuntimeError(f"CloudMailGen 请求失败: {method} {path}, HTTP {resp.status_code}, body={resp.text[:300]}")
+        return {} if resp.status_code == 204 else resp.json()
+
+    def _cache_key(self) -> str:
+        return f"{self.api_base}|{self.admin_email}"
+
+    def _get_token(self) -> str:
+        if not self.admin_email or not self.admin_password:
+            raise RuntimeError("CloudMailGen 缺少 admin_email 或 admin_password")
+        cache_key = self._cache_key()
+        now = time.time()
+        with cloudmail_token_lock:
+            cached = cloudmail_token_cache.get(cache_key)
+            if cached and now < cached[1] - 300:
+                return cached[0]
+        data = self._request(
+            "POST",
+            "/api/public/genToken",
+            payload={"email": self.admin_email, "password": self.admin_password},
+        )
+        token = ""
+        if isinstance(data, dict) and data.get("code") == 200:
+            token = str((data.get("data") or {}).get("token") or "").strip()
+        if not token:
+            raise RuntimeError(f"CloudMailGen genToken 返回异常: {data}")
+        with cloudmail_token_lock:
+            cloudmail_token_cache[cache_key] = (token, now + 24 * 3600)
+        return token
+
+    def _resolve_address(self, username: str | None = None) -> str:
+        domain = _next_domain(self.domain)
+        if self.subdomain:
+            domain = f"{random.choice(self.subdomain)}.{domain}"
+        if username:
+            local_part = username
+        elif self.email_prefix:
+            local_part = f"{self.email_prefix}_{''.join(random.choices(string.ascii_lowercase + string.digits, k=6))}"
+        else:
+            local_part = _random_mailbox_name()
+        return f"{local_part}@{domain}"
+
+    def create_mailbox(self, username: str | None = None) -> dict[str, Any]:
+        if not self.domain:
+            raise RuntimeError("CloudMailGen 需要至少配置一个 domain")
+        address = self._resolve_address(username)
+        return {"provider": self.name, "provider_ref": self.provider_ref, "address": address}
+
+    def fetch_latest_message(self, mailbox: dict[str, Any]) -> dict[str, Any] | None:
+        address = str(mailbox.get("address") or "").strip()
+        if not address:
+            raise RuntimeError("CloudMailGen 缺少 address")
+        token = self._get_token()
+        data = self._request(
+            "POST",
+            "/api/public/emailList",
+            headers={"Authorization": token},
+            payload={"toEmail": address, "size": 20, "timeSort": "desc"},
+        )
+        items = (data.get("data") or []) if isinstance(data, dict) and data.get("code") == 200 else []
+        messages = [item for item in items if isinstance(item, dict) and _message_matches_email(item, address)]
+        if not messages:
+            return None
+        item = messages[0]
+        text_content, html_content = _extract_content(item)
+        return {
+            "provider": self.name,
+            "mailbox": address,
+            "message_id": str(item.get("id") or item.get("_id") or item.get("messageId") or ""),
+            "subject": str(item.get("subject") or ""),
+            "sender": str(item.get("from") or item.get("sender") or ""),
+            "text_content": text_content,
+            "html_content": html_content,
+            "received_at": _parse_received_at(
+                item.get("createdAt") or item.get("created_at") or item.get("receivedAt") or item.get("date") or item.get("timestamp")
+            ),
+            "to": item.get("to") or item.get("toEmail") or item.get("mailTo"),
+            "raw": item,
+        }
 
     def close(self) -> None:
         self.session.close()
@@ -635,6 +763,8 @@ def _create_provider(mail_config: dict, provider: str = "", provider_ref: str = 
     entry = next((dict(item) for item in _entries(mail_config) if provider_ref and item["provider_ref"] == provider_ref), None)
     entry = entry or next((dict(item) for item in _enabled_entries(mail_config) if provider and item["type"] == provider), None) or _next_entry(mail_config)
     conf = _config(mail_config)
+    if entry["type"] == "cloudmail_gen":
+        return CloudMailGenProvider(entry, conf)
     if entry["type"] == "cloudflare_temp_email":
         return CloudflareTempMailProvider(entry, conf)
     if entry["type"] == "tempmail_lol":

--- a/web/src/app/accounts/page.tsx
+++ b/web/src/app/accounts/page.tsx
@@ -149,6 +149,25 @@ function maskToken(token?: string) {
   return `${token.slice(0, 16)}...${token.slice(-8)}`;
 }
 
+function renderPrivacyEmail(email?: string | null) {
+  const value = String(email || "").trim();
+  if (!value) {
+    return <span>—</span>;
+  }
+  const atIndex = value.indexOf("@");
+  if (atIndex < 0) {
+    return <span className="transition duration-150 blur-sm hover:blur-none">{value}</span>;
+  }
+  const localPart = value.slice(0, atIndex + 1);
+  const domain = value.slice(atIndex + 1);
+  return (
+    <span className="group inline-flex max-w-full items-center">
+      <span className="truncate">{localPart}</span>
+      <span className="truncate transition duration-150 blur-sm group-hover:blur-none">{domain}</span>
+    </span>
+  );
+}
+
 function downloadTokens(accounts: Account[]) {
   const content = `${accounts.map((account) => account.access_token).join("\n")}\n`;
   const blob = new Blob([content], { type: "text/plain;charset=utf-8" });
@@ -633,8 +652,11 @@ function AccountsPageContent() {
                         </td>
                         <td className="px-4 py-3">
                           <div className="flex items-center gap-2">
-                            <span className="font-medium tracking-tight text-stone-700">
-                              {maskToken(account.access_token)}
+                            <span
+                              className="max-w-[240px] truncate font-medium tracking-tight text-stone-700 transition duration-150 blur-sm hover:blur-none"
+                              title={account.access_token}
+                            >
+                              {account.access_token}
                             </span>
                             <button
                               type="button"
@@ -663,7 +685,7 @@ function AccountsPageContent() {
                           </Badge>
                         </td>
                         <td className="px-4 py-3">
-                          <div className="text-xs leading-5 text-stone-500">{account.email ?? "—"}</div>
+                          <div className="text-xs leading-5 text-stone-500">{renderPrivacyEmail(account.email)}</div>
                         </td>
                         <td className="px-4 py-3">
                           <Badge variant="info" className="rounded-md">

--- a/web/src/app/register/components/register-card.tsx
+++ b/web/src/app/register/components/register-card.tsx
@@ -47,6 +47,7 @@ export function RegisterCard() {
     updateProvider(index, {
       type,
       enable: true,
+      ...(type === "cloudmail_gen" ? { api_base: "", admin_email: "", admin_password: "", domain: [], subdomain: [], email_prefix: "" } : {}),
       ...(type === "cloudflare_temp_email" ? { api_base: "", admin_password: "", domain: [] } : {}),
       ...(type === "tempmail_lol" ? { api_key: "", domain: [] } : {}),
       ...(type === "moemail" ? { api_base: "", api_key: "", domain: [] } : {}),
@@ -146,6 +147,7 @@ export function RegisterCard() {
               {providers.map((provider, index) => {
                 const type = String(provider.type || "tempmail_lol");
                 const domains = Array.isArray(provider.domain) ? provider.domain.map(String).join("\n") : "";
+                const subdomains = Array.isArray(provider.subdomain) ? provider.subdomain.map(String).join("\n") : "";
                 return (
                   <div key={index} className="space-y-3 border-t border-stone-200 pt-3 first:border-t-0 first:pt-0">
                     <div className="flex items-center justify-between gap-3">
@@ -166,6 +168,7 @@ export function RegisterCard() {
                             <SelectValue />
                           </SelectTrigger>
                           <SelectContent>
+                            <SelectItem value="cloudmail_gen">cloudmail_gen</SelectItem>
                             <SelectItem value="cloudflare_temp_email">cloudflare_temp_email</SelectItem>
                             <SelectItem value="tempmail_lol">tempmail_lol</SelectItem>
                             <SelectItem value="moemail">moemail</SelectItem>
@@ -176,12 +179,24 @@ export function RegisterCard() {
                           </SelectContent>
                         </Select>
                       </div>
-                      {type === "cloudflare_temp_email" || type === "moemail" || type === "inbucket" || type === "yyds_mail" ? (
+                      {type === "cloudmail_gen" || type === "cloudflare_temp_email" || type === "moemail" || type === "inbucket" || type === "yyds_mail" ? (
                         <>
                           <div className="space-y-2">
-                            <label className="text-sm text-stone-700">API Base</label>
+                            <label className="text-sm text-stone-700">{type === "cloudmail_gen" ? "CloudMail URL" : "API Base"}</label>
                             <Input value={String(provider.api_base || "")} onChange={(event) => updateProvider(index, { api_base: event.target.value })} className="h-10 rounded-xl border-stone-200 bg-white" disabled={config.enabled} />
                           </div>
+                          {type === "cloudmail_gen" ? (
+                            <>
+                              <div className="space-y-2">
+                                <label className="text-sm text-stone-700">管理员邮箱</label>
+                                <Input value={String(provider.admin_email || "")} onChange={(event) => updateProvider(index, { admin_email: event.target.value })} className="h-10 rounded-xl border-stone-200 bg-white" disabled={config.enabled} />
+                              </div>
+                              <div className="space-y-2">
+                                <label className="text-sm text-stone-700">管理员密码</label>
+                                <Input value={String(provider.admin_password || "")} onChange={(event) => updateProvider(index, { admin_password: event.target.value })} className="h-10 rounded-xl border-stone-200 bg-white" disabled={config.enabled} />
+                              </div>
+                            </>
+                          ) : null}
                           {type === "cloudflare_temp_email" ? (
                             <div className="space-y-2">
                               <label className="text-sm text-stone-700">Admin Password</label>
@@ -222,10 +237,16 @@ export function RegisterCard() {
                       ) : null}
                     </div>
 
-                    {type === "tempmail_lol" || type === "cloudflare_temp_email" || type === "moemail" || type === "inbucket" || type === "yyds_mail" ? (
+                    {type === "cloudmail_gen" || type === "tempmail_lol" || type === "cloudflare_temp_email" || type === "moemail" || type === "inbucket" || type === "yyds_mail" ? (
                       <div className="space-y-2">
-                        <label className="text-sm text-stone-700">{type === "inbucket" ? "基础域名列表" : "Domain"}</label>
-                        <Textarea value={domains} onChange={(event) => updateProvider(index, { domain: event.target.value.split(/[\n,]/).map((item) => item.trim()).filter(Boolean) })} placeholder={type === "inbucket" ? "每行一个基础域名，系统会自动生成随机子域名" : type === "moemail" ? "每行一个域名" : "每行一个域名，留空则使用服务默认域名"} className="min-h-20 rounded-xl border-stone-200 bg-white font-mono text-xs" disabled={config.enabled} />
+                        <label className="text-sm text-stone-700">{type === "cloudmail_gen" ? "邮箱域名" : type === "inbucket" ? "基础域名列表" : "Domain"}</label>
+                        <Textarea value={domains} onChange={(event) => updateProvider(index, { domain: event.target.value.split(/[\n,]/).map((item) => item.trim()).filter(Boolean) })} placeholder={type === "cloudmail_gen" ? "每行一个域名，留空则使用服务默认域名" : type === "inbucket" ? "每行一个基础域名，系统会自动生成随机子域名" : type === "moemail" ? "每行一个域名" : "每行一个域名，留空则使用服务默认域名"} className="min-h-20 rounded-xl border-stone-200 bg-white font-mono text-xs" disabled={config.enabled} />
+                      </div>
+                    ) : null}
+                    {type === "cloudmail_gen" ? (
+                      <div className="space-y-2">
+                        <label className="text-sm text-stone-700">子域名（支持多个）</label>
+                        <Textarea value={subdomains} onChange={(event) => updateProvider(index, { subdomain: event.target.value.split(/[\n,]/).map((item) => item.trim()).filter(Boolean) })} placeholder="每行一个子域名前缀，留空则直接使用主域名" className="min-h-20 rounded-xl border-stone-200 bg-white font-mono text-xs" disabled={config.enabled} />
                       </div>
                     ) : null}
                   </div>

--- a/web/src/app/settings/store.ts
+++ b/web/src/app/settings/store.ts
@@ -591,7 +591,7 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
           ...state.registerConfig.mail,
           providers: [
             ...(state.registerConfig.mail.providers || []),
-            { enable: true, type: "tempmail_lol", api_key: "", domain: [] },
+            { enable: true, type: "cloudmail_gen", api_base: "", admin_email: "", admin_password: "", domain: [], subdomain: [], email_prefix: "" },
           ],
         },
       },


### PR DESCRIPTION
## 变更概述

这个 PR 为注册流程新增了 `cloudmail_gen` 邮箱提供商支持，并同步更新了前端注册配置界面。

另外，还对号池管理页面中的 token 和邮箱域名信息增加了隐私模糊显示，避免敏感信息直接暴露。

## 具体改动

- 在 `services/register/mail_provider.py` 中新增 `cloudmail_gen` provider
- 将 `cloudmail_gen` 接入注册流程的 provider 选择逻辑
- 在注册页面中新增 CloudMail 相关配置项：
  - CloudMail URL
  - 管理员邮箱
  - 管理员密码
  - 邮箱域名
  - 子域名（支持多个）
- 将新增注册 provider 的默认类型调整为 `cloudmail_gen`
- 在号池管理页面中，为 token 和邮箱域名增加隐私模糊显示

## 说明

- 本次提交未包含本地配置、账号数据、auth 文件等敏感内容
- 相关改动已经在本地 Docker 构建环境中完成验证