### PR TITLE
fix: improve API error responses and image edit polling

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -8,6 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 
 from api import accounts, ai, image_tasks, register, system
+from api.errors import install_exception_handlers
 from api.support import resolve_web_asset, start_limited_account_watcher
 from services.backup_service import backup_service
 from services.config import config
@@ -30,6 +31,7 @@ def create_app() -> FastAPI:
             backup_service.stop()
 
     app = FastAPI(title="chatgpt2api", version=app_version, lifespan=lifespan)
+    install_exception_handlers(app)
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["*"],

--- a/api/errors.py
+++ b/api/errors.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, Request
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+from services.protocol.error_response import anthropic_error_response, openai_error_response
+
+
+def _is_openai_compatible_path(path: str) -> bool:
+    return path == "/v1" or path.startswith("/v1/")
+
+
+def _is_anthropic_messages_path(path: str) -> bool:
+    return path == "/v1/messages"
+
+
+def _compatible_error_response(
+    request: Request,
+    detail: object,
+    status_code: int,
+    headers: dict[str, str] | None = None,
+) -> JSONResponse:
+    if _is_anthropic_messages_path(request.url.path):
+        return anthropic_error_response(detail, status_code, headers=headers)
+    return openai_error_response(detail, status_code, headers=headers)
+
+
+def install_exception_handlers(app: FastAPI) -> None:
+    @app.exception_handler(StarletteHTTPException)
+    async def http_exception_handler(request: Request, exc: StarletteHTTPException) -> JSONResponse:
+        if _is_openai_compatible_path(request.url.path):
+            return _compatible_error_response(request, exc.detail, exc.status_code, exc.headers)
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={"detail": jsonable_encoder(exc.detail)},
+            headers=exc.headers,
+        )
+
+    @app.exception_handler(RequestValidationError)
+    async def validation_exception_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
+        if _is_openai_compatible_path(request.url.path):
+            return _compatible_error_response(request, exc.errors(), 422)
+        return JSONResponse(status_code=422, content={"detail": jsonable_encoder(exc.errors())})

--- a/services/log_service.py
+++ b/services/log_service.py
@@ -15,6 +15,7 @@ from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import JSONResponse, StreamingResponse
 
 from services.config import DATA_DIR
+from services.protocol.error_response import anthropic_error_response, openai_error_response
 from utils.helper import anthropic_sse_stream, sse_json_stream
 
 LOG_TYPE_CALL = "call"
@@ -140,9 +141,8 @@ def _request_excerpt(text: object, limit: int = 1000) -> str:
 def _image_error_response(exc: Exception) -> JSONResponse:
     message = str(exc)
     if "no available image quota" in message.lower():
-        return JSONResponse(
-            status_code=429,
-            content={
+        return openai_error_response(
+            {
                 "error": {
                     "message": "no available image quota",
                     "type": "insufficient_quota",
@@ -150,20 +150,18 @@ def _image_error_response(exc: Exception) -> JSONResponse:
                     "code": "insufficient_quota",
                 }
             },
+            429,
         )
     if hasattr(exc, "to_openai_error") and hasattr(exc, "status_code"):
         return JSONResponse(status_code=int(exc.status_code), content=exc.to_openai_error())
-    return JSONResponse(
-        status_code=502,
-        content={
-            "error": {
-                "message": message,
-                "type": "server_error",
-                "param": None,
-                "code": "upstream_error",
-            }
-        },
-    )
+    return openai_error_response(message, 502)
+
+
+def _protocol_error_response(exc: Exception, status_code: int, sse: str) -> JSONResponse:
+    message = str(exc)
+    if sse == "anthropic":
+        return anthropic_error_response(message, status_code)
+    return openai_error_response(message, status_code)
 
 
 def _next_item(items):
@@ -195,7 +193,7 @@ class LoggedCall:
             raise
         except Exception as exc:
             self.log("调用失败", status="failed", error=str(exc))
-            raise HTTPException(status_code=502, detail={"error": str(exc)}) from exc
+            return _protocol_error_response(exc, 502, sse)
 
         if isinstance(result, dict):
             self.log("调用完成", result)
@@ -212,7 +210,7 @@ class LoggedCall:
             raise
         except Exception as exc:
             self.log("调用失败", status="failed", error=str(exc))
-            raise HTTPException(status_code=502, detail={"error": str(exc)}) from exc
+            return _protocol_error_response(exc, 502, sse)
         if not has_first:
             self.log("流式调用结束")
             return StreamingResponse(sender(()), media_type="text/event-stream")

--- a/services/protocol/conversation.py
+++ b/services/protocol/conversation.py
@@ -572,7 +572,6 @@ def stream_image_outputs(
     file_ids = [str(item) for item in last.get("file_ids") or []]
     sediment_ids = [str(item) for item in last.get("sediment_ids") or []]
     message = str(last.get("text") or "").strip()
-    is_text_response = last.get("tool_invoked") is False or last.get("turn_use_case") == "text"
     logger.info({
         "event": "image_stream_resolve_start",
         "conversation_id": conversation_id,
@@ -581,7 +580,11 @@ def stream_image_outputs(
         "tool_invoked": last.get("tool_invoked"),
         "turn_use_case": last.get("turn_use_case"),
     })
-    if message and not file_ids and not sediment_ids and (last.get("blocked") or is_text_response):
+    if message and not file_ids and not sediment_ids and last.get("blocked"):
+        yield ImageOutput(kind="message", model=request.model, index=index, total=total, text=message)
+        return
+    should_poll_for_image = bool(request.images) or last.get("turn_use_case") == "image gen"
+    if message and not file_ids and not sediment_ids and not should_poll_for_image:
         yield ImageOutput(kind="message", model=request.model, index=index, total=total, text=message)
         return
 

--- a/services/protocol/error_response.py
+++ b/services/protocol/error_response.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi.responses import JSONResponse
+
+
+def _message_from_value(value: object) -> str:
+    if isinstance(value, str):
+        return value
+    if not isinstance(value, dict):
+        return ""
+    message = value.get("message")
+    if isinstance(message, str) and message:
+        return message
+    return _message_from_value(value.get("error"))
+
+
+def error_message_from_detail(detail: object) -> str:
+    if isinstance(detail, list):
+        messages = []
+        for item in detail:
+            if not isinstance(item, dict):
+                continue
+            location = ".".join(str(part) for part in item.get("loc", []) if part != "body")
+            message = str(item.get("msg") or "").strip()
+            if location and message:
+                messages.append(f"{location}: {message}")
+            elif message:
+                messages.append(message)
+        return "; ".join(messages)
+    if isinstance(detail, dict):
+        message = _message_from_value(detail.get("error")) or _message_from_value(detail)
+        if message:
+            return message
+    return str(detail or "").strip()
+
+
+def _default_error_type(status_code: int) -> str:
+    if status_code == 401:
+        return "authentication_error"
+    if status_code == 403:
+        return "permission_error"
+    if status_code == 429:
+        return "rate_limit_error"
+    if 400 <= status_code < 500:
+        return "invalid_request_error"
+    return "server_error"
+
+
+def _default_error_code(status_code: int) -> str:
+    if status_code == 401:
+        return "invalid_api_key"
+    if status_code == 403:
+        return "permission_denied"
+    if status_code == 429:
+        return "rate_limit_exceeded"
+    if 400 <= status_code < 500:
+        return "bad_request"
+    return "upstream_error"
+
+
+def openai_error_payload(
+    detail: object,
+    status_code: int,
+    *,
+    error_type: str | None = None,
+    code: object | None = None,
+    param: object | None = None,
+) -> dict[str, Any]:
+    error_detail = detail.get("error") if isinstance(detail, dict) else None
+    if isinstance(error_detail, dict):
+        return {
+            "error": {
+                "message": error_message_from_detail(error_detail) or "request failed",
+                "type": str(error_detail.get("type") or error_type or _default_error_type(status_code)),
+                "param": error_detail.get("param", param),
+                "code": error_detail.get("code", code if code is not None else _default_error_code(status_code)),
+            }
+        }
+    return {
+        "error": {
+            "message": error_message_from_detail(detail) or "request failed",
+            "type": error_type or _default_error_type(status_code),
+            "param": param,
+            "code": code if code is not None else _default_error_code(status_code),
+        }
+    }
+
+
+def openai_error_response(
+    detail: object,
+    status_code: int,
+    *,
+    headers: dict[str, str] | None = None,
+    error_type: str | None = None,
+    code: object | None = None,
+    param: object | None = None,
+) -> JSONResponse:
+    return JSONResponse(
+        status_code=status_code,
+        content=openai_error_payload(detail, status_code, error_type=error_type, code=code, param=param),
+        headers=headers,
+    )
+
+
+def anthropic_error_response(
+    detail: object,
+    status_code: int,
+    *,
+    headers: dict[str, str] | None = None,
+) -> JSONResponse:
+    error_type = "api_error" if status_code >= 500 else _default_error_type(status_code)
+    return JSONResponse(
+        status_code=status_code,
+        content={
+            "type": "error",
+            "error": {
+                "type": error_type,
+                "message": error_message_from_detail(detail) or "request failed",
+            },
+        },
+        headers=headers,
+    )


### PR DESCRIPTION
## Summary

- Add OpenAI/Anthropic-compatible error response helpers and install them on the main FastAPI app.
- Normalize logged runtime and image generation errors into client-compatible response shapes.
- Avoid prematurely failing image edit requests when upstream returns text before delayed image attachments become available.

## Root Cause

- Some protocol errors were returned through FastAPI default shapes, which made compatible clients receive inconsistent error payloads.
- Image edit requests with references can receive an upstream text message before the final image attachment is available in the conversation. The previous handling treated that text as the final failure too early.

## Impact

- Clients now receive more consistent OpenAI/Anthropic-style errors.
- Image edit requests continue polling for delayed image results when references are present, while blocked or pure text responses still return quickly.

## Validation

- Ran `uv run python -m compileall api/app.py api/errors.py services/log_service.py services/protocol/error_response.py services/protocol/conversation.py`.
- Confirmed the PR diff contains runtime code only and does not include test files.