### PR TITLE
fix: 修复图片管理暗黑模式高亮与复选框显示

### DIFF
--- a/web/src/app/image-manager/page.tsx
+++ b/web/src/app/image-manager/page.tsx
@@ -17,6 +17,7 @@ import { compressAllImages, deleteImageTag, deleteManagedImages, deleteToTarget,
 import { useAuthGuard } from "@/lib/use-auth-guard";
 
 const LONG_PRESS_MS = 800;
+const IMAGE_MANAGER_CHECKBOX_CLASS = "border-stone-300 bg-white/80 dark:border-white/35 dark:bg-white/5 data-[state=checked]:border-stone-950 dark:data-[state=checked]:border-white";
 
 function formatSize(size: number) {
   return size > 1024 * 1024 ? `${(size / 1024 / 1024).toFixed(2)} MB` : `${Math.ceil(size / 1024)} KB`;
@@ -444,11 +445,11 @@ function ImageManagerContent() {
               共 {filteredItems.length} 张
               {selectedTags.length > 0 ? <span className="text-stone-400">（筛选自 {items.length} 张）</span> : null}
               <label className="flex items-center gap-2">
-                <Checkbox checked={currentPageSelected} onCheckedChange={(checked) => togglePaths(currentRows.map(imageKey), Boolean(checked))} />
+                <Checkbox className={IMAGE_MANAGER_CHECKBOX_CLASS} checked={currentPageSelected} onCheckedChange={(checked) => togglePaths(currentRows.map(imageKey), Boolean(checked))} />
                 本页全选
               </label>
               <label className="flex items-center gap-2">
-                <Checkbox checked={allSelected} onCheckedChange={(checked) => togglePaths(filteredItems.map(imageKey), Boolean(checked))} />
+                <Checkbox className={IMAGE_MANAGER_CHECKBOX_CLASS} checked={allSelected} onCheckedChange={(checked) => togglePaths(filteredItems.map(imageKey), Boolean(checked))} />
                 全选结果
               </label>
               {selectedPaths.length > 0 ? <span>已选 {selectedPaths.length} 张</span> : null}
@@ -475,7 +476,7 @@ function ImageManagerContent() {
             {currentRows.map((item) => {
               const imageIndex = filteredItems.findIndex((row) => row.url === item.url);
               return (
-              <div key={item.rel} className="group border-r border-b border-stone-100 p-4 transition hover:bg-stone-50">
+              <div key={item.rel} className="group border-r border-b border-stone-100 p-4 transition hover:bg-stone-50 dark:hover:bg-white/5">
                 <div className="relative">
                   <button
                     type="button"
@@ -538,7 +539,7 @@ function ImageManagerContent() {
                       >
                         <Copy className="size-4" />
                       </Button>
-                      <Checkbox checked={selectedSet.has(imageKey(item))} onCheckedChange={(checked) => togglePaths([imageKey(item)], Boolean(checked))} />
+                      <Checkbox className={IMAGE_MANAGER_CHECKBOX_CLASS} checked={selectedSet.has(imageKey(item))} onCheckedChange={(checked) => togglePaths([imageKey(item)], Boolean(checked))} />
                     </div>
                   </div>
                   <div className="flex items-center justify-between gap-2">


### PR DESCRIPTION
﻿## 修复内容
- 修复图片管理页在暗黑模式下卡片悬停时出现白色高亮的问题
- 修复图片管理页暗黑模式下复选框边框和底色对比度不足、难以看见的问题

## 实现方式
- 为图片管理页卡片补充暗黑模式悬停背景样式，避免沿用亮色 hover 效果
- 为图片管理页使用到的复选框补充页面级暗黑样式，保证未选中和选中状态都清晰可见

## 验证
- 已本地重建 Docker 镜像并重新部署容器
- 容器启动正常，首页访问返回 200
- 可在暗黑模式下进入图片管理页验证悬停和复选框显示
