### PR TITLE
fix(image): 避免图片任务因前置文本过早失败

### DIFF
--- a/services/protocol/conversation.py
+++ b/services/protocol/conversation.py
@@ -572,7 +572,6 @@ def stream_image_outputs(
     file_ids = [str(item) for item in last.get("file_ids") or []]
     sediment_ids = [str(item) for item in last.get("sediment_ids") or []]
     message = str(last.get("text") or "").strip()
-    is_text_response = last.get("tool_invoked") is False or last.get("turn_use_case") == "text"
     logger.info({
         "event": "image_stream_resolve_start",
         "conversation_id": conversation_id,
@@ -581,7 +580,11 @@ def stream_image_outputs(
         "tool_invoked": last.get("tool_invoked"),
         "turn_use_case": last.get("turn_use_case"),
     })
-    if message and not file_ids and not sediment_ids and (last.get("blocked") or is_text_response):
+    if message and not file_ids and not sediment_ids and last.get("blocked"):
+        yield ImageOutput(kind="message", model=request.model, index=index, total=total, text=message)
+        return
+    should_poll_for_image = bool(request.images) or last.get("turn_use_case") == "image gen"
+    if message and not file_ids and not sediment_ids and not should_poll_for_image:
         yield ImageOutput(kind="message", model=request.model, index=index, total=total, text=message)
         return
 


### PR DESCRIPTION
## 背景

生产日志里看到一类图片请求快速失败：上游先返回一段 assistant 文本，但生成图片的 asset 可能稍后才写入 conversation。

旧逻辑在没有 `file_ids` / `sediment_ids` 且看到文本响应时，会直接把文本作为最终失败返回，导致已有的图片结果解析和 poll 逻辑没有机会执行。

## 根因

`stream_image_outputs` 对文本响应的提前返回条件过宽：

- 有 assistant 文本
- 暂时没有图片 id
- `tool_invoked is False` 或 `turn_use_case == "text"`

这会误伤图片任务中的“前置文本”场景。实际上后续 `resolve_conversation_image_urls()` 已经具备基于 `conversation_id` 查询延迟图片 asset 的能力，但提前 return 跳过了它。

## 改动

- moderation blocked 仍然快速返回。
- 图片任务存在参考图，或上游标记为 `image gen` 时，不再因为前置文本提前失败。
- 继续进入已有的 `resolve_conversation_image_urls()` 路径，等待 conversation 里延迟出现的图片 asset。
- 没有图片上下文的纯文本响应仍快速返回，避免无意义等待。

## 影响

- 修复“先出文字、后出图”时被过早判失败的问题。
- 不改变成功响应结构。
- 不新增额外接口，只修正现有流程的提前退出条件。

## 验证

- [x] 本地语法检查：`uv run python -m compileall services/protocol/conversation.py`
- [x] 本地覆盖过“先文本后图片 asset”“blocked 不 poll”“纯文本响应不 poll”；为减少 review 负担未包含测试文件进 PR。