### PR TITLE
Fix Sub2API account sync with redacted credentials

### DIFF
--- a/services/sub2api_service.py
+++ b/services/sub2api_service.py
@@ -245,6 +245,19 @@ def _extract_access_token(credentials: object) -> str:
     return ""
 
 
+def _credentials_status(account: dict) -> dict:
+    status = account.get("credentials_status")
+    return status if isinstance(status, dict) else {}
+
+
+def _has_access_token(account: dict, credentials: dict) -> bool:
+    return bool(_extract_access_token(credentials) or _credentials_status(account).get("has_access_token"))
+
+
+def _has_refresh_token(account: dict, credentials: dict) -> bool:
+    return bool(_clean(credentials.get("refresh_token")) or _credentials_status(account).get("has_refresh_token"))
+
+
 def _unwrap_envelope(payload: object) -> object:
     """Peel sub2api's `{code, message, data}` envelope, returning the inner `data` field
     when present. Also handles unwrapped responses from older/alt versions."""
@@ -309,8 +322,7 @@ def list_remote_accounts(server: dict) -> list[dict]:
                 if not isinstance(account, dict):
                     continue
                 credentials = account.get("credentials") if isinstance(account.get("credentials"), dict) else {}
-                access_token = _extract_access_token(credentials)
-                if not access_token:
+                if not _has_access_token(account, credentials):
                     continue
                 account_id = account.get("id")
                 items.append({
@@ -320,7 +332,7 @@ def list_remote_accounts(server: dict) -> list[dict]:
                     "plan_type": _clean(credentials.get("plan_type")),
                     "status": _clean(account.get("status")),
                     "expires_at": _clean(credentials.get("expires_at")),
-                    "has_refresh_token": bool(_clean(credentials.get("refresh_token"))),
+                    "has_refresh_token": _has_refresh_token(account, credentials),
                 })
 
             if page * 200 >= total or len(data) < 200:
@@ -330,6 +342,15 @@ def list_remote_accounts(server: dict) -> list[dict]:
         session.close()
 
     return items
+
+
+def _extract_data_accounts(payload: object) -> list[dict]:
+    data = _unwrap_envelope(payload)
+    if isinstance(data, dict):
+        accounts = data.get("accounts")
+        if isinstance(accounts, list):
+            return [account for account in accounts if isinstance(account, dict)]
+    return []
 
 
 def list_remote_groups(server: dict) -> list[dict]:
@@ -387,8 +408,35 @@ def list_remote_groups(server: dict) -> list[dict]:
     return items
 
 
-def _fetch_access_token_for_account(server: dict, account_id: str) -> tuple[str, dict]:
-    """Return (access_token, account_meta) for a single sub2api account id."""
+def _fetch_account_from_data_export(server: dict, account_id: str) -> dict | None:
+    """Fetch raw account data from sub2api's admin data export endpoint.
+
+    The export may include refresh_token/id_token, but callers only consume access_token
+    to preserve chatgpt2api's access-token-only import behavior.
+    """
+    base_url = _clean(server.get("base_url"))
+    headers = _auth_headers(server)
+
+    session = Session(verify=True)
+    try:
+        response = session.get(
+            f"{base_url.rstrip('/')}/api/v1/admin/accounts/data",
+            headers=headers,
+            params={"ids": account_id, "include_proxies": "false"},
+            timeout=30,
+        )
+        if response.status_code == 404:
+            return None
+        if not response.ok:
+            raise RuntimeError(f"HTTP {response.status_code}")
+        accounts = _extract_data_accounts(response.json())
+    finally:
+        session.close()
+
+    return accounts[0] if accounts else None
+
+
+def _fetch_account_from_detail(server: dict, account_id: str) -> dict:
     base_url = _clean(server.get("base_url"))
     headers = _auth_headers(server)
 
@@ -408,6 +456,14 @@ def _fetch_access_token_for_account(server: dict, account_id: str) -> tuple[str,
     account = _unwrap_envelope(payload)
     if not isinstance(account, dict):
         account = payload if isinstance(payload, dict) else {}
+    return account
+
+
+def _fetch_access_token_for_account(server: dict, account_id: str) -> tuple[str, dict]:
+    """Return (access_token, account_meta) for a single sub2api account id."""
+    account = _fetch_account_from_data_export(server, account_id)
+    if account is None:
+        account = _fetch_account_from_detail(server, account_id)
     credentials = account.get("credentials") if isinstance(account.get("credentials"), dict) else {}
     access_token = _extract_access_token(credentials)
     if not access_token:

--- a/test/test_sub2api_service.py
+++ b/test/test_sub2api_service.py
@@ -1,0 +1,190 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from services import sub2api_service
+
+
+class FakeResponse:
+    def __init__(self, payload: dict, *, ok: bool = True, status_code: int = 200) -> None:
+        self._payload = payload
+        self.ok = ok
+        self.status_code = status_code
+        self.text = str(payload)
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class FakeSession:
+    responses: list[FakeResponse] = []
+    requests: list[dict] = []
+
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    def get(self, url: str, **kwargs) -> FakeResponse:
+        self.requests.append({"url": url, **kwargs})
+        if not self.responses:
+            raise AssertionError("No fake response queued")
+        return self.responses.pop(0)
+
+    def close(self) -> None:
+        pass
+
+
+class Sub2APIServiceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        FakeSession.responses = []
+        FakeSession.requests = []
+
+    def test_list_remote_accounts_keeps_redacted_accounts_with_access_token_status(self) -> None:
+        FakeSession.responses = [
+            FakeResponse(
+                {
+                    "code": 0,
+                    "data": {
+                        "items": [
+                            {
+                                "id": 123,
+                                "name": "user@example.com",
+                                "platform": "openai",
+                                "type": "oauth",
+                                "status": "active",
+                                "credentials": {"email": "user@example.com", "plan_type": "Plus"},
+                                "credentials_status": {
+                                    "has_access_token": True,
+                                    "has_refresh_token": True,
+                                },
+                            }
+                        ],
+                        "total": 1,
+                    },
+                }
+            )
+        ]
+
+        with patch.object(sub2api_service, "Session", FakeSession):
+            accounts = sub2api_service.list_remote_accounts(
+                {"base_url": "https://sub2api.test", "api_key": "admin-key"}
+            )
+
+        self.assertEqual(len(accounts), 1)
+        self.assertEqual(accounts[0]["id"], "123")
+        self.assertEqual(accounts[0]["email"], "user@example.com")
+        self.assertEqual(accounts[0]["plan_type"], "Plus")
+        self.assertTrue(accounts[0]["has_refresh_token"])
+
+    def test_list_remote_accounts_skips_redacted_accounts_without_access_token_status(self) -> None:
+        FakeSession.responses = [
+            FakeResponse(
+                {
+                    "code": 0,
+                    "data": {
+                        "items": [
+                            {
+                                "id": 123,
+                                "name": "missing-token",
+                                "credentials": {"email": "missing@example.com"},
+                                "credentials_status": {"has_refresh_token": True},
+                            }
+                        ],
+                        "total": 1,
+                    },
+                }
+            )
+        ]
+
+        with patch.object(sub2api_service, "Session", FakeSession):
+            accounts = sub2api_service.list_remote_accounts(
+                {"base_url": "https://sub2api.test", "api_key": "admin-key"}
+            )
+
+        self.assertEqual(accounts, [])
+
+    def test_fetch_access_token_prefers_data_export_and_ignores_refresh_token(self) -> None:
+        FakeSession.responses = [
+            FakeResponse(
+                {
+                    "code": 0,
+                    "data": {
+                        "accounts": [
+                            {
+                                "name": "user@example.com",
+                                "credentials": {
+                                    "access_token": "access-token-from-export",
+                                    "refresh_token": "refresh-token-must-not-be-imported",
+                                    "id_token": "id-token-must-not-be-imported",
+                                    "email": "user@example.com",
+                                    "plan_type": "Pro",
+                                },
+                            }
+                        ]
+                    },
+                }
+            )
+        ]
+
+        with patch.object(sub2api_service, "Session", FakeSession):
+            token, meta = sub2api_service._fetch_access_token_for_account(
+                {"base_url": "https://sub2api.test", "api_key": "admin-key"},
+                "123",
+            )
+
+        self.assertEqual(token, "access-token-from-export")
+        self.assertEqual(meta, {"email": "user@example.com", "plan_type": "Pro"})
+        self.assertEqual(len(FakeSession.requests), 1)
+        self.assertTrue(FakeSession.requests[0]["url"].endswith("/api/v1/admin/accounts/data"))
+        self.assertEqual(FakeSession.requests[0]["params"]["include_proxies"], "false")
+
+    def test_fetch_access_token_falls_back_to_legacy_detail_when_data_export_is_missing(self) -> None:
+        FakeSession.responses = [
+            FakeResponse({"message": "not found"}, ok=False, status_code=404),
+            FakeResponse(
+                {
+                    "code": 0,
+                    "data": {
+                        "credentials": {
+                            "access_token": "legacy-access-token",
+                            "refresh_token": "legacy-refresh-token-must-not-be-imported",
+                            "email": "legacy@example.com",
+                        }
+                    },
+                }
+            ),
+        ]
+
+        with patch.object(sub2api_service, "Session", FakeSession):
+            token, meta = sub2api_service._fetch_access_token_for_account(
+                {"base_url": "https://sub2api.test", "api_key": "admin-key"},
+                "123",
+            )
+
+        self.assertEqual(token, "legacy-access-token")
+        self.assertEqual(meta, {"email": "legacy@example.com", "plan_type": ""})
+        self.assertEqual(len(FakeSession.requests), 2)
+        self.assertTrue(FakeSession.requests[1]["url"].endswith("/api/v1/admin/accounts/123"))
+
+    def test_run_import_still_adds_only_access_tokens(self) -> None:
+        config = MagicMock()
+        config.get_import_job.return_value = {
+            "total": 1,
+            "completed": 0,
+            "errors": [],
+        }
+        importer = sub2api_service.Sub2APIImportService(config)
+        account_service = MagicMock()
+        account_service.add_accounts.return_value = {"added": 1, "skipped": 0}
+        account_service.refresh_accounts.return_value = {"refreshed": 1}
+
+        with (
+            patch.object(sub2api_service, "_fetch_access_token_for_account", return_value=("access-only", {})),
+            patch.object(sub2api_service, "account_service", account_service),
+        ):
+            importer._run_import("server-id", {"id": "server-id"}, ["123"])
+
+        account_service.add_accounts.assert_called_once_with(["access-only"])
+        account_service.refresh_accounts.assert_called_once_with(["access-only"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- keep Sub2API OAuth accounts visible when v0.1.129 redacts credentials but reports `credentials_status.has_access_token`
- fetch raw account data through the admin data export endpoint during import, then import only `access_token`
- preserve the original access-token-only design: no `refresh_token`/`id_token` is saved or used

Fixes #187
Fixes #189

## Tests
- `uv run python -m unittest test.test_sub2api_service`
- `uv run python -m unittest test.test_account_export test.test_sub2api_service`