### PR TITLE
修复账号注册后异常及 OAuth Token 自动刷新

### DIFF
--- a/api/support.py
+++ b/api/support.py
@@ -86,14 +86,28 @@ def start_limited_account_watcher(stop_event: Event) -> Thread:
         while not stop_event.is_set():
             try:
                 limited_tokens = account_service.list_limited_tokens()
-                if limited_tokens:
-                    print(f"[account-limited-watcher] checking {len(limited_tokens)} limited accounts")
-                    account_service.refresh_accounts(limited_tokens)
+                expiring_tokens = account_service.list_expiring_access_tokens()
+                keepalive_tokens = account_service.list_refresh_token_keepalive_tokens()
+                tokens = list(dict.fromkeys([*limited_tokens, *expiring_tokens]))
+                expiring_token_set = set(expiring_tokens)
+                keepalive_tokens = [token for token in keepalive_tokens if token not in expiring_token_set]
+                if tokens:
+                    print(
+                        "[account-watcher] checking "
+                        f"{len(limited_tokens)} limited accounts, "
+                        f"{len(expiring_tokens)} expiring access tokens"
+                    )
+                    account_service.refresh_accounts(tokens)
+                if keepalive_tokens:
+                    print(f"[account-watcher] keepalive {len(keepalive_tokens)} refresh tokens")
+                    result = account_service.keepalive_refresh_tokens(keepalive_tokens)
+                    if result.get("errors"):
+                        print(f"[account-watcher] keepalive errors: {result['errors']}")
             except Exception as exc:
-                print(f"[account-limited-watcher] fail {exc}")
+                print(f"[account-watcher] fail {exc}")
             stop_event.wait(interval_seconds)
 
-    thread = Thread(target=worker, name="limited-account-watcher", daemon=True)
+    thread = Thread(target=worker, name="account-watcher", daemon=True)
     thread.start()
     return thread
 

--- a/services/account_service.py
+++ b/services/account_service.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from threading import Condition, Lock
 from typing import Any
-from datetime import datetime, timezone
-from pathlib import Path
 
 from services.config import config
 from services.log_service import (
@@ -18,13 +19,30 @@ from utils.helper import anonymize_token
 class AccountService:
     """账号池服务，使用 token -> account 的 dict 保存账号。"""
 
+    _NEW_ACCOUNT_INVALID_GRACE_SECONDS = 10 * 60
+    _INVALID_CONFIRM_SECONDS = 30
+    _ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 24 * 60 * 60
+    _REFRESH_TOKEN_KEEPALIVE_SECONDS = 3 * 24 * 60 * 60
+    _REFRESH_TOKEN_KEEPALIVE_ERROR_BACKOFF_SECONDS = 6 * 60 * 60
+    _REFRESH_TOKEN_KEEPALIVE_BATCH_SIZE = 3
+    _TOKEN_REFRESH_ERROR_BACKOFF_SECONDS = 5 * 60
+    _OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
+    _OAUTH_CLIENT_ID = "app_2SKx67EdpoN0G6j64rFvigXD"
+    _OAUTH_USER_AGENT = (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/145.0.0.0 Safari/537.36"
+    )
+
     def __init__(self, storage_backend: StorageBackend):
         self.storage = storage_backend
         self._lock = Lock()
+        self._token_refresh_lock = Lock()
         self._image_slot_condition = Condition(self._lock)
         self._index = 0
         self._accounts = self._load_accounts()
         self._image_inflight: dict[str, int] = {}
+        self._token_aliases: dict[str, str] = {}
         self._cumulative_total = self._load_cumulative_total()
 
     def _get_cumulative_file(self) -> Path:
@@ -50,6 +68,43 @@ class AccountService:
     def _now() -> str:
         return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
 
+    @staticmethod
+    def _decode_jwt_payload(token: str) -> dict:
+        try:
+            payload = str(token or "").split(".")[1]
+            payload += "=" * ((4 - len(payload) % 4) % 4)
+            import base64
+            import json
+            data = json.loads(base64.urlsafe_b64decode(payload.encode("ascii")))
+            return data if isinstance(data, dict) else {}
+        except Exception:
+            return {}
+
+    @staticmethod
+    def _parse_time(value: object) -> datetime | None:
+        raw = str(value or "").strip()
+        if not raw:
+            return None
+        try:
+            parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        except Exception:
+            try:
+                parsed = datetime.strptime(raw, "%Y-%m-%d %H:%M:%S")
+            except Exception:
+                return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+
+    @staticmethod
+    def _timestamp_to_iso(value: object) -> str:
+        try:
+            ts = int(value)
+        except (TypeError, ValueError):
+            return ""
+        tz = timezone(timedelta(hours=8))
+        return datetime.fromtimestamp(ts, tz=timezone.utc).astimezone(tz).isoformat()
+
     def _load_accounts(self) -> dict[str, dict]:
         accounts = self.storage.load_accounts()
         return {
@@ -71,13 +126,49 @@ class AccountService:
             return True
         return int(account.get("quota") or 0) > 0
 
+    @staticmethod
+    def _normalize_account_type(value: object) -> str | None:
+        raw = str(value or "").strip()
+        if not raw:
+            return None
+        key = raw.lower().replace("-", "_").replace(" ", "_")
+        compact = key.replace("_", "")
+        aliases = {
+            "free": "free",
+            "plus": "Plus",
+            "pro": "Pro",
+            "prolite": "ProLite",
+            "team": "Team",
+            "business": "Team",
+            "enterprise": "Enterprise",
+        }
+        return aliases.get(compact) or aliases.get(key) or raw
+
+    def _search_account_type(self, payload: object) -> str | None:
+        if isinstance(payload, dict):
+            for key in ("plan_type", "account_plan", "account_type", "subscription_type", "type"):
+                plan = self._normalize_account_type(payload.get(key))
+                if plan:
+                    return plan
+            for value in payload.values():
+                plan = self._search_account_type(value)
+                if plan:
+                    return plan
+        elif isinstance(payload, list):
+            for value in payload:
+                plan = self._search_account_type(value)
+                if plan:
+                    return plan
+        return None
+
     def _normalize_account(self, item: dict) -> dict | None:
         if not isinstance(item, dict):
             return None
-        access_token = item.get("access_token") or ""
+        access_token = item.get("access_token") or item.get("accessToken") or ""
         if not access_token:
             return None
         normalized = dict(item)
+        normalized.pop("accessToken", None)
         normalized["access_token"] = access_token
         normalized["type"] = normalized.get("type") or "free"
         normalized["status"] = normalized.get("status") or "正常"
@@ -91,9 +182,278 @@ class AccountService:
         normalized["restore_at"] = normalized.get("restore_at") or None
         normalized["success"] = int(normalized.get("success") or 0)
         normalized["fail"] = int(normalized.get("fail") or 0)
+        normalized["invalid_count"] = int(normalized.get("invalid_count") or 0)
         normalized["last_used_at"] = normalized.get("last_used_at")
+        normalized["last_invalid_at"] = normalized.get("last_invalid_at") or None
+        normalized["last_refresh_error"] = normalized.get("last_refresh_error") or None
+        normalized["last_refresh_error_at"] = normalized.get("last_refresh_error_at") or None
+        normalized["last_token_refresh_at"] = normalized.get("last_token_refresh_at") or None
+        normalized["last_token_refresh_error"] = normalized.get("last_token_refresh_error") or None
+        normalized["last_token_refresh_error_at"] = normalized.get("last_token_refresh_error_at") or None
         normalized["created_at"] = normalized.get("created_at") or AccountService._now()
         return normalized
+
+    @staticmethod
+    def _jwt_exp(access_token: str) -> int:
+        try:
+            return int(AccountService._decode_jwt_payload(access_token).get("exp") or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    @classmethod
+    def _token_expires_in(cls, access_token: str) -> int | None:
+        exp = cls._jwt_exp(access_token)
+        if exp <= 0:
+            return None
+        return exp - int(time.time())
+
+    @classmethod
+    def _token_needs_refresh(cls, access_token: str, *, force: bool = False) -> bool:
+        if force:
+            return True
+        remaining = cls._token_expires_in(access_token)
+        return remaining is not None and remaining <= cls._ACCESS_TOKEN_REFRESH_SKEW_SECONDS
+
+    @classmethod
+    def _token_issued_at(cls, access_token: str) -> datetime | None:
+        try:
+            iat = int(cls._decode_jwt_payload(access_token).get("iat") or 0)
+        except (TypeError, ValueError):
+            return None
+        if iat <= 0:
+            return None
+        return datetime.fromtimestamp(iat, tz=timezone.utc)
+
+    @staticmethod
+    def _safe_response_text(response: object, limit: int = 300) -> str:
+        try:
+            return str(getattr(response, "text", "") or "")[:limit]
+        except Exception:
+            return ""
+
+    def _resolve_access_token_locked(self, access_token: str) -> str:
+        token = str(access_token or "").strip()
+        seen: set[str] = set()
+        while token and token not in self._accounts and token in self._token_aliases and token not in seen:
+            seen.add(token)
+            token = self._token_aliases.get(token, token)
+        return token
+
+    def resolve_access_token(self, access_token: str) -> str:
+        if not access_token:
+            return ""
+        with self._lock:
+            return self._resolve_access_token_locked(access_token)
+
+    def _get_account_for_token(self, access_token: str) -> tuple[str, dict | None]:
+        with self._lock:
+            resolved = self._resolve_access_token_locked(access_token)
+            account = self._accounts.get(resolved)
+            return resolved, dict(account) if account else None
+
+    def _record_token_refresh_error(self, access_token: str, event: str, error: str) -> None:
+        now = datetime.now(timezone.utc).isoformat()
+        with self._lock:
+            resolved = self._resolve_access_token_locked(access_token)
+            current = self._accounts.get(resolved)
+            if current is None:
+                return
+            next_item = dict(current)
+            next_item["last_token_refresh_error"] = str(error or "refresh token failed")
+            next_item["last_token_refresh_error_at"] = now
+            account = self._normalize_account(next_item)
+            if account is not None:
+                self._accounts[resolved] = account
+                self._save_accounts()
+        log_service.add(
+            LOG_TYPE_ACCOUNT,
+            "refresh_token 刷新 access_token 失败",
+            {"source": event, "token": anonymize_token(access_token), "error": str(error or "")},
+        )
+
+    def _recent_token_refresh_error(self, account: dict) -> bool:
+        last_error_at = self._parse_time(account.get("last_token_refresh_error_at"))
+        if last_error_at is None:
+            return False
+        return (datetime.now(timezone.utc) - last_error_at).total_seconds() < self._TOKEN_REFRESH_ERROR_BACKOFF_SECONDS
+
+    def _recent_refresh_token_keepalive_error(self, account: dict, now: datetime) -> bool:
+        last_error_at = self._parse_time(account.get("last_token_refresh_error_at"))
+        if last_error_at is None:
+            return False
+        return (now - last_error_at).total_seconds() < self._REFRESH_TOKEN_KEEPALIVE_ERROR_BACKOFF_SECONDS
+
+    def _refresh_token_keepalive_anchor(self, account: dict) -> datetime | None:
+        return (
+            self._parse_time(account.get("last_token_refresh_at"))
+            or self._token_issued_at(str(account.get("access_token") or ""))
+            or self._parse_time(account.get("created_at"))
+        )
+
+    def _refresh_token_keepalive_due_at(self, account: dict, now: datetime) -> datetime | None:
+        if not str(account.get("refresh_token") or "").strip():
+            return None
+        if account.get("status") == "禁用":
+            return None
+        if self._recent_refresh_token_keepalive_error(account, now):
+            return None
+        anchor = self._refresh_token_keepalive_anchor(account)
+        if anchor is None:
+            return now
+        due_at = anchor + timedelta(seconds=self._REFRESH_TOKEN_KEEPALIVE_SECONDS)
+        return due_at if due_at <= now else None
+
+    def _request_access_token_refresh(self, refresh_token: str) -> dict[str, str]:
+        from curl_cffi import requests
+        from services.proxy_service import proxy_settings
+
+        session = requests.Session(**proxy_settings.build_session_kwargs(impersonate="chrome", verify=True))
+        try:
+            response = session.post(
+                self._OAUTH_TOKEN_URL,
+                headers={
+                    "Accept": "application/json",
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "User-Agent": self._OAUTH_USER_AGENT,
+                },
+                data={
+                    "grant_type": "refresh_token",
+                    "refresh_token": refresh_token,
+                    "client_id": self._OAUTH_CLIENT_ID,
+                },
+                timeout=60,
+            )
+            data = response.json() if response.text else {}
+            if response.status_code != 200 or not isinstance(data, dict) or not data.get("access_token"):
+                detail = ""
+                if isinstance(data, dict):
+                    detail = str(data.get("error_description") or data.get("error") or data.get("message") or "")
+                detail = detail or self._safe_response_text(response)
+                raise RuntimeError(f"oauth_refresh_http_{response.status_code}{': ' + detail if detail else ''}")
+            return {
+                "access_token": str(data.get("access_token") or "").strip(),
+                "refresh_token": str(data.get("refresh_token") or refresh_token).strip(),
+                "id_token": str(data.get("id_token") or "").strip(),
+            }
+        finally:
+            session.close()
+
+    def _apply_refreshed_tokens(self, old_access_token: str, token_data: dict, event: str) -> str:
+        now = datetime.now(timezone.utc).isoformat()
+        with self._image_slot_condition:
+            old_token = self._resolve_access_token_locked(old_access_token)
+            current = self._accounts.get(old_token)
+            if current is None:
+                return old_token
+            new_token = str(token_data.get("access_token") or old_token).strip()
+            if not new_token:
+                return old_token
+
+            next_item = dict(current)
+            next_item["access_token"] = new_token
+            if token_data.get("refresh_token"):
+                next_item["refresh_token"] = str(token_data.get("refresh_token") or "").strip()
+            if token_data.get("id_token"):
+                next_item["id_token"] = str(token_data.get("id_token") or "").strip()
+            next_item["last_token_refresh_at"] = now
+            next_item["last_token_refresh_error"] = None
+            next_item["last_token_refresh_error_at"] = None
+            next_item["invalid_count"] = 0
+            next_item["last_invalid_at"] = None
+            next_item["last_refresh_error"] = None
+            next_item["last_refresh_error_at"] = None
+
+            account = self._normalize_account(next_item)
+            if account is None:
+                return old_token
+
+            rotated = new_token != old_token
+            if rotated:
+                self._accounts.pop(old_token, None)
+                self._token_aliases[old_token] = new_token
+                old_inflight = int(self._image_inflight.pop(old_token, 0))
+                if old_inflight:
+                    self._image_inflight[new_token] = int(self._image_inflight.get(new_token, 0)) + old_inflight
+            self._accounts[new_token] = account
+            self._save_accounts()
+            self._image_slot_condition.notify_all()
+
+        log_service.add(
+            LOG_TYPE_ACCOUNT,
+            "refresh_token 已刷新 access_token",
+            {"source": event, "token": anonymize_token(new_token), "rotated": rotated},
+        )
+        return new_token
+
+    def refresh_access_token(self, access_token: str, *, force: bool = False, event: str = "refresh_access_token") -> str:
+        if not access_token:
+            return ""
+        with self._token_refresh_lock:
+            resolved_token, account = self._get_account_for_token(access_token)
+            if not account:
+                return access_token
+            active_token = str(account.get("access_token") or resolved_token or access_token)
+            if not self._token_needs_refresh(active_token, force=force):
+                return active_token
+            refresh_token = str(account.get("refresh_token") or "").strip()
+            if not refresh_token:
+                return active_token
+            if not force and self._recent_token_refresh_error(account):
+                return active_token
+            try:
+                token_data = self._request_access_token_refresh(refresh_token)
+            except Exception as exc:
+                self._record_token_refresh_error(active_token, event, str(exc))
+                return active_token
+            return self._apply_refreshed_tokens(active_token, token_data, event)
+
+    def list_expiring_access_tokens(self) -> list[str]:
+        with self._lock:
+            return [
+                token
+                for account in self._accounts.values()
+                if str(account.get("refresh_token") or "").strip()
+                and (token := str(account.get("access_token") or "").strip())
+                and self._token_needs_refresh(token)
+            ]
+
+    def list_refresh_token_keepalive_tokens(self) -> list[str]:
+        now = datetime.now(timezone.utc)
+        due_items: list[tuple[datetime, str]] = []
+        with self._lock:
+            for account in self._accounts.values():
+                due_at = self._refresh_token_keepalive_due_at(account, now)
+                token = str(account.get("access_token") or "").strip()
+                if due_at is not None and token:
+                    due_items.append((due_at, token))
+        due_items.sort(key=lambda item: item[0])
+        return [token for _, token in due_items[: self._REFRESH_TOKEN_KEEPALIVE_BATCH_SIZE]]
+
+    def keepalive_refresh_tokens(self, access_tokens: list[str]) -> dict[str, Any]:
+        access_tokens = list(dict.fromkeys(token for token in access_tokens if token))
+        if not access_tokens:
+            return {"refreshed": 0, "errors": [], "items": self.list_accounts()}
+
+        refreshed = 0
+        errors = []
+        for access_token in access_tokens:
+            before = self.resolve_access_token(access_token)
+            after = self.refresh_access_token(before, force=True, event="refresh_token_keepalive")
+            account = self.get_account(after)
+            if account and str(account.get("last_token_refresh_error") or "").strip():
+                errors.append({
+                    "token": anonymize_token(before),
+                    "error": str(account.get("last_token_refresh_error") or "refresh token failed"),
+                })
+                continue
+            if account:
+                refreshed += 1
+
+        return {
+            "refreshed": refreshed,
+            "errors": errors,
+            "items": self.list_accounts(),
+        }
 
     def list_tokens(self) -> list[str]:
         with self._lock:
@@ -134,6 +494,7 @@ class AccountService:
         if not access_token:
             return
         with self._image_slot_condition:
+            access_token = self._resolve_access_token_locked(access_token)
             current_inflight = int(self._image_inflight.get(access_token, 0))
             if current_inflight <= 1:
                 self._image_inflight.pop(access_token, None)
@@ -152,7 +513,7 @@ class AccountService:
                 self.release_image_slot(access_token)
                 continue
             if self._is_image_account_available(account or {}):
-                return access_token
+                return str((account or {}).get("access_token") or access_token)
             self.release_image_slot(access_token)
 
     def get_text_access_token(self, excluded_tokens: set[str] | None = None) -> str:
@@ -169,12 +530,13 @@ class AccountService:
                 return ""
             access_token = candidates[self._index % len(candidates)]
             self._index += 1
-            return access_token
+        return self.refresh_access_token(access_token, event="get_text_access_token") or access_token
 
     def mark_text_used(self, access_token: str) -> None:
         if not access_token:
             return
         with self._lock:
+            access_token = self._resolve_access_token_locked(access_token)
             current = self._accounts.get(access_token)
             if current is None:
                 return
@@ -202,6 +564,7 @@ class AccountService:
         if not access_token:
             return None
         with self._lock:
+            access_token = self._resolve_access_token_locked(access_token)
             account = self._accounts.get(access_token)
             return dict(account) if account else None
 
@@ -218,19 +581,60 @@ class AccountService:
                    and (token := item.get("access_token") or "")
             ]
 
+    @staticmethod
+    def _account_payload_token(item: dict) -> str:
+        return str(item.get("access_token") or item.get("accessToken") or "").strip()
+
+    @staticmethod
+    def _prepare_account_payload(item: dict) -> dict | None:
+        if not isinstance(item, dict):
+            return None
+        access_token = AccountService._account_payload_token(item)
+        if not access_token:
+            return None
+        payload = dict(item)
+        payload.pop("accessToken", None)
+        payload["access_token"] = access_token
+        # CPA/Codex 导出文件里的 `type=codex` 是导出格式，不是号池套餐类型。
+        if str(payload.get("type") or "").strip().lower() == "codex":
+            payload["export_type"] = "codex"
+            payload.pop("type", None)
+        if payload.get("plan_type") and not payload.get("type"):
+            payload["type"] = str(payload.get("plan_type") or "").strip()
+        return payload
+
     def add_account_items(self, items: list[dict]) -> dict:
-        tokens = [str(item.get("access_token") or "").strip() for item in items if isinstance(item, dict)]
-        return self.add_accounts(tokens)
+        payloads = [
+            payload
+            for item in items
+            if (payload := self._prepare_account_payload(item)) is not None
+        ]
+        return self._add_account_payloads(payloads)
 
     def add_accounts(self, tokens: list[str]) -> dict:
         tokens = list(dict.fromkeys(token for token in tokens if token))
         if not tokens:
             return {"added": 0, "skipped": 0, "items": self.list_accounts()}
+        return self._add_account_payloads([{"access_token": token} for token in tokens])
+
+    def _add_account_payloads(self, payloads: list[dict]) -> dict:
+        deduped: dict[str, dict] = {}
+        for payload in payloads:
+            if not isinstance(payload, dict):
+                continue
+            access_token = self._account_payload_token(payload)
+            if not access_token:
+                continue
+            current = deduped.get(access_token, {})
+            deduped[access_token] = {**current, **payload, "access_token": access_token}
+
+        if not deduped:
+            return {"added": 0, "skipped": 0, "items": self.list_accounts()}
 
         with self._lock:
             added = 0
             skipped = 0
-            for access_token in tokens:
+            for access_token, payload in deduped.items():
                 current = self._accounts.get(access_token)
                 if current is None:
                     added += 1
@@ -239,11 +643,15 @@ class AccountService:
                     current = {"created_at": self._now()}
                 else:
                     skipped += 1
+                incoming = dict(payload)
+                if not incoming.get("created_at"):
+                    incoming.pop("created_at", None)
                 account = self._normalize_account(
                     {
                         **current,
+                        **incoming,
                         "access_token": access_token,
-                        "type": str(current.get("type") or "free"),
+                        "type": str(incoming.get("type") or current.get("type") or "free"),
                     }
                 )
                 if account is not None:
@@ -259,9 +667,15 @@ class AccountService:
         if not target_set:
             return {"removed": 0, "items": self.list_accounts()}
         with self._lock:
+            target_set = {self._resolve_access_token_locked(token) for token in target_set if token}
             removed = sum(self._accounts.pop(token, None) is not None for token in target_set)
             for token in target_set:
                 self._image_inflight.pop(token, None)
+            self._token_aliases = {
+                old: new
+                for old, new in self._token_aliases.items()
+                if old not in target_set and new not in target_set
+            }
             if removed:
                 if self._accounts:
                     self._index %= len(self._accounts)
@@ -276,6 +690,7 @@ class AccountService:
         if not access_token:
             return None
         with self._lock:
+            access_token = self._resolve_access_token_locked(access_token)
             current = self._accounts.get(access_token)
             if current is None:
                 return None
@@ -294,11 +709,67 @@ class AccountService:
             return dict(account)
         return None
 
+    def _record_refresh_success(self, access_token: str) -> None:
+        with self._lock:
+            access_token = self._resolve_access_token_locked(access_token)
+            current = self._accounts.get(access_token)
+            if current is None:
+                return
+            next_item = dict(current)
+            next_item["invalid_count"] = 0
+            next_item["last_invalid_at"] = None
+            next_item["last_refresh_error"] = None
+            next_item["last_refresh_error_at"] = None
+            account = self._normalize_account(next_item)
+            if account is not None:
+                self._accounts[access_token] = account
+
+    def _should_defer_invalid_token(self, account: dict | None, now: datetime) -> bool:
+        if not isinstance(account, dict):
+            return False
+        created_at = self._parse_time(account.get("created_at"))
+        if created_at is not None and (now - created_at).total_seconds() < self._NEW_ACCOUNT_INVALID_GRACE_SECONDS:
+            return True
+        last_invalid_at = self._parse_time(account.get("last_invalid_at"))
+        invalid_count = int(account.get("invalid_count") or 0)
+        if invalid_count <= 1:
+            return True
+        if last_invalid_at is not None and (now - last_invalid_at).total_seconds() < self._INVALID_CONFIRM_SECONDS:
+            return True
+        return False
+
+    def _record_invalid_token_seen(self, access_token: str, event: str, error: str) -> bool:
+        now = datetime.now(timezone.utc)
+        with self._lock:
+            access_token = self._resolve_access_token_locked(access_token)
+            current = self._accounts.get(access_token)
+            if current is None:
+                return True
+            should_defer = self._should_defer_invalid_token(current, now)
+            next_item = dict(current)
+            next_item["invalid_count"] = int(next_item.get("invalid_count") or 0) + 1
+            next_item["last_invalid_at"] = now.isoformat()
+            next_item["last_refresh_error"] = str(error or "invalid access token")
+            next_item["last_refresh_error_at"] = now.isoformat()
+            account = self._normalize_account(next_item)
+            if account is not None:
+                self._accounts[access_token] = account
+                self._save_accounts()
+            if should_defer:
+                log_service.add(
+                    LOG_TYPE_ACCOUNT,
+                    "暂缓标记异常账号",
+                    {"source": event, "token": anonymize_token(access_token), "error": str(error or "")},
+                )
+                return False
+        return True
+
     def mark_image_result(self, access_token: str, success: bool) -> dict | None:
         if not access_token:
             return None
         self.release_image_slot(access_token)
         with self._lock:
+            access_token = self._resolve_access_token_locked(access_token)
             current = self._accounts.get(access_token)
             if current is None:
                 return None
@@ -333,13 +804,26 @@ class AccountService:
         if not access_token:
             raise ValueError("access_token is required")
 
+        active_token = self.refresh_access_token(access_token, event=f"{event}:preflight") or access_token
         try:
             from services.openai_backend_api import InvalidAccessTokenError, OpenAIBackendAPI
-            result = OpenAIBackendAPI(access_token).get_user_info()
-        except InvalidAccessTokenError:
-            self.remove_invalid_token(access_token, event)
-            raise
-        return self.update_account(access_token, result)
+            result = OpenAIBackendAPI(active_token).get_user_info()
+        except InvalidAccessTokenError as exc:
+            refreshed_token = self.refresh_access_token(active_token, force=True, event=f"{event}:invalid_access_token")
+            if refreshed_token and refreshed_token != active_token:
+                try:
+                    result = OpenAIBackendAPI(refreshed_token).get_user_info()
+                except InvalidAccessTokenError as retry_exc:
+                    if self._record_invalid_token_seen(refreshed_token, event, str(retry_exc)):
+                        self.remove_invalid_token(refreshed_token, event)
+                    raise
+                active_token = refreshed_token
+            else:
+                if self._record_invalid_token_seen(active_token, event, str(exc)):
+                    self.remove_invalid_token(active_token, event)
+                raise
+        self._record_refresh_success(active_token)
+        return self.update_account(active_token, result)
 
     def refresh_accounts(self, access_tokens: list[str]) -> dict[str, Any]:
         access_tokens = list(dict.fromkeys(token for token in access_tokens if token))
@@ -370,6 +854,55 @@ class AccountService:
             "items": self.list_accounts(),
         }
 
+    def build_export_items(self, access_tokens: list[str] | None = None) -> list[dict[str, str]]:
+        target_tokens = set(token for token in (access_tokens or []) if token)
+        with self._lock:
+            accounts = [
+                dict(item)
+                for item in self._accounts.values()
+                if not target_tokens or str(item.get("access_token") or "") in target_tokens
+            ]
+
+        items: list[dict[str, str]] = []
+        for account in accounts:
+            access_token = str(account.get("access_token") or "").strip()
+            refresh_token = str(account.get("refresh_token") or "").strip()
+            id_token = str(account.get("id_token") or "").strip()
+            if not access_token or not refresh_token or not id_token:
+                continue
+
+            access_payload = self._decode_jwt_payload(access_token)
+            id_payload = self._decode_jwt_payload(id_token)
+            auth_claim = access_payload.get("https://api.openai.com/auth")
+            auth_claim = auth_claim if isinstance(auth_claim, dict) else {}
+            profile_claim = access_payload.get("https://api.openai.com/profile")
+            profile_claim = profile_claim if isinstance(profile_claim, dict) else {}
+
+            email = (
+                str(account.get("email") or "").strip()
+                or str(profile_claim.get("email") or "").strip()
+                or str(id_payload.get("email") or "").strip()
+            )
+            account_id = (
+                str(account.get("account_id") or "").strip()
+                or str(auth_claim.get("chatgpt_account_id") or "").strip()
+                or str(account.get("user_id") or "").strip()
+            )
+            item = {
+                "type": str(account.get("export_type") or "codex"),
+                "email": email,
+                "account_id": account_id,
+                "access_token": access_token,
+                "refresh_token": refresh_token,
+                "id_token": id_token,
+                "expired": self._timestamp_to_iso(access_payload.get("exp")),
+                "last_refresh": self._timestamp_to_iso(access_payload.get("iat")),
+            }
+            password = str(account.get("password") or "").strip()
+            if password:
+                item["password"] = password
+            items.append(item)
+        return items
 
     def get_stats(self) -> dict:
         with self._lock:

--- a/services/protocol/conversation.py
+++ b/services/protocol/conversation.py
@@ -521,8 +521,12 @@ def stream_text_deltas(backend: OpenAIBackendAPI, request: ConversationRequest) 
         except Exception as exc:
             error_message = str(exc)
             if token and not emitted and is_token_invalid_error(error_message):
-                account_service.remove_invalid_token(token, "text_stream")
-                token = account_service.get_text_access_token(attempted_tokens)
+                refreshed_token = account_service.refresh_access_token(token, force=True, event="text_stream")
+                if refreshed_token and refreshed_token != token and refreshed_token not in attempted_tokens:
+                    token = refreshed_token
+                else:
+                    account_service.remove_invalid_token(token, "text_stream")
+                    token = account_service.get_text_access_token(attempted_tokens)
                 if token:
                     continue
             raise
@@ -657,6 +661,10 @@ def stream_image_outputs_with_pool(request: ConversationRequest) -> Iterator[Ima
                 last_error = str(exc)
                 logger.warning({"event": "image_stream_fail", "request_token": token, "error": last_error})
                 if not emitted_for_token and is_token_invalid_error(last_error):
+                    refreshed_token = account_service.refresh_access_token(token, force=True, event="image_stream")
+                    if refreshed_token and refreshed_token != token:
+                        token = refreshed_token
+                        continue
                     account_service.remove_invalid_token(token, "image_stream")
                     continue
                 raise ImageGenerationError(image_stream_error_message(last_error)) from exc

--- a/services/register/openai_register.py
+++ b/services/register/openai_register.py
@@ -578,15 +578,26 @@ class PlatformRegistrar:
             h.update(_make_trace_headers())
             return h
 
-        resp, error = request_with_local_retry(
-            login_session, "get",
-            f"{auth_base}/api/accounts/authorize?{urlencode(params)}",
-            headers=_login_nav_headers(f"{platform_base}/"),
-            allow_redirects=True, verify=False
-        )
-        if resp is None:
-            raise RuntimeError(error or "platform_login_authorize_failed")
-        step(index, "登录 authorize 完成")
+        def _clear_login_auth_cookies() -> None:
+            for cookie in list(login_session.cookies):
+                if "auth.openai.com" in str(cookie.domain):
+                    login_session.cookies.clear(domain=cookie.domain, path=cookie.path, name=cookie.name)
+            login_session.cookies.set("oai-did", login_device_id, domain=".auth.openai.com")
+            login_session.cookies.set("oai-did", login_device_id, domain="auth.openai.com")
+
+        def _do_login_authorize(label: str) -> None:
+            nonlocal resp, error
+            resp, error = request_with_local_retry(
+                login_session, "get",
+                f"{auth_base}/api/accounts/authorize?{urlencode(params)}",
+                headers=_login_nav_headers(f"{platform_base}/"),
+                allow_redirects=True, verify=False
+            )
+            if resp is None:
+                raise RuntimeError(error or f"platform_login_authorize_{label}_failed")
+            if resp.status_code not in (200, 302):
+                raise RuntimeError(error or f"platform_login_authorize_{label}_http_{getattr(resp, 'status_code', 'unknown')}")
+            step(index, "登录 authorize 完成" if label == "initial" else f"登录 authorize 重试完成[{label}]")
 
         # 提交邮箱（原样，不带 state）
         def _do_authorize_continue():
@@ -601,57 +612,68 @@ class PlatformRegistrar:
                 verify=False
             )
 
-        step(index, "开始提交邮箱")
-        resp, error = _do_authorize_continue()
-        if resp is not None and resp.status_code == 409:
-            step(index, "邮箱提交 invalid_state，重新 authorize 后重试")
-            # 再次清除 cookie 并重新 authorize
-            for cookie in list(login_session.cookies):
-                if 'auth.openai.com' in cookie.domain:
-                    login_session.cookies.clear(domain=cookie.domain, path=cookie.path, name=cookie.name)
-            login_session.cookies.set("oai-did", login_device_id, domain=".auth.openai.com")
-            login_session.cookies.set("oai-did", login_device_id, domain="auth.openai.com")
-            resp, error = request_with_local_retry(
-                login_session, "get",
-                f"{auth_base}/api/accounts/authorize?{urlencode(params)}",
-                headers=_login_nav_headers(f"{platform_base}/"),
-                allow_redirects=True, verify=False
-            )
-            if resp is None:
-                raise RuntimeError(error or "platform_login_authorize_retry_failed")
-            resp, error = _do_authorize_continue()
+        def _submit_email_with_reauth() -> None:
+            nonlocal resp, error
+            step(index, "开始提交邮箱")
+            for attempt in range(3):
+                if attempt:
+                    step(index, f"邮箱提交 409/状态失效，清理 cookie 后重新 authorize 重试({attempt + 1}/3)", "yellow")
+                    _clear_login_auth_cookies()
+                    _do_login_authorize(f"email-{attempt + 1}")
+                resp, error = _do_authorize_continue()
+                if resp is not None and resp.status_code == 409:
+                    continue
+                break
+            if resp is None or resp.status_code != 200:
+                data = _response_json(resp) if resp is not None else {}
+                detail = json.dumps(data, ensure_ascii=False) if data else ""
+                raise RuntimeError(
+                    error or f"email_submit_http_{getattr(resp, 'status_code', 'unknown')}"
+                    + (f": {detail}" if detail else "")
+                )
+            step(index, "邮箱提交完成")
 
-        if resp is None or resp.status_code != 200:
-            data = _response_json(resp) if resp is not None else {}
-            detail = json.dumps(data, ensure_ascii=False) if data else ""
-            raise RuntimeError(
-                error or f"email_submit_http_{getattr(resp, 'status_code', 'unknown')}"
-                + (f": {detail}" if detail else "")
+        def _verify_password_once():
+            headers = _login_json_headers(f"{auth_base}/log-in/password")
+            headers["openai-sentinel-token"] = build_sentinel_token(
+                login_session, login_device_id, "password_verify"
             )
-        step(index, "邮箱提交完成")
+            return request_with_local_retry(
+                login_session, "post",
+                f"{auth_base}/api/accounts/password/verify",
+                json={"password": password},
+                headers=headers,
+                allow_redirects=False,
+                verify=False
+            )
 
-        # 密码验证
-        step(index, "开始密码校验")
-        headers = _login_json_headers(f"{auth_base}/log-in/password")
-        headers["openai-sentinel-token"] = build_sentinel_token(
-            login_session, login_device_id, "password_verify"
-        )
-        resp, error = request_with_local_retry(
-            login_session, "post",
-            f"{auth_base}/api/accounts/password/verify",
-            json={"password": password},
-            headers=headers,
-            allow_redirects=False,
-            verify=False
-        )
-        if resp is None or resp.status_code != 200:
-            body = ""
-            try:
-                body = (resp.text or "")[:500] if resp is not None else ""
-            except Exception:
-                pass
-            raise RuntimeError(error or f"password_verify_http_{getattr(resp, 'status_code', '')}_body={body}")
-        step(index, "密码校验完成")
+        def _verify_password_with_reauth() -> None:
+            nonlocal resp, error
+            step(index, "开始密码校验")
+            for attempt in range(3):
+                if attempt:
+                    step(index, f"密码校验 HTTP 409，重新登录状态后重试({attempt + 1}/3)", "yellow")
+                    _clear_login_auth_cookies()
+                    _do_login_authorize(f"password-{attempt + 1}")
+                    _submit_email_with_reauth()
+                resp, error = _verify_password_once()
+                if resp is not None and resp.status_code == 409:
+                    continue
+                break
+            if resp is None or resp.status_code != 200:
+                body = ""
+                try:
+                    body = (resp.text or "")[:500] if resp is not None else ""
+                except Exception:
+                    pass
+                raise RuntimeError(error or f"password_verify_http_{getattr(resp, 'status_code', '')}_body={body}")
+            step(index, "密码校验完成")
+
+        resp = None
+        error = ""
+        _do_login_authorize("initial")
+        _submit_email_with_reauth()
+        _verify_password_with_reauth()
 
         payload = _response_json(resp)
         continue_url = str(payload.get("continue_url") or "").strip()
@@ -724,7 +746,9 @@ def worker(index: int) -> dict:
         cost = time.time() - start
         access_token = str(result["access_token"])
         account_service.add_account_items([result])
-        account_service.refresh_accounts([access_token])
+        refresh_result = account_service.refresh_accounts([access_token])
+        if refresh_result.get("errors"):
+            step(index, f"账号已保存，刷新状态暂未成功，稍后可重试: {refresh_result['errors']}", "yellow")
         with stats_lock:
             stats["done"] += 1
             stats["success"] += 1


### PR DESCRIPTION
## 变更说明

这个 PR 主要修复新注册账号保存后立即变成异常的问题，并补齐 OAuth token 的自动刷新/兜底机制。

### 修复内容

- 注册成功后保留完整账号信息，包括 `refresh_token`、`id_token`、邮箱、密码等字段，避免只保存 `access_token` 导致后续无法刷新。
- 新注册账号遇到短暂的 `InvalidAccessTokenError` 时增加 grace 保护，避免刚注册就被标记异常或删除。
- 在账号信息刷新、文本会话、图片会话获取到 invalid access token 时，优先使用 `refresh_token` 强制刷新并重试。
- 后台 watcher 会定期刷新快过期的 access token。
- 增加 refresh token keepalive 兜底：长期不用的账号也会定期触发一次刷新，降低 refresh token 因长期不使用而失效的概率。
- 保留 codex 导出兼容逻辑，避免导入时 `type=codex` 覆盖账号池套餐类型。

### 验证

本地已执行：

```bash
uv run python -m py_compile services/account_service.py api/support.py
uv run python -m unittest test/test_account_image_capabilities.py test/test_account_export.py
```

结果：测试通过。
