### PR TITLE
fix(api): 统一兼容 OpenAI/Anthropic 错误响应

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -8,6 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 
 from api import accounts, ai, image_tasks, register, system
+from api.errors import install_exception_handlers
 from api.support import resolve_web_asset, start_limited_account_watcher
 from services.backup_service import backup_service
 from services.config import config
@@ -30,6 +31,7 @@ def create_app() -> FastAPI:
             backup_service.stop()
 
     app = FastAPI(title="chatgpt2api", version=app_version, lifespan=lifespan)
+    install_exception_handlers(app)
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["*"],

--- a/api/errors.py
+++ b/api/errors.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, Request
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+from services.protocol.error_response import anthropic_error_response, openai_error_response
+
+
+def _is_openai_compatible_path(path: str) -> bool:
+    return path == "/v1" or path.startswith("/v1/")
+
+
+def _is_anthropic_messages_path(path: str) -> bool:
+    return path == "/v1/messages"
+
+
+def _compatible_error_response(
+    request: Request,
+    detail: object,
+    status_code: int,
+    headers: dict[str, str] | None = None,
+) -> JSONResponse:
+    if _is_anthropic_messages_path(request.url.path):
+        return anthropic_error_response(detail, status_code, headers=headers)
+    return openai_error_response(detail, status_code, headers=headers)
+
+
+def install_exception_handlers(app: FastAPI) -> None:
+    @app.exception_handler(StarletteHTTPException)
+    async def http_exception_handler(request: Request, exc: StarletteHTTPException) -> JSONResponse:
+        if _is_openai_compatible_path(request.url.path):
+            return _compatible_error_response(request, exc.detail, exc.status_code, exc.headers)
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={"detail": jsonable_encoder(exc.detail)},
+            headers=exc.headers,
+        )
+
+    @app.exception_handler(RequestValidationError)
+    async def validation_exception_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
+        if _is_openai_compatible_path(request.url.path):
+            return _compatible_error_response(request, exc.errors(), 422)
+        return JSONResponse(status_code=422, content={"detail": jsonable_encoder(exc.errors())})

--- a/services/log_service.py
+++ b/services/log_service.py
@@ -15,6 +15,7 @@ from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import JSONResponse, StreamingResponse
 
 from services.config import DATA_DIR
+from services.protocol.error_response import anthropic_error_response, openai_error_response
 from utils.helper import anthropic_sse_stream, sse_json_stream
 
 LOG_TYPE_CALL = "call"
@@ -140,9 +141,8 @@ def _request_excerpt(text: object, limit: int = 1000) -> str:
 def _image_error_response(exc: Exception) -> JSONResponse:
     message = str(exc)
     if "no available image quota" in message.lower():
-        return JSONResponse(
-            status_code=429,
-            content={
+        return openai_error_response(
+            {
                 "error": {
                     "message": "no available image quota",
                     "type": "insufficient_quota",
@@ -150,20 +150,18 @@ def _image_error_response(exc: Exception) -> JSONResponse:
                     "code": "insufficient_quota",
                 }
             },
+            429,
         )
     if hasattr(exc, "to_openai_error") and hasattr(exc, "status_code"):
         return JSONResponse(status_code=int(exc.status_code), content=exc.to_openai_error())
-    return JSONResponse(
-        status_code=502,
-        content={
-            "error": {
-                "message": message,
-                "type": "server_error",
-                "param": None,
-                "code": "upstream_error",
-            }
-        },
-    )
+    return openai_error_response(message, 502)
+
+
+def _protocol_error_response(exc: Exception, status_code: int, sse: str) -> JSONResponse:
+    message = str(exc)
+    if sse == "anthropic":
+        return anthropic_error_response(message, status_code)
+    return openai_error_response(message, status_code)
 
 
 def _next_item(items):
@@ -195,7 +193,7 @@ class LoggedCall:
             raise
         except Exception as exc:
             self.log("调用失败", status="failed", error=str(exc))
-            raise HTTPException(status_code=502, detail={"error": str(exc)}) from exc
+            return _protocol_error_response(exc, 502, sse)
 
         if isinstance(result, dict):
             self.log("调用完成", result)
@@ -212,7 +210,7 @@ class LoggedCall:
             raise
         except Exception as exc:
             self.log("调用失败", status="failed", error=str(exc))
-            raise HTTPException(status_code=502, detail={"error": str(exc)}) from exc
+            return _protocol_error_response(exc, 502, sse)
         if not has_first:
             self.log("流式调用结束")
             return StreamingResponse(sender(()), media_type="text/event-stream")

--- a/services/protocol/error_response.py
+++ b/services/protocol/error_response.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi.responses import JSONResponse
+
+
+def _message_from_value(value: object) -> str:
+    if isinstance(value, str):
+        return value
+    if not isinstance(value, dict):
+        return ""
+    message = value.get("message")
+    if isinstance(message, str) and message:
+        return message
+    return _message_from_value(value.get("error"))
+
+
+def error_message_from_detail(detail: object) -> str:
+    if isinstance(detail, list):
+        messages = []
+        for item in detail:
+            if not isinstance(item, dict):
+                continue
+            location = ".".join(str(part) for part in item.get("loc", []) if part != "body")
+            message = str(item.get("msg") or "").strip()
+            if location and message:
+                messages.append(f"{location}: {message}")
+            elif message:
+                messages.append(message)
+        return "; ".join(messages)
+    if isinstance(detail, dict):
+        message = _message_from_value(detail.get("error")) or _message_from_value(detail)
+        if message:
+            return message
+    return str(detail or "").strip()
+
+
+def _default_error_type(status_code: int) -> str:
+    if status_code == 401:
+        return "authentication_error"
+    if status_code == 403:
+        return "permission_error"
+    if status_code == 429:
+        return "rate_limit_error"
+    if 400 <= status_code < 500:
+        return "invalid_request_error"
+    return "server_error"
+
+
+def _default_error_code(status_code: int) -> str:
+    if status_code == 401:
+        return "invalid_api_key"
+    if status_code == 403:
+        return "permission_denied"
+    if status_code == 429:
+        return "rate_limit_exceeded"
+    if 400 <= status_code < 500:
+        return "bad_request"
+    return "upstream_error"
+
+
+def openai_error_payload(
+    detail: object,
+    status_code: int,
+    *,
+    error_type: str | None = None,
+    code: object | None = None,
+    param: object | None = None,
+) -> dict[str, Any]:
+    error_detail = detail.get("error") if isinstance(detail, dict) else None
+    if isinstance(error_detail, dict):
+        return {
+            "error": {
+                "message": error_message_from_detail(error_detail) or "request failed",
+                "type": str(error_detail.get("type") or error_type or _default_error_type(status_code)),
+                "param": error_detail.get("param", param),
+                "code": error_detail.get("code", code if code is not None else _default_error_code(status_code)),
+            }
+        }
+    return {
+        "error": {
+            "message": error_message_from_detail(detail) or "request failed",
+            "type": error_type or _default_error_type(status_code),
+            "param": param,
+            "code": code if code is not None else _default_error_code(status_code),
+        }
+    }
+
+
+def openai_error_response(
+    detail: object,
+    status_code: int,
+    *,
+    headers: dict[str, str] | None = None,
+    error_type: str | None = None,
+    code: object | None = None,
+    param: object | None = None,
+) -> JSONResponse:
+    return JSONResponse(
+        status_code=status_code,
+        content=openai_error_payload(detail, status_code, error_type=error_type, code=code, param=param),
+        headers=headers,
+    )
+
+
+def anthropic_error_response(
+    detail: object,
+    status_code: int,
+    *,
+    headers: dict[str, str] | None = None,
+) -> JSONResponse:
+    error_type = "api_error" if status_code >= 500 else _default_error_type(status_code)
+    return JSONResponse(
+        status_code=status_code,
+        content={
+            "type": "error",
+            "error": {
+                "type": error_type,
+                "message": error_message_from_detail(detail) or "request failed",
+            },
+        },
+        headers=headers,
+    )


### PR DESCRIPTION
## 背景

生产排查时发现，部分 `/v1/*` 兼容接口在异常路径下会返回 FastAPI 默认错误结构，或者把运行时异常直接包装成不稳定的字符串。

这会导致 OpenAI / Anthropic 兼容客户端拿到的错误 payload 不一致：有时是 `detail`，有时是裸字符串，有时又是图片链路自己的错误格式。对接方很难稳定解析 `error.message`、`error.type` 和状态码。

## 根因

当前异常处理分散在多个调用点：

- FastAPI 参数校验和 HTTPException 走默认响应结构。
- 普通 RuntimeError 由 `LoggedCall` 临时包装。
- 图片生成错误有单独的 `ImageGenerationError` 分支。
- Anthropic `/v1/messages` 需要另一套 `type: error` 响应结构。

这些路径没有统一出口，导致兼容接口在失败时暴露了实现细节，而不是协议兼容的错误格式。

## 改动

- 新增 `api.errors.install_exception_handlers`，在主 FastAPI app 上安装兼容异常处理器。
- 新增 `services.protocol.error_response`，集中生成 OpenAI 和 Anthropic 风格错误响应。
- 调整 `LoggedCall` 的异常响应逻辑：
  - OpenAI 风格接口返回 `{ "error": { "message", "type", "param", "code" } }`。
  - Anthropic 消息接口返回 `{ "type": "error", "error": { "type", "message" } }`。
  - 图片额度不足仍映射为 `insufficient_quota` / 429。
- 保留现有日志记录行为，只改变客户端可见的错误响应形状。

## 调整后结果

线上反馈已经从原先不稳定、难解析的错误内容，变成明确的兼容错误：

<img width="1214" height="652" alt="image" src="https://github.com/user-attachments/assets/0ad8b5f9-095a-4177-9314-4b44a4eb54c7" />
<img width="408" height="172" alt="image" src="https://github.com/user-attachments/assets/de00f93a-7645-452d-97be-7ff41f969252" />


这说明修复后调用方可以稳定拿到 HTTP 400 和可读的审核拒绝原因，客户端也能按兼容错误结构展示，不再暴露 FastAPI `detail` 或裸字符串。

## 影响

这个改动只影响异常路径，不改变成功响应结构。客户端可以更稳定地按 OpenAI/Anthropic 兼容协议解析失败原因。

## 验证

- [x] 本地语法检查通过：`uv run python -m compileall api/app.py api/errors.py services/log_service.py services/protocol/error_response.py`。
- [x] 线上客户端验证：AI 审核未通过时，调用方现在能拿到 `status_code=400` 和明确的 `AI 审核未通过，拒绝本次任务`，前端也能展示为 `AI_APICallError` 的可读错误，而不是混乱的 FastAPI `detail` 或不可解析字符串。
- [x] 本地配套验证已覆盖 OpenAI 校验错误、HTTPException、RuntimeError、Anthropic 错误结构；为减少 review 负担未包含测试文件进 PR。