### PR TITLE
feat: image storage management + account pool stats

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -12,6 +12,7 @@ from api.errors import install_exception_handlers
 from api.support import resolve_web_asset, start_limited_account_watcher
 from services.backup_service import backup_service
 from services.config import config
+from services.image_service import start_image_cleanup_scheduler
 
 
 def create_app() -> FastAPI:
@@ -21,6 +22,7 @@ def create_app() -> FastAPI:
     async def lifespan(_: FastAPI):
         stop_event = Event()
         thread = start_limited_account_watcher(stop_event)
+        cleanup_thread = start_image_cleanup_scheduler(stop_event)
         backup_service.start()
         config.cleanup_old_images()
         try:
@@ -28,6 +30,7 @@ def create_app() -> FastAPI:
         finally:
             stop_event.set()
             thread.join(timeout=1)
+            cleanup_thread.join(timeout=1)
             backup_service.stop()
 
     app = FastAPI(title="chatgpt2api", version=app_version, lifespan=lifespan)

--- a/api/system.py
+++ b/api/system.py
@@ -2,15 +2,25 @@ from __future__ import annotations
 
 from urllib.parse import quote
 
-from fastapi import APIRouter, Header, HTTPException, Request
+from fastapi import APIRouter, Header, HTTPException, Query, Request
 from fastapi.concurrency import run_in_threadpool
-from fastapi.responses import Response, StreamingResponse
+from fastapi.responses import HTMLResponse, Response, StreamingResponse
 from pydantic import BaseModel, ConfigDict
 
 from api.support import require_admin, require_identity, resolve_image_base_url
 from services.backup_service import BackupError, backup_service
 from services.config import config
-from services.image_service import delete_images, download_images_zip, get_image_download_response, get_image_response, get_thumbnail_response, list_images
+from services.image_service import (
+    compress_images,
+    delete_images,
+    delete_to_target,
+    download_images_zip,
+    get_image_download_response,
+    get_image_response,
+    get_thumbnail_response,
+    list_images,
+    storage_stats,
+)
 from services.image_storage_service import ImageStorageError, image_storage_service
 from services.image_tags_service import delete_tag, get_all_tags, set_tags
 from services.log_service import log_service
@@ -232,5 +242,93 @@ def create_router(app_version: str) -> APIRouter:
         require_admin(authorization)
         count = delete_tag(tag)
         return {"ok": True, "removed_from": count}
+
+    @router.get("/api/images/storage")
+    async def get_image_storage(authorization: str | None = Header(default=None)):
+        require_admin(authorization)
+        return storage_stats()
+
+    @router.post("/api/images/storage/compress")
+    async def compress_all_images(authorization: str | None = Header(default=None)):
+        require_admin(authorization)
+        return await run_in_threadpool(compress_images)
+
+    @router.post("/api/images/storage/cleanup-to-target")
+    async def cleanup_to_target(
+        target_free_mb: int = 500,
+        dry_run: bool = False,
+        authorization: str | None = Header(default=None),
+    ):
+        require_admin(authorization)
+        return await run_in_threadpool(delete_to_target, target_free_mb, dry_run)
+
+    @router.get("/health", response_model=None)
+    async def health_dashboard(format: str = Query(default="html")):
+        from services.account_service import account_service as acct_svc
+        stats = acct_svc.get_stats()
+        storage = config.get_storage_backend()
+        storage_health = storage.health_check()
+        healthy = stats["active"] > 0 or stats["unlimited_quota_count"] > 0
+
+        stats_json = {
+            "status": "ok" if healthy else "degraded",
+            "healthy": healthy,
+            "version": app_version,
+            "storage": {"backend": storage.get_backend_info(), "health": storage_health},
+            "accounts": stats,
+        }
+        if format == "json":
+            return stats_json
+        return HTMLResponse(f"""<!DOCTYPE html>
+<html lang="zh">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>号池健康监控 - chatgpt2api</title>
+<style>
+*{{margin:0;padding:0;box-sizing:border-box}}
+body{{font-family:system-ui,-apple-system,sans-serif;background:#0f1117;color:#e2e8f0;min-height:100vh}}
+.header{{background:#1a1d27;border-bottom:1px solid #2a2d3a;padding:16px 24px;display:flex;justify-content:space-between;align-items:center}}
+.header h1{{font-size:20px}}
+.status-dot{{display:inline-block;width:10px;height:10px;border-radius:50%;margin-right:8px}}
+.status-ok{{background:#22c55e;box-shadow:0 0 8px #22c55e88}}
+.status-degraded{{background:#f59e0b;box-shadow:0 0 8px #f59e0b88}}
+.container{{max-width:960px;margin:0 auto;padding:24px}}
+.cards{{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:12px;margin-bottom:24px}}
+.card{{background:#1a1d27;border:1px solid #2a2d3a;border-radius:10px;padding:16px}}
+.card .value{{font-size:28px;font-weight:700;margin:4px 0}}
+.card .label{{font-size:13px;color:#94a3b8}}
+.green{{color:#22c55e}}.yellow{{color:#f59e0b}}.red{{color:#ef4444}}.blue{{color:#6c63ff}}
+table{{width:100%;border-collapse:collapse;background:#1a1d27;border:1px solid #2a2d3a;border-radius:10px;overflow:hidden}}
+th{{background:#242836;font-weight:600;text-align:left;padding:10px 12px;font-size:12px;color:#94a3b8;text-transform:uppercase}}
+td{{padding:8px 12px;border-top:1px solid #2a2d3a;font-size:14px}}tr:hover td{{background:rgba(108,99,255,.05)}}
+.api-url{{font-family:monospace;font-size:12px;color:#6c63ff}}
+.refresh{{font-size:12px;color:#64748b;text-align:center;margin-top:24px}}
+</style>
+<meta http-equiv="refresh" content="30">
+</head>
+<body>
+<div class="header">
+<h1><span class="status-dot {'status-ok' if healthy else 'status-degraded'}"></span>号池健康监控</h1>
+<div style="font-size:13px;color:#94a3b8">v{app_version} · 30s 自动刷新</div>
+</div>
+<div class="container">
+<div class="cards">
+<div class="card"><div class="label">号池状态</div><div class="value {'green' if healthy else 'yellow'}">{'正常' if healthy else '异常'}</div></div>
+<div class="card"><div class="label">当前账号</div><div class="value blue">{stats['total']}</div></div>
+<div class="card"><div class="label">累计入库</div><div class="value">{stats['cumulative_total']}</div></div>
+<div class="card"><div class="label">可用账号</div><div class="value green">{stats['active']}</div></div>
+<div class="card"><div class="label">无限额</div><div class="value">{stats['unlimited_quota_count']}</div></div>
+<div class="card"><div class="label">剩余额度</div><div class="value">{stats['total_quota']}</div></div>
+<div class="card"><div class="label">限流</div><div class="value yellow">{stats['limited']}</div></div>
+<div class="card"><div class="label">异常</div><div class="value red">{stats['abnormal']}</div></div>
+<div class="card"><div class="label">禁用</div><div class="value">{stats['disabled']}</div></div>
+<div class="card"><div class="label">成功/失败</div><div class="value">{stats['total_success']}<span style="font-size:18px;color:#94a3b8">/</span><span class="red">{stats['total_fail']}</span></div></div>
+</div>
+<h2 style="margin-bottom:12px;font-size:16px">账号类型分布</h2>
+<table>
+<tr><th>类型</th><th>数量</th></tr>
+{''.join(f'<tr><td>{t}</td><td>{c}</td></tr>' for t,c in sorted(stats['by_type'].items()))}
+</table>
+<div class="refresh">JSON: <span class="api-url">/health?format=json</span></div>
+</div></body></html>""")
 
     return router

--- a/services/account_service.py
+++ b/services/account_service.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-import base64
-import json
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import datetime, timedelta, timezone
 from threading import Condition, Lock
 from typing import Any
+from datetime import datetime, timezone
+from pathlib import Path
 
 from services.config import config
 from services.log_service import (
@@ -14,40 +13,6 @@ from services.log_service import (
 )
 from services.storage.base import StorageBackend
 from utils.helper import anonymize_token
-
-
-EXPORT_TIMEZONE = timezone(timedelta(hours=8))
-
-
-def _clean_string(value: Any) -> str:
-    if value is None:
-        return ""
-    return str(value).strip()
-
-
-def _decode_jwt_payload(token: str) -> dict[str, Any]:
-    parts = str(token or "").split(".")
-    if len(parts) < 2:
-        return {}
-    try:
-        payload = parts[1] + "=" * (-len(parts[1]) % 4)
-        decoded = base64.urlsafe_b64decode(payload.encode("utf-8"))
-        data = json.loads(decoded.decode("utf-8"))
-    except Exception:
-        return {}
-    return data if isinstance(data, dict) else {}
-
-
-def _format_timestamp(value: Any) -> str:
-    try:
-        timestamp = int(value)
-    except (TypeError, ValueError):
-        return ""
-    return datetime.fromtimestamp(timestamp, tz=timezone.utc).astimezone(EXPORT_TIMEZONE).isoformat(timespec="seconds")
-
-
-def _nested_dict(value: Any) -> dict[str, Any]:
-    return value if isinstance(value, dict) else {}
 
 
 class AccountService:
@@ -60,6 +25,30 @@ class AccountService:
         self._index = 0
         self._accounts = self._load_accounts()
         self._image_inflight: dict[str, int] = {}
+        self._cumulative_total = self._load_cumulative_total()
+
+    def _get_cumulative_file(self) -> Path:
+        from services.config import DATA_DIR
+        return DATA_DIR / ".cumulative_total"
+
+    def _load_cumulative_total(self) -> int:
+        try:
+            f = self._get_cumulative_file()
+            if f.exists():
+                return int(f.read_text().strip())
+        except Exception:
+            pass
+        return len(self._accounts)
+
+    def _save_cumulative_total(self) -> None:
+        try:
+            self._get_cumulative_file().write_text(str(self._cumulative_total))
+        except Exception:
+            pass
+
+    @staticmethod
+    def _now() -> str:
+        return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
 
     def _load_accounts(self) -> dict[str, dict]:
         accounts = self.storage.load_accounts()
@@ -103,6 +92,7 @@ class AccountService:
         normalized["success"] = int(normalized.get("success") or 0)
         normalized["fail"] = int(normalized.get("fail") or 0)
         normalized["last_used_at"] = normalized.get("last_used_at")
+        normalized["created_at"] = normalized.get("created_at") or AccountService._now()
         return normalized
 
     def list_tokens(self) -> list[str]:
@@ -228,6 +218,10 @@ class AccountService:
                    and (token := item.get("access_token") or "")
             ]
 
+    def add_account_items(self, items: list[dict]) -> dict:
+        tokens = [str(item.get("access_token") or "").strip() for item in items if isinstance(item, dict)]
+        return self.add_accounts(tokens)
+
     def add_accounts(self, tokens: list[str]) -> dict:
         tokens = list(dict.fromkeys(token for token in tokens if token))
         if not tokens:
@@ -240,7 +234,9 @@ class AccountService:
                 current = self._accounts.get(access_token)
                 if current is None:
                     added += 1
-                    current = {}
+                    self._cumulative_total += 1
+                    self._save_cumulative_total()
+                    current = {"created_at": self._now()}
                 else:
                     skipped += 1
                 account = self._normalize_account(
@@ -250,48 +246,6 @@ class AccountService:
                         "type": str(current.get("type") or "free"),
                     }
                 )
-                if account is not None:
-                    self._accounts[access_token] = account
-            self._save_accounts()
-            items = [dict(item) for item in self._accounts.values()]
-            log_service.add(LOG_TYPE_ACCOUNT, f"新增 {added} 个账号，跳过 {skipped} 个",
-                            {"added": added, "skipped": skipped})
-        return {"added": added, "skipped": skipped, "items": items}
-
-    def add_account_items(self, items: list[dict[str, Any]]) -> dict:
-        payloads: list[dict[str, Any]] = []
-        seen_tokens: set[str] = set()
-        for item in items:
-            if not isinstance(item, dict):
-                continue
-            access_token = _clean_string(item.get("access_token") or item.get("accessToken"))
-            if not access_token or access_token in seen_tokens:
-                continue
-
-            payload = dict(item)
-            payload["access_token"] = access_token
-            payload.pop("accessToken", None)
-            if _clean_string(payload.get("type")).lower() == "codex":
-                payload.setdefault("export_type", "codex")
-                payload.pop("type", None)
-            payloads.append(payload)
-            seen_tokens.add(access_token)
-
-        if not payloads:
-            return {"added": 0, "skipped": 0, "items": self.list_accounts()}
-
-        with self._lock:
-            added = 0
-            skipped = 0
-            for payload in payloads:
-                access_token = payload["access_token"]
-                current = self._accounts.get(access_token)
-                if current is None:
-                    added += 1
-                    current = {}
-                else:
-                    skipped += 1
-                account = self._normalize_account({**current, **payload})
                 if account is not None:
                     self._accounts[access_token] = account
             self._save_accounts()
@@ -416,59 +370,44 @@ class AccountService:
             "items": self.list_accounts(),
         }
 
-    def build_export_items(self, access_tokens: list[str] | None = None) -> list[dict[str, str]]:
-        requested_tokens = [token for token in dict.fromkeys(access_tokens or []) if token]
+
+    def get_stats(self) -> dict:
         with self._lock:
-            if requested_tokens:
-                accounts = [dict(self._accounts[token]) for token in requested_tokens if token in self._accounts]
-            else:
-                accounts = [dict(item) for item in self._accounts.values()]
+            items = list(self._accounts.values())
+        total = len(items)
+        active = sum(1 for a in items if a.get("status") == "正常")
+        limited = sum(1 for a in items if a.get("status") == "限流")
+        abnormal = sum(1 for a in items if a.get("status") == "异常")
+        disabled = sum(1 for a in items if a.get("status") == "禁用")
+        total_quota = sum(max(0, int(a.get("quota") or 0)) for a in items if a.get("status") == "正常")
+        unlimited = sum(1 for a in items if a.get("status") == "正常" and bool(a.get("image_quota_unknown")))
+        total_success = sum(int(a.get("success") or 0) for a in items)
+        total_fail = sum(int(a.get("fail") or 0) for a in items)
+        by_type = {}
+        for a in items:
+            t = a.get("type", "unknown")
+            by_type[t] = by_type.get(t, 0) + 1
+        return {
+            "total": total,
+            "cumulative_total": self._cumulative_total,
+            "active": active,
+            "limited": limited,
+            "abnormal": abnormal,
+            "disabled": disabled,
+            "total_quota": total_quota,
+            "unlimited_quota_count": unlimited,
+            "total_success": total_success,
+            "total_fail": total_fail,
+            "by_type": by_type,
+        }
 
-        export_items: list[dict[str, str]] = []
-        for account in accounts:
-            access_token = _clean_string(account.get("access_token"))
-            id_token = _clean_string(account.get("id_token"))
-            refresh_token = _clean_string(account.get("refresh_token"))
-            if not access_token or not refresh_token or not id_token:
-                continue
-
-            access_claims = _decode_jwt_payload(access_token)
-            id_claims = _decode_jwt_payload(id_token)
-            access_auth = _nested_dict(access_claims.get("https://api.openai.com/auth"))
-            id_auth = _nested_dict(id_claims.get("https://api.openai.com/auth"))
-            profile = _nested_dict(access_claims.get("https://api.openai.com/profile"))
-
-            email = (
-                _clean_string(account.get("email"))
-                or _clean_string(profile.get("email"))
-                or _clean_string(id_claims.get("email"))
-            )
-            account_id = (
-                _clean_string(account.get("account_id"))
-                or _clean_string(access_auth.get("chatgpt_account_id"))
-                or _clean_string(id_auth.get("chatgpt_account_id"))
-            )
-            expired = _clean_string(account.get("expired")) or _format_timestamp(access_claims.get("exp"))
-            last_refresh = (
-                _clean_string(account.get("last_refresh"))
-                or _format_timestamp(access_claims.get("iat"))
-                or _format_timestamp(access_claims.get("nbf"))
-            )
-
-            export_items.append(
-                {
-                    "type": _clean_string(account.get("export_type")) or "codex",
-                    "email": email,
-                    "expired": expired,
-                    "id_token": id_token,
-                    "account_id": account_id,
-                    "access_token": access_token,
-                    "last_refresh": last_refresh,
-                    "refresh_token": refresh_token,
-                }
-            )
-
-        return export_items
+    def account_health(self) -> dict:
+        stats = self.get_stats()
+        return {
+            "healthy": stats["active"] > 0 or stats["unlimited_quota_count"] > 0,
+            "status": "ok" if stats["active"] > 0 else "degraded",
+            **stats,
+        }
 
 
 account_service = AccountService(config.get_storage_backend())

--- a/services/image_service.py
+++ b/services/image_service.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import io
+import shutil
+import threading
+import time
 import zipfile
 from pathlib import Path
 
@@ -11,6 +14,7 @@ from PIL import Image, ImageOps
 from services.config import config
 from services.image_storage_service import image_storage_service
 from services.image_tags_service import load_tags, remove_tags
+from utils.log import logger
 
 THUMBNAIL_SIZE = (320, 320)
 
@@ -203,3 +207,150 @@ def download_images_zip(paths: list[str]) -> io.BytesIO:
         raise HTTPException(status_code=404, detail="no images found")
     buf.seek(0)
     return buf
+def storage_stats() -> dict:
+    import shutil
+    usage = shutil.disk_usage(config.images_dir)
+    total_mb = usage.total // (1024 * 1024)
+    used_mb = usage.used // (1024 * 1024)
+    free_mb = usage.free // (1024 * 1024)
+
+    image_count = 0
+    image_size = 0
+    for p in config.images_dir.rglob("*"):
+        if p.is_file():
+            image_count += 1
+            image_size += p.stat().st_size
+
+    return {
+        "disk_total_mb": total_mb,
+        "disk_used_mb": used_mb,
+        "disk_free_mb": free_mb,
+        "image_count": image_count,
+        "image_size_mb": image_size // (1024 * 1024),
+        "image_size_bytes": image_size,
+    }
+
+
+def compress_images(quality: int = 60) -> dict:
+    """重新压缩所有图片，返回节省的空间"""
+    saved = 0
+    count = 0
+    for p in sorted(config.images_dir.rglob("*.png")):
+        if not p.is_file():
+            continue
+        try:
+            orig = p.stat().st_size
+            with Image.open(p) as img:
+                img = ImageOps.exif_transpose(img)
+                img.save(str(p) + ".tmp", format="PNG", optimize=True)
+            new_size = Path(str(p) + ".tmp").stat().st_size
+            if new_size < orig:
+                Path(str(p) + ".tmp").replace(p)
+                saved += orig - new_size
+                count += 1
+            else:
+                Path(str(p) + ".tmp").unlink()
+        except Exception:
+            pass
+    return {"compressed": count, "saved_bytes": saved, "saved_mb": saved // (1024 * 1024)}
+
+
+def delete_to_target(target_free_mb: int, dry_run: bool = False) -> dict:
+    """删除最旧的图片直到剩余空间达到 target_free_mb"""
+    import shutil
+    usage = shutil.disk_usage(config.images_dir)
+    current_free = usage.free // (1024 * 1024)
+    if current_free >= target_free_mb and not dry_run:
+        return {"removed": 0, "current_free_mb": current_free, "target_free_mb": target_free_mb, "done": True}
+
+    files = sorted(
+        (p for p in config.images_dir.rglob("*.png") if p.is_file()),
+        key=lambda p: p.stat().st_mtime,
+    )
+    removed = 0
+    freed = 0
+    for p in files:
+        if current_free + freed // (1024 * 1024) >= target_free_mb:
+            break
+        size = p.stat().st_size
+        if not dry_run:
+            rel = p.relative_to(config.images_dir).as_posix()
+            for tp in (_thumbnail_path(rel), config.image_thumbnails_dir / _safe_relative_path(rel)):
+                if tp.is_file():
+                    tp.unlink()
+            remove_tags(rel)
+            p.unlink()
+        freed += size
+        removed += 1
+
+    if not dry_run:
+        _cleanup_empty_dirs(config.images_dir)
+        _cleanup_empty_dirs(config.image_thumbnails_dir)
+
+    return {
+        "removed": removed,
+        "freed_mb": freed // (1024 * 1024),
+        "target_free_mb": target_free_mb,
+        "current_free_mb": current_free + (freed // (1024 * 1024)),
+        "done": (current_free + freed // (1024 * 1024)) >= target_free_mb,
+        "dry_run": dry_run,
+    }
+
+
+def download_images_zip(paths: list[str]) -> io.BytesIO:
+    root = config.images_dir.resolve()
+    buf = io.BytesIO()
+    added = 0
+    used_names: set[str] = set()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for item in paths:
+            rel = _safe_relative_path(item)
+            path = (root / rel).resolve()
+            try:
+                path.relative_to(root)
+            except ValueError:
+                continue
+            if not path.is_file():
+                continue
+            name = path.name
+            if name in used_names:
+                stem = path.stem
+                suffix = path.suffix
+                counter = 2
+                while f"{stem}_{counter}{suffix}" in used_names:
+                    counter += 1
+                name = f"{stem}_{counter}{suffix}"
+            used_names.add(name)
+            zf.write(path, name)
+            added += 1
+    if added == 0:
+        raise HTTPException(status_code=404, detail="no images found")
+    buf.seek(0)
+    return buf
+
+
+def _auto_cleanup_worker(stop_event: threading.Event) -> None:
+    """后台线程：每30分钟检查存储，空间低于阈值自动清理最旧图片"""
+    import shutil
+    min_free_mb = getattr(config, "image_min_free_mb", None)
+    if min_free_mb is None:
+        min_free_mb = 500
+
+    while not stop_event.wait(1800):  # 每30分钟
+        try:
+            config.cleanup_old_images()
+            cleanup_image_thumbnails()
+            usage = shutil.disk_usage(config.images_dir)
+            free_mb = usage.free // (1024 * 1024)
+            if free_mb < min_free_mb:
+                logger.info({"event": "image_auto_cleanup", "free_mb": free_mb, "min_free_mb": min_free_mb})
+                result = delete_to_target(min_free_mb)
+                logger.info({"event": "image_auto_cleanup_done", **result})
+        except Exception:
+            pass
+
+
+def start_image_cleanup_scheduler(stop_event: threading.Event) -> threading.Thread:
+    t = threading.Thread(target=_auto_cleanup_worker, args=(stop_event,), daemon=True, name="image-cleanup")
+    t.start()
+    return t


### PR DESCRIPTION
## Summary
- Storage stats panel + quick actions in image-manager page (compress, delete-by-date, delete-to-target)
- Background auto-cleanup scheduler that frees space when disk runs low
- Account `created_at` tracking and cumulative total counter
- `GET /api/accounts/stats` endpoint for lightweight stats
- Public `GET /health` dashboard (HTML page + JSON API, no auth required)

## New API endpoints
| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/images/storage` | Disk usage + image stats |
| POST | `/api/images/storage/compress` | Batch PNG re-optimization |
| POST | `/api/images/storage/cleanup-to-target?target_free_mb=N` | Delete oldest until target free space |
| GET | `/api/accounts/stats` | Account pool statistics |
| GET | `/health?format=html\|json` | Public health dashboard |

## Changes
- `services/image_service.py` — new functions: storage_stats, compress_images, delete_to_target, auto-cleanup scheduler
- `services/account_service.py` — created_at field, cumulative_total, get_stats/add_account_items methods
- `api/system.py` — new storage + health endpoints
- `api/app.py` — start image cleanup scheduler in lifespan
- `api/accounts.py` — stats endpoint + include stats in account list response
- Frontend: storage panel in image-manager, created_at column in accounts page