### PR TITLE
feat(accounts): 新增 OAuth 登录已有账号导入方式

### DIFF
--- a/api/accounts.py
+++ b/api/accounts.py
@@ -23,6 +23,7 @@ from api.support import (
 )
 from services.account_service import account_service
 from services.cpa_service import cpa_config, cpa_import_service, list_remote_files
+from services.oauth_login_service import OAuthLoginError, oauth_login_service
 from services.sub2api_service import (
     list_remote_accounts as sub2api_list_remote_accounts,
     list_remote_groups as sub2api_list_remote_groups,
@@ -103,6 +104,17 @@ class Sub2APIServerUpdateRequest(BaseModel):
 
 class Sub2APIImportRequest(BaseModel):
     account_ids: list[str] = Field(default_factory=list)
+
+
+class OAuthLoginStartRequest(BaseModel):
+    """起始 OAuth 桥。email_hint 可选，仅用于让 OpenAI 登录页预填邮箱。"""
+    email_hint: str = ""
+
+
+class OAuthLoginFinishRequest(BaseModel):
+    """提交 callback。callback 既可以是完整 URL 也可以只填 code。"""
+    session_id: str = ""
+    callback: str = ""
 
 
 def _account_payload_token(item: dict[str, Any]) -> str:
@@ -281,6 +293,55 @@ def create_router() -> APIRouter:
         if account is None:
             raise HTTPException(status_code=404, detail={"error": "account not found"})
         return {"item": account, "items": account_service.list_accounts()}
+
+    @router.post("/api/accounts/oauth/start")
+    async def start_oauth_login(
+            body: OAuthLoginStartRequest,
+            authorization: str | None = Header(default=None),
+    ):
+        """登记一次 PKCE 会话，返回可让用户浏览器打开的 authorize URL。"""
+        require_admin(authorization)
+        try:
+            return await run_in_threadpool(oauth_login_service.start, body.email_hint)
+        except OAuthLoginError as exc:
+            raise HTTPException(status_code=400, detail={"error": str(exc)}) from exc
+
+    @router.post("/api/accounts/oauth/finish")
+    async def finish_oauth_login(
+            body: OAuthLoginFinishRequest,
+            authorization: str | None = Header(default=None),
+    ):
+        """收用户从浏览器抓回的 callback URL / code，换出 token 三件套并落盘。"""
+        require_admin(authorization)
+        # 入参日志：截断敏感字段，仅保留前几位，方便排错而不泄密
+        cb_preview = (body.callback or "")[:80]
+        sid_preview = (body.session_id or "")[:8]
+        print(
+            f"[oauth-login] finish called: session_id={sid_preview}..., callback_preview={cb_preview!r}",
+            flush=True,
+        )
+        try:
+            tokens = await run_in_threadpool(oauth_login_service.finish, body.session_id, body.callback)
+        except OAuthLoginError as exc:
+            print(f"[oauth-login] finish rejected: {exc}", flush=True)
+            raise HTTPException(status_code=400, detail={"error": str(exc)}) from exc
+
+        payload = {
+            "access_token": tokens["access_token"],
+            "refresh_token": tokens["refresh_token"],
+            "id_token": tokens["id_token"],
+            "source_type": "oauth_login",
+        }
+        add_result = await run_in_threadpool(account_service.add_account_items, [payload])
+        refresh_result = await run_in_threadpool(
+            account_service.refresh_accounts, [tokens["access_token"]]
+        )
+        return {
+            **add_result,
+            "refreshed": refresh_result.get("refreshed", 0),
+            "errors": refresh_result.get("errors", []),
+            "items": refresh_result.get("items", add_result.get("items", [])),
+        }
 
     @router.get("/api/cpa/pools")
     async def list_cpa_pools(authorization: str | None = Header(default=None)):

--- a/scripts/verify_oauth_refresh.py
+++ b/scripts/verify_oauth_refresh.py
@@ -1,0 +1,92 @@
+"""验证 OAuth 账号的自动刷新是否生效。
+
+用法（在容器内，工作目录 /app）：
+    uv run python scripts/verify_oauth_refresh.py            # 只读诊断，安全
+    uv run python scripts/verify_oauth_refresh.py --force    # 真正触发一次刷新
+
+只读模式：列出每个账号的 access_token 剩余有效期、是否带 refresh_token、
+          上次刷新时间与上次刷新错误，判断"有没有料可刷"。
+--force ：对每个带 refresh_token 的账号强制走一次 refresh_access_token(force=True)，
+          直接验证 refresh_token + 本项目 client_id 能否从 OpenAI 换出新 access_token。
+          这会真实轮换 access_token（新 token 有效，不损坏账号）。
+"""
+from __future__ import annotations
+
+import sys
+
+from services.account_service import account_service
+
+
+def _fmt_remaining(seconds: int | None) -> str:
+    if seconds is None:
+        return "无法解析 exp"
+    if seconds <= 0:
+        return f"已过期 {(-seconds) // 3600}h"
+    return f"{seconds // 3600}h{(seconds % 3600) // 60}m 后过期"
+
+
+def diagnose() -> list[str]:
+    """只读：打印每个账号的刷新就绪状态，返回带 refresh_token 的 token 列表。"""
+    tokens = account_service.list_tokens()
+    print(f"账号总数: {len(tokens)}\n")
+    refreshable: list[str] = []
+    for token in tokens:
+        account = account_service.get_account(token) or {}
+        remaining = account_service._token_expires_in(token)
+        has_rt = bool(str(account.get("refresh_token") or "").strip())
+        if has_rt:
+            refreshable.append(token)
+        print(f"- email={account.get('email') or '(未知)'}")
+        print(f"    access_token[:20]   = {token[:20]}...")
+        print(f"    距过期              = {_fmt_remaining(remaining)}")
+        print(f"    refresh_token       = {'有 ✅' if has_rt else '无 ❌（无法自动刷新）'}")
+        print(f"    last_token_refresh_at    = {account.get('last_token_refresh_at')}")
+        print(f"    last_token_refresh_error = {account.get('last_token_refresh_error')}")
+        print()
+    return refreshable
+
+
+def force_refresh(tokens: list[str]) -> None:
+    """对每个账号 force 刷新一次，并对比前后状态判断成败。"""
+    if not tokens:
+        print("没有带 refresh_token 的账号，无法验证刷新。")
+        return
+    print("=" * 60)
+    print(f"开始对 {len(tokens)} 个账号 force 刷新（真实调用 OpenAI）...\n")
+    ok = 0
+    for token in tokens:
+        before = account_service.get_account(token) or {}
+        new_token = account_service.refresh_access_token(token, force=True, event="manual_verify")
+        after = account_service.get_account(new_token) or {}
+        err = str(after.get("last_token_refresh_error") or "").strip()
+        rotated = new_token != token
+        success = bool(new_token) and not err
+        if success:
+            ok += 1
+        print(f"- email={before.get('email') or '(未知)'}")
+        print(f"    旧 access_token[:20] = {token[:20]}...")
+        print(f"    新 access_token[:20] = {new_token[:20]}...")
+        print(f"    token 是否轮换       = {'是' if rotated else '否（exp 未到刷新窗口时可能返回原值）'}")
+        print(f"    last_token_refresh_at    = {after.get('last_token_refresh_at')}")
+        print(f"    last_token_refresh_error = {after.get('last_token_refresh_error') or '无'}")
+        print(f"    >>> 刷新结果         = {'成功 ✅' if success else '失败 ❌'}")
+        print()
+    print("=" * 60)
+    print(f"汇总: {ok}/{len(tokens)} 个账号刷新成功")
+    if ok == len(tokens):
+        print("✅ 自动刷新机制对这些账号完全可用——refresh_token 与 client_id 匹配。")
+    else:
+        print("❌ 有账号刷新失败，看上面的 last_token_refresh_error，或 docker logs 里的 [oauth-login]/refresh 日志。")
+
+
+def main() -> None:
+    do_force = "--force" in sys.argv[1:]
+    refreshable = diagnose()
+    if do_force:
+        force_refresh(refreshable)
+    else:
+        print("提示: 加 --force 参数可真正触发一次刷新以验证能否成功。")
+
+
+if __name__ == "__main__":
+    main()

--- a/services/oauth_login_service.py
+++ b/services/oauth_login_service.py
@@ -1,0 +1,272 @@
+"""手动 OAuth 桥服务
+
+让用户用自己浏览器走一遍 OpenAI 的标准 OAuth + PKCE 授权码流程：
+  1. 后端生成 code_verifier / code_challenge / state，构造 authorize URL。
+  2. 用户在浏览器登录，浏览器最终被 OpenAI 重定向到 platform.openai.com 的
+     callback 地址；用户从地址栏或 devtools 抓出 code，回填到前端。
+  3. 后端拿之前存好的 code_verifier + 回填的 code 调用 /api/accounts/oauth/token
+     得到 {access_token, refresh_token, id_token}。
+
+得到的 refresh_token 跟 account_service 自动刷新机制用的 client_id 是同一个
+（app_2SKx67EdpoN0G6j64rFvigXD），所以落盘后能直接进入 keepalive 周期。
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+import threading
+import time
+import uuid
+from typing import Any
+from urllib.parse import parse_qs, urlencode, urlparse
+
+from curl_cffi import requests
+
+from services.proxy_service import proxy_settings
+from services.register.openai_register import (
+    auth_base,
+    common_headers,
+    platform_auth0_client,
+    platform_base,
+    platform_oauth_audience,
+    platform_oauth_client_id,
+    platform_oauth_redirect_uri,
+    sec_ch_ua,
+    user_agent,
+)
+
+
+class OAuthLoginError(Exception):
+    """OAuth 桥流程中的可预期错误，会被 API 层翻译成 400。"""
+
+
+class OAuthLoginService:
+    """维护 PKCE 临时会话，并完成 code → token 的兑换。"""
+
+    _SESSION_TTL_SECONDS = 10 * 60  # 用户点开浏览器 + 拿 code 给的时间上限
+    _MAX_SESSIONS = 64               # 防止异常累积；超过容量时清理最老的
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._sessions: dict[str, dict[str, Any]] = {}
+
+    @staticmethod
+    def _generate_pkce() -> tuple[str, str]:
+        """生成 PKCE code_verifier 与对应的 code_challenge（S256）。"""
+        verifier = base64.urlsafe_b64encode(secrets.token_bytes(64)).rstrip(b"=").decode("ascii")
+        challenge = base64.urlsafe_b64encode(
+            hashlib.sha256(verifier.encode("ascii")).digest()
+        ).rstrip(b"=").decode("ascii")
+        return verifier, challenge
+
+    def _purge_expired_locked(self) -> None:
+        """清理过期或溢出容量的会话，必须在持锁状态下调用。"""
+        now = time.time()
+        expired = [sid for sid, item in self._sessions.items() if now - item["created_at"] > self._SESSION_TTL_SECONDS]
+        for sid in expired:
+            self._sessions.pop(sid, None)
+        if len(self._sessions) > self._MAX_SESSIONS:
+            ordered = sorted(self._sessions.items(), key=lambda kv: kv[1]["created_at"])
+            for sid, _ in ordered[: len(self._sessions) - self._MAX_SESSIONS]:
+                self._sessions.pop(sid, None)
+
+    def start(self, email_hint: str = "") -> dict[str, str]:
+        """登记一个新的 PKCE 会话，返回 session_id 与可让用户打开的 authorize_url。
+
+        state 形如 "<session_id>.<nonce>"，让 callback URL 自带 session_id，
+        finish 时即便前端 React 状态被覆盖也能从 URL 恢复正确的 verifier。
+        """
+        verifier, challenge = self._generate_pkce()
+        nonce = secrets.token_urlsafe(32)
+        device_id = str(uuid.uuid4())
+        session_id = uuid.uuid4().hex
+        state = f"{session_id}.{secrets.token_urlsafe(16)}"
+
+        params = {
+            "issuer": auth_base,
+            "client_id": platform_oauth_client_id,
+            "audience": platform_oauth_audience,
+            "redirect_uri": platform_oauth_redirect_uri,
+            "device_id": device_id,
+            "screen_hint": "login_or_signup",
+            "max_age": "0",
+            "scope": "openid profile email offline_access",
+            "response_type": "code",
+            "response_mode": "query",
+            "state": state,
+            "nonce": nonce,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "auth0Client": platform_auth0_client,
+        }
+        email_hint = str(email_hint or "").strip()
+        if email_hint:
+            params["login_hint"] = email_hint
+
+        authorize_url = f"{auth_base}/api/accounts/authorize?{urlencode(params)}"
+
+        with self._lock:
+            self._purge_expired_locked()
+            self._sessions[session_id] = {
+                "code_verifier": verifier,
+                "state": state,
+                "created_at": time.time(),
+                "redirect_uri": platform_oauth_redirect_uri,
+            }
+
+        return {
+            "session_id": session_id,
+            "authorize_url": authorize_url,
+            "expires_in": str(self._SESSION_TTL_SECONDS),
+            "redirect_uri_prefix": platform_oauth_redirect_uri,
+        }
+
+    @staticmethod
+    def _extract_code_from_callback(value: str) -> tuple[str, str]:
+        """从 callback URL 或 raw code 中提取 (code, state)。
+
+        既允许用户粘贴整段 platform.openai.com/auth/callback?code=...&state=... 的 URL，
+        也允许只粘 code 本身。
+        """
+        raw = str(value or "").strip()
+        if not raw:
+            return "", ""
+        if raw.startswith("http://") or raw.startswith("https://"):
+            try:
+                parsed = parse_qs(urlparse(raw).query)
+            except Exception as exc:
+                raise OAuthLoginError(f"无法解析 callback URL: {exc}") from exc
+            code = str((parsed.get("code") or [""])[0]).strip()
+            state = str((parsed.get("state") or [""])[0]).strip()
+            if not code:
+                err = str((parsed.get("error_description") or parsed.get("error") or [""])[0]).strip()
+                raise OAuthLoginError(err or "callback URL 中没有 code 参数")
+            return code, state
+        # 用户可能直接粘了 code 字符串
+        return raw, ""
+
+    def finish(self, session_id: str, callback: str) -> dict[str, str]:
+        """用 session_id 配对的 code_verifier 把 callback 里的 code 换成 token 三件套。
+
+        - 优先用 callback URL 自带 state 里的 session_id（更可靠），
+          找不到才用前端传来的 session_id；
+        - 失败时不立刻销毁 session（OAuth code 错配换 token 失败通常不会消耗 code），
+          只有成功兑换才 pop，便于用户用同一 verifier 重试。
+        """
+        body_sid = str(session_id or "").strip()
+        code, state = self._extract_code_from_callback(callback)
+        if not code:
+            raise OAuthLoginError("缺少 code 或 callback URL")
+
+        # state 里嵌的 session_id 优先级最高
+        state_sid = state.split(".", 1)[0] if state else ""
+        candidate_sids = [sid for sid in (state_sid, body_sid) if sid]
+        if not candidate_sids:
+            raise OAuthLoginError("既未提供 session_id，callback URL 中也未携带 state")
+
+        with self._lock:
+            self._purge_expired_locked()
+            session = None
+            picked_sid = ""
+            for sid in candidate_sids:
+                cur = self._sessions.get(sid)
+                if cur is not None:
+                    session = cur
+                    picked_sid = sid
+                    break
+        if session is None:
+            raise OAuthLoginError(
+                "OAuth 会话已过期或不存在，请回到导入对话框点\"重新生成\"再走一次"
+            )
+
+        if state and session.get("state") and state != session["state"]:
+            raise OAuthLoginError(
+                "state 不匹配。常见原因：你点过两次\"打开授权页面\"，但浏览器里登录的还是前一次的窗口。请点\"重新生成\"重来。"
+            )
+
+        tokens = self._exchange_code(
+            code,
+            session["code_verifier"],
+            session.get("redirect_uri") or platform_oauth_redirect_uri,
+        )
+        # 仅在成功兑换之后才消耗 session
+        with self._lock:
+            self._sessions.pop(picked_sid, None)
+        return tokens
+
+    @staticmethod
+    def _exchange_code(code: str, code_verifier: str, redirect_uri: str) -> dict[str, str]:
+        """调用 /api/accounts/oauth/token 用 code+verifier 换 token 三件套。"""
+        kwargs = proxy_settings.build_session_kwargs(impersonate="chrome", verify=False)
+        session = requests.Session(**kwargs)
+        try:
+            response = session.post(
+                f"{auth_base}/api/accounts/oauth/token",
+                headers={
+                    **common_headers,
+                    "referer": f"{platform_base}/",
+                    "origin": platform_base,
+                    "auth0-client": platform_auth0_client,
+                    "sec-ch-ua": sec_ch_ua,
+                    "user-agent": user_agent,
+                },
+                json={
+                    "client_id": platform_oauth_client_id,
+                    "code_verifier": code_verifier,
+                    "grant_type": "authorization_code",
+                    "code": code,
+                    "redirect_uri": redirect_uri,
+                },
+                timeout=60,
+            )
+        except Exception as exc:
+            raise OAuthLoginError(f"换 token 网络异常: {exc}") from exc
+        finally:
+            session.close()
+
+        try:
+            data = response.json() if response.text else {}
+        except Exception:
+            data = {}
+
+        if response.status_code != 200 or not isinstance(data, dict) or not data.get("access_token"):
+            detail = ""
+            if isinstance(data, dict):
+                detail = str(data.get("error_description") or data.get("error") or data.get("message") or "")
+            if not detail:
+                try:
+                    detail = str(response.text or "")[:300]
+                except Exception:
+                    detail = ""
+            # 打到 docker logs 方便排错——OAuth 换 token 的失败原因往往只有这里能看到
+            print(
+                f"[oauth-login] /api/accounts/oauth/token rejected: "
+                f"status={response.status_code} detail={detail!r} "
+                f"raw_body={(getattr(response, 'text', '') or '')[:500]!r}",
+                flush=True,
+            )
+            raise OAuthLoginError(
+                f"OpenAI 拒绝换 token (HTTP {response.status_code}){': ' + detail if detail else ''}"
+            )
+
+        access_token = str(data.get("access_token") or "").strip()
+        refresh_token = str(data.get("refresh_token") or "").strip()
+        id_token = str(data.get("id_token") or "").strip()
+
+        if not access_token:
+            raise OAuthLoginError("OpenAI 返回的 access_token 为空")
+        if not refresh_token:
+            # scope 含 offline_access 时正常会下发 refresh_token；这里给出明确提示
+            raise OAuthLoginError(
+                "OpenAI 没有返回 refresh_token（可能 scope 未包含 offline_access 或 code 已使用过）"
+            )
+
+        return {
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+            "id_token": id_token,
+        }
+
+
+oauth_login_service = OAuthLoginService()

--- a/web/src/app/accounts/components/account-import-dialog.tsx
+++ b/web/src/app/accounts/components/account-import-dialog.tsx
@@ -4,12 +4,14 @@ import { useRouter } from "next/navigation";
 import { useRef, useState, type ChangeEvent } from "react";
 import {
   ArrowLeft,
+  Copy,
   ExternalLink,
   FileJson,
   FileText,
   Files,
   KeyRound,
   LoaderCircle,
+  LogIn,
   ServerCog,
   Upload,
 } from "lucide-react";
@@ -26,10 +28,17 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Textarea } from "@/components/ui/textarea";
-import { createAccounts, type Account, type AccountImportPayload } from "@/lib/api";
+import {
+  createAccounts,
+  finishOAuthLogin,
+  startOAuthLogin,
+  type Account,
+  type AccountImportPayload,
+  type OAuthLoginStartResponse,
+} from "@/lib/api";
 import { cn } from "@/lib/utils";
 
-type ImportMethod = "menu" | "token" | "session" | "cpa";
+type ImportMethod = "menu" | "token" | "session" | "cpa" | "oauth";
 
 type AccountImportDialogProps = {
   disabled?: boolean;
@@ -130,6 +139,10 @@ export function AccountImportDialog({ disabled, onImported }: AccountImportDialo
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [pendingCpaImport, setPendingCpaImport] = useState<PendingCpaImport | null>(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [oauthEmailHint, setOauthEmailHint] = useState("");
+  const [oauthSession, setOauthSession] = useState<OAuthLoginStartResponse | null>(null);
+  const [oauthCallbackInput, setOauthCallbackInput] = useState("");
+  const [oauthStarting, setOauthStarting] = useState(false);
 
   const txtInputRef = useRef<HTMLInputElement | null>(null);
   const cpaInputRef = useRef<HTMLInputElement | null>(null);
@@ -140,6 +153,10 @@ export function AccountImportDialog({ disabled, onImported }: AccountImportDialo
     setSessionInput("");
     setPendingCpaImport(null);
     setConfirmOpen(false);
+    setOauthEmailHint("");
+    setOauthSession(null);
+    setOauthCallbackInput("");
+    setOauthStarting(false);
   };
 
   const handleOpenChange = (nextOpen: boolean) => {
@@ -184,6 +201,79 @@ export function AccountImportDialog({ disabled, onImported }: AccountImportDialo
 
   const handleImportTokenText = async () => {
     await submitTokens(splitTokens(tokenInput), "Access Token 导入完成");
+  };
+
+  // 起授权：拿 authorize URL，立刻在新窗口打开，方便用户登录
+  const handleStartOAuth = async () => {
+    setOauthStarting(true);
+    try {
+      const data = await startOAuthLogin(oauthEmailHint.trim());
+      setOauthSession(data);
+      setOauthCallbackInput("");
+      if (typeof window !== "undefined") {
+        window.open(data.authorize_url, "_blank", "noopener,noreferrer");
+      }
+      toast.success("已打开 OpenAI 授权页面，请在登录后复制 callback URL 回来");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "OAuth 起始失败";
+      toast.error(message);
+    } finally {
+      setOauthStarting(false);
+    }
+  };
+
+  // 用粘贴回来的 callback URL 完成换 token + 落盘
+  const handleFinishOAuth = async () => {
+    if (!oauthSession) {
+      toast.error("请先点击\"打开授权页面\"获取 session");
+      return;
+    }
+    const trimmed = oauthCallbackInput.trim();
+    if (!trimmed) {
+      toast.error("请粘贴 callback URL 或 code");
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const data = await finishOAuthLogin(oauthSession.session_id, trimmed);
+      onImported(data.items);
+      setOpen(false);
+      resetState();
+
+      if ((data.errors?.length ?? 0) > 0) {
+        const firstError = data.errors?.[0]?.error;
+        toast.error(
+          `OAuth 登录完成，新增 ${data.added ?? 0} 个，已刷新 ${data.refreshed ?? 0} 个，失败 ${data.errors?.length ?? 0} 个${firstError ? `，首个错误：${firstError}` : ""}`,
+        );
+      } else {
+        toast.success(
+          `OAuth 登录完成，新增 ${data.added ?? 0} 个，跳过 ${data.skipped ?? 0} 个重复项，已自动刷新账号信息`,
+        );
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "OAuth 换 token 失败";
+      toast.error(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // 复制 authorize URL 到剪贴板（适配浏览器和 fallback）
+  const handleCopyAuthorizeUrl = async () => {
+    if (!oauthSession) {
+      return;
+    }
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(oauthSession.authorize_url);
+        toast.success("授权 URL 已复制到剪贴板");
+      } else {
+        toast.error("当前环境不支持自动复制，请手动选择并复制");
+      }
+    } catch {
+      toast.error("复制失败，请手动选择并复制");
+    }
   };
 
   const handleTxtSelected = async (event: ChangeEvent<HTMLInputElement>) => {
@@ -378,6 +468,105 @@ export function AccountImportDialog({ disabled, onImported }: AccountImportDialo
       );
     }
 
+    if (method === "oauth") {
+      return (
+        <div className="space-y-4">
+          <button
+            type="button"
+            onClick={() => setMethod("menu")}
+            className="inline-flex items-center gap-1 text-sm text-stone-500 transition hover:text-stone-800"
+          >
+            <ArrowLeft className="size-4" />
+            返回导入方式
+          </button>
+          <div className="rounded-2xl border border-stone-200 bg-stone-50 p-4 text-sm leading-6 text-stone-600 space-y-2">
+            <div className="font-medium text-stone-800">操作步骤</div>
+            <ol className="list-decimal pl-5 space-y-1">
+              <li>（可选）填写你 ChatGPT 账号的邮箱，登录页会预填。</li>
+              <li>点击下方"打开授权页面"，在新标签里登录自己的 ChatGPT 账号。</li>
+              <li>登录完成后浏览器会跳到 <code className="rounded bg-stone-200 px-1">platform.openai.com/auth/callback?code=...</code>。立刻从地址栏复制整段 URL（或开 F12 在 Network 里抓到 callback 那一行，右键 Copy → Copy URL）。</li>
+              <li>把 callback URL 粘到下面输入框，点"完成导入"。</li>
+            </ol>
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-stone-700">邮箱（可选预填）</label>
+            <input
+              type="email"
+              placeholder="you@example.com"
+              value={oauthEmailHint}
+              onChange={(event) => setOauthEmailHint(event.target.value)}
+              disabled={Boolean(oauthSession) || oauthStarting}
+              className="w-full rounded-xl border border-stone-200 bg-white px-3 py-2 text-sm outline-none focus:border-stone-400"
+            />
+          </div>
+          {!oauthSession ? (
+            <Button
+              type="button"
+              className="h-10 rounded-xl bg-stone-950 text-white hover:bg-stone-800"
+              onClick={() => void handleStartOAuth()}
+              disabled={oauthStarting}
+            >
+              {oauthStarting ? <LoaderCircle className="size-4 animate-spin" /> : <ExternalLink className="size-4" />}
+              打开授权页面
+            </Button>
+          ) : (
+            <div className="space-y-3">
+              <div className="rounded-2xl border border-stone-200 bg-white p-3 text-xs leading-6 text-stone-600 break-all font-mono">
+                {oauthSession.authorize_url}
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="rounded-xl border-stone-200 bg-white"
+                  onClick={() => void handleCopyAuthorizeUrl()}
+                >
+                  <Copy className="size-4" />
+                  复制授权 URL
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="rounded-xl border-stone-200 bg-white"
+                  onClick={() => window.open(oauthSession.authorize_url, "_blank", "noopener,noreferrer")}
+                >
+                  <ExternalLink className="size-4" />
+                  再次打开
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="rounded-xl border-stone-200 bg-white"
+                  onClick={() => {
+                    setOauthSession(null);
+                    setOauthCallbackInput("");
+                  }}
+                >
+                  重新生成
+                </Button>
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-stone-700">粘贴 callback URL（或仅 code）</label>
+                <Textarea
+                  placeholder={"https://platform.openai.com/auth/callback?code=...&state=..."}
+                  value={oauthCallbackInput}
+                  onChange={(event) => setOauthCallbackInput(event.target.value)}
+                  className="min-h-24 resize-none rounded-xl border-stone-200 font-mono text-xs"
+                />
+              </div>
+            </div>
+          )}
+          <div className="rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm leading-6 text-amber-900">
+            <div className="font-medium">注意</div>
+            <div>
+              授权码（code）只能使用一次。如果浏览器的 callback 页加载完成、显示了 OpenAI 的错误页，那 code 大概率已经被消耗，
+              请点击"重新生成"再走一次。整个流程在 10 分钟内完成即可。
+            </div>
+          </div>
+        </div>
+      );
+    }
+
     if (method === "cpa") {
       return (
         <div className="space-y-4">
@@ -426,6 +615,12 @@ export function AccountImportDialog({ disabled, onImported }: AccountImportDialo
 
     return (
       <div className="space-y-3">
+        <MethodCard
+          title="OAuth 登录已有账号（带自动刷新）"
+          description="用浏览器登录自己的 ChatGPT 账号，回填 callback URL 即可拿到 refresh_token，后台会自动续期。"
+          icon={LogIn}
+          onClick={() => setMethod("oauth")}
+        />
         <MethodCard
           title="导入 Access Token"
           description="支持直接粘贴，一行一个；也支持从 TXT 文件读取，一行一个。"
@@ -490,7 +685,9 @@ export function AccountImportDialog({ disabled, onImported }: AccountImportDialo
                   ? "导入 Access Token"
                   : method === "session"
                     ? "导入 Session JSON"
-                    : "导入 CPA JSON"}
+                    : method === "oauth"
+                      ? "OAuth 登录已有账号"
+                      : "导入 CPA JSON"}
             </DialogTitle>
             <DialogDescription className="text-sm leading-6">
               {method === "menu"
@@ -499,7 +696,9 @@ export function AccountImportDialog({ disabled, onImported }: AccountImportDialo
                   ? "支持手动粘贴或从 TXT 文件导入，一行一个 Token。"
                   : method === "session"
                     ? "粘贴完整 Session JSON，系统会自动提取 accessToken。"
-                    : "支持一次读取多个本地 JSON 文件，并在提交前做数量确认。"}
+                    : method === "oauth"
+                      ? "用浏览器跑一遍 OpenAI 标准 OAuth，拿回 refresh_token 后系统会自动续期。"
+                      : "支持一次读取多个本地 JSON 文件，并在提交前做数量确认。"}
             </DialogDescription>
           </DialogHeader>
 
@@ -532,6 +731,19 @@ export function AccountImportDialog({ disabled, onImported }: AccountImportDialo
               >
                 {isSubmitting ? <LoaderCircle className="size-4 animate-spin" /> : null}
                 导入 JSON
+              </Button>
+            ) : null}
+            {method === "oauth" ? (
+              <Button
+                className={cn(
+                  "h-10 rounded-xl bg-stone-950 px-5 text-white hover:bg-stone-800",
+                  !oauthSession ? "hidden" : "",
+                )}
+                onClick={() => void handleFinishOAuth()}
+                disabled={footerDisabled || !oauthSession || !oauthCallbackInput.trim()}
+              >
+                {isSubmitting ? <LoaderCircle className="size-4 animate-spin" /> : null}
+                完成导入
               </Button>
             ) : null}
             {method === "cpa" ? (

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -274,6 +274,27 @@ export async function createAccounts(tokens: string[]) {
   });
 }
 
+export type OAuthLoginStartResponse = {
+  session_id: string;
+  authorize_url: string;
+  expires_in: string;
+  redirect_uri_prefix: string;
+};
+
+export async function startOAuthLogin(emailHint?: string) {
+  return httpRequest<OAuthLoginStartResponse>("/api/accounts/oauth/start", {
+    method: "POST",
+    body: { email_hint: emailHint ?? "" },
+  });
+}
+
+export async function finishOAuthLogin(sessionId: string, callback: string) {
+  return httpRequest<AccountMutationResponse>("/api/accounts/oauth/finish", {
+    method: "POST",
+    body: { session_id: sessionId, callback },
+  });
+}
+
 export async function deleteAccounts(tokens: string[]) {
   return httpRequest<AccountMutationResponse>("/api/accounts", {
     method: "DELETE",


### PR DESCRIPTION
通过浏览器走 OpenAI 标准 OAuth + PKCE 流程获取 refresh_token，落盘后由 account_service 的自动刷新机制接管，解决 Sub2API/CPA 等导入路径只保留
access_token 导致账号过期失效的问题。state 中嵌入 session_id，让前端状态 覆盖时也能从 callback URL 恢复正确的 verifier。
#200 