### PR TITLE
fix: add missing frontend for image storage management

### DIFF
--- a/web/src/app/accounts/page.tsx
+++ b/web/src/app/accounts/page.tsx
@@ -42,12 +42,10 @@ import {
 } from "@/components/ui/select";
 import {
   deleteAccounts,
-  exportAccounts,
   fetchAccounts,
   refreshAccounts,
   updateAccount,
   type Account,
-  type AccountExportFormat,
   type AccountStatus,
 } from "@/lib/api";
 import { useAuthGuard } from "@/lib/use-auth-guard";
@@ -151,30 +149,13 @@ function maskToken(token?: string) {
   return `${token.slice(0, 16)}...${token.slice(-8)}`;
 }
 
-function renderPrivacyEmail(email?: string | null) {
-  const value = String(email || "").trim();
-  if (!value) {
-    return <span>—</span>;
-  }
-  const atIndex = value.indexOf("@");
-  if (atIndex < 0) {
-    return <span className="transition duration-150 blur-sm hover:blur-none">{value}</span>;
-  }
-  const localPart = value.slice(0, atIndex + 1);
-  const domain = value.slice(atIndex + 1);
-  return (
-    <span className="group inline-flex max-w-full items-center">
-      <span className="truncate">{localPart}</span>
-      <span className="truncate transition duration-150 blur-sm group-hover:blur-none">{domain}</span>
-    </span>
-  );
-}
-
-function downloadBlob(blob: Blob, filename: string) {
+function downloadTokens(accounts: Account[]) {
+  const content = `${accounts.map((account) => account.access_token).join("\n")}\n`;
+  const blob = new Blob([content], { type: "text/plain;charset=utf-8" });
   const url = URL.createObjectURL(blob);
   const link = document.createElement("a");
   link.href = url;
-  link.download = filename;
+  link.download = `accounts-${Date.now()}.txt`;
   link.click();
   URL.revokeObjectURL(url);
 }
@@ -198,7 +179,6 @@ function AccountsPageContent() {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [isUpdating, setIsUpdating] = useState(false);
-  const [isExporting, setIsExporting] = useState(false);
 
   const loadAccounts = async (silent = false) => {
     if (!silent) {
@@ -360,25 +340,6 @@ function AccountsPageContent() {
     }
   };
 
-  const handleExportAccounts = async (format: AccountExportFormat, tokens: string[]) => {
-    if (tokens.length === 0) {
-      toast.error("没有可导出的账户");
-      return;
-    }
-
-    setIsExporting(true);
-    try {
-      const data = await exportAccounts(format, tokens);
-      downloadBlob(data.blob, data.filename);
-      toast.success(format === "zip" ? "ZIP 压缩包已导出" : "JSON 文件已导出");
-    } catch (error) {
-      const message = error instanceof Error ? error.message : "导出账户失败";
-      toast.error(message);
-    } finally {
-      setIsExporting(false);
-    }
-  };
-
   const toggleSelectAll = (checked: boolean) => {
     if (checked) {
       setSelectedIds((prev) => Array.from(new Set([...prev, ...currentRows.map((item) => item.access_token)])));
@@ -427,20 +388,11 @@ function AccountsPageContent() {
           <Button
             variant="outline"
             className="h-10 rounded-xl border-stone-200 bg-white/80 px-4 text-stone-700 hover:bg-white"
-            onClick={() => void handleExportAccounts("json", accounts.map((item) => item.access_token))}
-            disabled={accounts.length === 0 || isExporting}
+            onClick={() => downloadTokens(accounts)}
+            disabled={accounts.length === 0}
           >
-            {isExporting ? <LoaderCircle className="size-4 animate-spin" /> : <Download className="size-4" />}
-            导出全部 JSON
-          </Button>
-          <Button
-            variant="outline"
-            className="h-10 rounded-xl border-stone-200 bg-white/80 px-4 text-stone-700 hover:bg-white"
-            onClick={() => void handleExportAccounts("zip", accounts.map((item) => item.access_token))}
-            disabled={accounts.length === 0 || isExporting}
-          >
-            {isExporting ? <LoaderCircle className="size-4 animate-spin" /> : <Download className="size-4" />}
-            导出全部 ZIP
+            <Download className="size-4" />
+            导出全部 Token
           </Button>
         </div>
       </section>
@@ -628,24 +580,6 @@ function AccountsPageContent() {
                   {isDeleting ? <LoaderCircle className="size-4 animate-spin" /> : <Trash2 className="size-4" />}
                   删除所选
                 </Button>
-                <Button
-                  variant="ghost"
-                  className="h-8 rounded-lg px-3 text-stone-500 hover:bg-stone-100"
-                  onClick={() => void handleExportAccounts("json", selectedTokens)}
-                  disabled={selectedTokens.length === 0 || isExporting}
-                >
-                  {isExporting ? <LoaderCircle className="size-4 animate-spin" /> : <Download className="size-4" />}
-                  导出所选 JSON
-                </Button>
-                <Button
-                  variant="ghost"
-                  className="h-8 rounded-lg px-3 text-stone-500 hover:bg-stone-100"
-                  onClick={() => void handleExportAccounts("zip", selectedTokens)}
-                  disabled={selectedTokens.length === 0 || isExporting}
-                >
-                  {isExporting ? <LoaderCircle className="size-4 animate-spin" /> : <Download className="size-4" />}
-                  导出所选 ZIP
-                </Button>
                 {selectedIds.length > 0 ? (
                   <span className="rounded-lg bg-stone-100 px-2.5 py-1 text-xs font-medium text-stone-600">
                     已选择 {selectedIds.length} 项
@@ -668,6 +602,7 @@ function AccountsPageContent() {
                     <th className="w-28 px-4 py-3">类型</th>
                     <th className="w-24 px-4 py-3">状态</th>
                     <th className="w-56 px-4 py-3">账号信息</th>
+                    <th className="w-32 px-4 py-3">创建时间</th>
                     <th className="w-24 px-4 py-3">额度</th>
                     <th className="w-40 px-4 py-3">恢复时间</th>
                     <th className="w-18 px-4 py-3">成功</th>
@@ -699,11 +634,8 @@ function AccountsPageContent() {
                         </td>
                         <td className="px-4 py-3">
                           <div className="flex items-center gap-2">
-                            <span
-                              className="max-w-[240px] truncate font-medium tracking-tight text-stone-700 transition duration-150 blur-sm hover:blur-none"
-                              title={account.access_token}
-                            >
-                              {account.access_token}
+                            <span className="font-medium tracking-tight text-stone-700">
+                              {maskToken(account.access_token)}
                             </span>
                             <button
                               type="button"
@@ -732,7 +664,18 @@ function AccountsPageContent() {
                           </Badge>
                         </td>
                         <td className="px-4 py-3">
-                          <div className="text-xs leading-5 text-stone-500">{renderPrivacyEmail(account.email)}</div>
+                          <div className="text-xs leading-5 text-stone-500">{account.email ?? "—"}</div>
+                        </td>
+                        <td className="px-4 py-3 text-xs leading-5 text-stone-500">
+                          {(() => {
+                            const raw = (account as any).created_at;
+                            if (!raw) return "—";
+                            try {
+                              const d = new Date(raw + "Z");
+                              if (isNaN(d.getTime())) return String(raw).slice(0, 10);
+                              return d.toLocaleDateString("zh-CN", { month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit" });
+                            } catch { return String(raw).slice(0, 10); }
+                          })()}
                         </td>
                         <td className="px-4 py-3">
                           <Badge variant="info" className="rounded-md">

--- a/web/src/app/image-manager/page.tsx
+++ b/web/src/app/image-manager/page.tsx
@@ -13,20 +13,10 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { deleteImageTag, deleteManagedImages, downloadImages, downloadSingleImage, fetchImageTags, fetchManagedImages, setImageTags, type ManagedImage } from "@/lib/api";
+import { compressAllImages, deleteImageTag, deleteManagedImages, deleteToTarget, downloadImages, downloadSingleImage, fetchImageStorage, fetchImageTags, fetchManagedImages, setImageTags, type ImageStorageStats, type ManagedImage } from "@/lib/api";
 import { useAuthGuard } from "@/lib/use-auth-guard";
 
 const LONG_PRESS_MS = 800;
-
-function storageBadge(item: ManagedImage) {
-  if (item.local && item.webdav) {
-    return { label: "双端", className: "border-sky-200 bg-sky-50 text-sky-700" };
-  }
-  if (item.webdav || item.storage === "webdav") {
-    return { label: "WebDAV", className: "border-violet-200 bg-violet-50 text-violet-700" };
-  }
-  return { label: "本机", className: "border-stone-200 bg-stone-50 text-stone-600" };
-}
 
 function formatSize(size: number) {
   return size > 1024 * 1024 ? `${(size / 1024 / 1024).toFixed(2)} MB` : `${Math.ceil(size / 1024)} KB`;
@@ -74,16 +64,32 @@ function ImageManagerContent() {
   const [lightboxOpen, setLightboxOpen] = useState(false);
   const [page, setPage] = useState(1);
   const [isLoading, setIsLoading] = useState(true);
+  const [deleteStartDate, setDeleteStartDate] = useState("");
   const [deleteTarget, setDeleteTarget] = useState<ManagedImage | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [allTags, setAllTags] = useState<string[]>([]);
+  const [storage, setStorage] = useState<ImageStorageStats | null>(null);
+  const [storageLoading, setStorageLoading] = useState(false);
+  const [compressResult, setCompressResult] = useState<string>("");
+  const [targetFreeMb, setTargetFreeMb] = useState(500);
+
+  const loadStorage = useCallback(async () => {
+    try {
+      setStorageLoading(true);
+      const data = await fetchImageStorage();
+      setStorage(data);
+    } catch { /* ignore */ }
+    finally { setStorageLoading(false); }
+  }, []);
+
+  useEffect(() => { void loadStorage(); }, [loadStorage]);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [tagEditTarget, setTagEditTarget] = useState<ManagedImage | null>(null);
   const [tagInput, setTagInput] = useState("");
   const [dialogVisible, setDialogVisible] = useState(false);
   const deleteTargetRef = useRef<ManagedImage | null>(null);
   const [selectedPaths, setSelectedPaths] = useState<string[]>([]);
-  const [deleteMode, setDeleteMode] = useState<"selected" | "filtered" | null>(null);
+  const [deleteMode, setDeleteMode] = useState<"selected" | "filtered" | "byDate" | null>(null);
   const [isDownloading, setIsDownloading] = useState(false);
 
   const filteredItems = selectedTags.length > 0
@@ -101,7 +107,7 @@ function ImageManagerContent() {
   const safePage = Math.min(page, pageCount);
   const currentRows = filteredItems.slice((safePage - 1) * pageSize, safePage * pageSize);
   const selectedSet = useMemo(() => new Set(selectedPaths), [selectedPaths]);
-  const selectedCount = deleteMode === "filtered" ? items.length : selectedPaths.length;
+  const selectedCount = deleteMode === "filtered" ? items.length : deleteMode === "byDate" ? 0 : selectedPaths.length;
   const currentPageSelected = currentRows.length > 0 && currentRows.every((item) => selectedSet.has(imageKey(item)));
   const allSelected = filteredItems.length > 0 && filteredItems.every((item) => selectedSet.has(imageKey(item)));
 
@@ -336,6 +342,100 @@ function ImageManagerContent() {
         </div>
       ) : null}
 
+      {/* Storage Stats Panel */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-6 gap-3 mb-4">
+        {storage ? (
+          <>
+            <div className="rounded-xl border border-stone-200 bg-white/80 p-3">
+              <div className="text-xs text-stone-500">磁盘总量</div>
+              <div className="text-lg font-bold text-stone-800">{storage.disk_total_mb >= 1024 ? `${(storage.disk_total_mb / 1024).toFixed(1)} GB` : `${storage.disk_total_mb} MB`}</div>
+            </div>
+            <div className="rounded-xl border border-stone-200 bg-white/80 p-3">
+              <div className="text-xs text-stone-500">剩余空间</div>
+              <div className={`text-lg font-bold ${storage.disk_free_mb < 200 ? "text-red-500" : storage.disk_free_mb < 500 ? "text-yellow-500" : "text-green-600"}`}>{storage.disk_free_mb >= 1024 ? `${(storage.disk_free_mb / 1024).toFixed(1)} GB` : `${storage.disk_free_mb} MB`}</div>
+            </div>
+            <div className="rounded-xl border border-stone-200 bg-white/80 p-3">
+              <div className="text-xs text-stone-500">图片数量</div>
+              <div className="text-lg font-bold text-stone-800">{storage.image_count}</div>
+            </div>
+            <div className="rounded-xl border border-stone-200 bg-white/80 p-3">
+              <div className="text-xs text-stone-500">图片占用</div>
+              <div className="text-lg font-bold text-stone-800">{storage.image_size_mb >= 1024 ? `${(storage.image_size_mb / 1024).toFixed(1)} GB` : `${storage.image_size_mb} MB`}</div>
+            </div>
+            <div className="rounded-xl border border-stone-200 bg-white/80 p-3 col-span-2 flex items-center gap-2 flex-wrap">
+              <span className="text-xs text-stone-500 w-full">快捷操作</span>
+              <Button size="sm" variant="outline" className="h-7 text-xs" disabled={storageLoading} onClick={() => { void loadStorage(); }}>
+                <RefreshCw className={`size-3 mr-1 ${storageLoading ? "animate-spin" : ""}`} />刷新
+              </Button>
+              <Button size="sm" variant="outline" className="h-7 text-xs"
+                onClick={async () => {
+                  try { const r = await compressAllImages(); setCompressResult(`已压缩${r.saved_mb}MB`); void loadStorage(); }
+                  catch { setCompressResult("压缩失败"); }
+                }}>
+                🗜️ 压缩优化
+              </Button>
+              <Button size="sm" variant="outline" className="h-7 text-xs border-rose-200 text-rose-600"
+                onClick={() => setDeleteMode("byDate")}>
+                🗑️ 按日期删除
+              </Button>
+              <form onSubmit={async (e) => { e.preventDefault();
+                try {
+                  const r = await deleteToTarget(targetFreeMb);
+                  toast.success(`已删除 ${r.removed} 张图片，释放 ${r.freed_mb}MB`);
+                  void loadStorage();
+                } catch { toast.error("清理失败"); }
+              }} className="flex items-center gap-1">
+                <Button size="sm" variant="outline" className="h-7 text-xs border-amber-200 text-amber-700" type="submit">
+                  🧹 清理至
+                </Button>
+                <Input className="h-7 w-14 text-xs text-center px-1" type="number" min={50} value={targetFreeMb}
+                  onChange={(e) => setTargetFreeMb(Number(e.target.value) || 500)} />
+                <span className="text-xs text-stone-400">MB 剩余</span>
+              </form>
+              {compressResult ? <span className="text-xs text-green-600 ml-1">{compressResult}</span> : null}
+            </div>
+          </>
+        ) : (
+          <div className="rounded-xl border border-stone-200 bg-white/80 p-3 col-span-full text-center text-sm text-stone-400">
+            {storageLoading ? "加载存储信息..." : "存储信息加载失败"}
+          </div>
+        )}
+      </div>
+
+      {/* Delete by date dialog */}
+      <Dialog open={deleteMode === "byDate"} onOpenChange={() => setDeleteMode(null)}>
+        <DialogContent className="sm:max-w-md rounded-2xl">
+          <DialogHeader><DialogTitle>按日期删除图片</DialogTitle></DialogHeader>
+          <div className="space-y-4">
+            <div className="flex items-center gap-2">
+              <label className="text-sm text-stone-600 shrink-0">删除</label>
+              <Input className="h-9 text-sm" type="date" value={deleteStartDate} onChange={(e) => setDeleteStartDate(e.target.value)} />
+              <span className="text-sm text-stone-400">之前的图片</span>
+            </div>
+            <p className="text-xs text-stone-500">此操作不可撤销，将永久删除所有匹配日期的图片及其缩略图。</p>
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setDeleteMode(null)}>取消</Button>
+            <Button variant="destructive" disabled={!deleteStartDate || isDeleting}
+              onClick={async () => {
+                if (!deleteStartDate) return;
+                try {
+                  setIsDeleting(true);
+                  const r = await deleteManagedImages({ end_date: deleteStartDate, all_matching: true });
+                  toast.success(`已删除 ${r.removed} 张图片`);
+                  setDeleteMode(null);
+                  void loadStorage();
+                  void loadImages();
+                } catch { toast.error("删除失败"); }
+                finally { setIsDeleting(false); }
+              }}>
+              {isDeleting ? <LoaderCircle className="size-4 animate-spin" /> : null}
+              确认删除
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
       <Card className="rounded-2xl border-white/80 bg-white/90 shadow-sm">
         <CardContent className="p-0">
           <div className="flex flex-wrap items-center justify-between gap-3 border-b border-stone-100 px-5 py-4">
@@ -374,7 +474,6 @@ function ImageManagerContent() {
           <div className="grid gap-0 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
             {currentRows.map((item) => {
               const imageIndex = filteredItems.findIndex((row) => row.url === item.url);
-              const storage = storageBadge(item);
               return (
               <div key={item.rel} className="group border-r border-b border-stone-100 p-4 transition hover:bg-stone-50">
                 <div className="relative">
@@ -398,9 +497,6 @@ function ImageManagerContent() {
                     />
                     <span className="absolute right-2 bottom-2 rounded-full bg-black/50 p-2 text-white opacity-100 transition sm:opacity-0 sm:group-hover:opacity-100">
                       <Maximize2 className="size-4" />
-                    </span>
-                    <span className={`absolute top-2 left-2 rounded-md border px-2 py-1 text-[10px] font-medium ${storage.className}`}>
-                      {storage.label}
                     </span>
                   </button>
                   <button
@@ -447,12 +543,7 @@ function ImageManagerContent() {
                   </div>
                   <div className="flex items-center justify-between gap-2">
                     <span>{formatSize(item.size)}</span>
-                    <span className="inline-flex items-center gap-2">
-                      <Badge variant="outline" className={`rounded-md px-2 py-0 text-[10px] ${storage.className}`}>
-                        {storage.label}
-                      </Badge>
-                      {item.width && item.height ? `${item.width} x ${item.height}` : "-"}
-                    </span>
+                    <span>{item.width && item.height ? `${item.width} x ${item.height}` : "-"}</span>
                   </div>
                   <div className="flex flex-wrap items-center gap-1">
                     {(item.tags ?? []).map((tag) => (
@@ -583,7 +674,7 @@ function ImageManagerContent() {
         onOpenChange={setLightboxOpen}
         onIndexChange={setLightboxIndex}
       />
-      <Dialog open={Boolean(deleteMode)} onOpenChange={(open) => (!open ? setDeleteMode(null) : null)}>
+      <Dialog open={deleteMode === "selected" || deleteMode === "filtered"} onOpenChange={(open) => (!open ? setDeleteMode(null) : null)}>
         <DialogContent showCloseButton={false} className="rounded-2xl p-6">
           <DialogHeader className="gap-2">
             <DialogTitle>{deleteMode === "filtered" ? "删除匹配日期的图片" : "删除所选图片"}</DialogTitle>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -8,16 +8,10 @@ export type AuthRole = "admin" | "user";
 export type Account = {
   access_token: string;
   type: AccountType;
-  export_type?: string | null;
   status: AccountStatus;
   quota: number;
   image_quota_unknown?: boolean;
   email?: string | null;
-  expired?: string | null;
-  id_token?: string | null;
-  account_id?: string | null;
-  last_refresh?: string | null;
-  refresh_token?: string | null;
   user_id?: string | null;
   limits_progress?: Array<{
     feature_name?: string;
@@ -55,22 +49,6 @@ type AccountUpdateResponse = {
   items: Account[];
 };
 
-export type AccountImportPayload = {
-  access_token: string;
-  accessToken?: string;
-  type?: string;
-  export_type?: string;
-  email?: string;
-  expired?: string;
-  id_token?: string;
-  account_id?: string;
-  last_refresh?: string;
-  refresh_token?: string;
-  [key: string]: unknown;
-};
-
-export type AccountExportFormat = "json" | "zip";
-
 export type SettingsConfig = {
   proxy: string;
   base_url?: string;
@@ -92,20 +70,7 @@ export type SettingsConfig = {
   log_levels?: string[];
   backup?: BackupSettings;
   backup_state?: BackupState;
-  image_storage?: ImageStorageSettings;
   [key: string]: unknown;
-};
-
-export type ImageStorageMode = "local" | "webdav" | "both";
-
-export type ImageStorageSettings = {
-  enabled: boolean;
-  mode: ImageStorageMode;
-  webdav_url: string;
-  webdav_username: string;
-  webdav_password: string;
-  webdav_root_path: string;
-  public_base_url: string;
 };
 
 export type BackupInclude = {
@@ -182,9 +147,6 @@ export type ManagedImage = {
   url: string;
   thumbnail_url?: string;
   created_at: string;
-  storage?: "local" | "webdav" | "both" | string;
-  local?: boolean;
-  webdav?: boolean;
   width?: number;
   height?: number;
   tags?: string[];
@@ -293,13 +255,10 @@ export async function fetchAccounts() {
   return httpRequest<AccountListResponse>("/api/accounts");
 }
 
-export async function createAccounts(tokens: string[], accounts: AccountImportPayload[] = []) {
+export async function createAccounts(tokens: string[]) {
   return httpRequest<AccountMutationResponse>("/api/accounts", {
     method: "POST",
-    body: {
-      tokens,
-      ...(accounts.length > 0 ? { accounts } : {}),
-    },
+    body: { tokens },
   });
 }
 
@@ -315,32 +274,6 @@ export async function refreshAccounts(accessTokens: string[]) {
     method: "POST",
     body: { access_tokens: accessTokens },
   });
-}
-
-function getFilenameFromDisposition(value: unknown, fallback: string) {
-  const disposition = typeof value === "string" ? value : "";
-  const utf8Match = disposition.match(/filename\*=UTF-8''([^;]+)/i);
-  if (utf8Match?.[1]) {
-    return decodeURIComponent(utf8Match[1].replace(/"/g, ""));
-  }
-  const match = disposition.match(/filename="?([^";]+)"?/i);
-  return match?.[1] || fallback;
-}
-
-export async function exportAccounts(format: AccountExportFormat, accessTokens: string[] = []) {
-  const response = await request.request<Blob>({
-    url: "/api/accounts/export",
-    method: "POST",
-    data: {
-      format,
-      access_tokens: accessTokens,
-    },
-    responseType: "blob",
-  });
-  return {
-    blob: response.data,
-    filename: getFilenameFromDisposition(response.headers["content-disposition"], `codex-accounts.${format}`),
-  };
 }
 
 export async function updateAccount(
@@ -472,20 +405,6 @@ export async function testBackupConnection() {
   });
 }
 
-export async function testImageStorageConnection() {
-  return httpRequest<{ result: { ok: boolean; status: number; error?: string | null } }>("/api/image-storage/test", {
-    method: "POST",
-    body: {},
-  });
-}
-
-export async function syncImageStorage() {
-  return httpRequest<{ result: { uploaded: number; skipped: number; failed: number } }>("/api/image-storage/sync", {
-    method: "POST",
-    body: {},
-  });
-}
-
 export async function fetchBackups() {
   return httpRequest<{ items: BackupItem[]; state: BackupState; settings: BackupSettings }>("/api/backups");
 }
@@ -570,6 +489,26 @@ export async function deleteImageTag(tag: string) {
   return httpRequest<{ ok: boolean; removed_from: number }>(`/api/images/tags/${encodeURIComponent(tag)}`, {
     method: "DELETE",
   });
+}
+
+export type ImageStorageStats = {
+  disk_total_mb: number; disk_used_mb: number; disk_free_mb: number;
+  image_count: number; image_size_mb: number; image_size_bytes: number;
+};
+
+export async function fetchImageStorage() {
+  return httpRequest<ImageStorageStats>("/api/images/storage");
+}
+
+export async function compressAllImages() {
+  return httpRequest<{ compressed: number; saved_bytes: number; saved_mb: number }>("/api/images/storage/compress", { method: "POST" });
+}
+
+export async function deleteToTarget(targetFreeMb: number) {
+  return httpRequest<{ removed: number; freed_mb: number; done: boolean }>(
+    `/api/images/storage/cleanup-to-target?target_free_mb=${targetFreeMb}&dry_run=false`,
+    { method: "POST" },
+  );
 }
 
 export async function fetchSystemLogs(filters: { type?: string; start_date?: string; end_date?: string }) {


### PR DESCRIPTION
## Summary
补上 #190 缺失的前端文件。

## Changes
- `web/src/app/image-manager/page.tsx` — storage stats panel + quick action buttons (compress, delete by date, delete to target free space)
- `web/src/app/accounts/page.tsx` — add created_at column
- `web/src/lib/api.ts` — new API functions (fetchImageStorage, compressAllImages, deleteToTarget)