### PR TITLE
Support remote image inputs in chat and Responses APIs

### DIFF
--- a/services/protocol/openai_v1_response.py
+++ b/services/protocol/openai_v1_response.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import base64
 import time
 import uuid
 from typing import Any, Iterable, Iterator
@@ -11,9 +10,11 @@ from services.protocol.chat_completion_cache import cache_key, chat_completion_c
 from services.protocol.conversation import (
     ConversationRequest,
     ImageOutput,
+    count_message_image_tokens,
     count_message_text_tokens,
     count_text_tokens,
     encode_images,
+    normalize_messages,
     stream_image_outputs_with_pool,
     stream_text_deltas,
     text_backend,
@@ -31,6 +32,8 @@ TOOL_UNAVAILABLE_SYSTEM_MESSAGE = (
     "or file operations. Do not claim to have run tools or inspected external resources. "
     "If a user asks you to use a tool, say that tool execution is unavailable through this backend."
 )
+
+RESPONSE_CONTENT_PART_TYPES = {"text", "input_text", "output_text", "image_url", "input_image"}
 
 
 def is_text_response_request(body: dict[str, Any]) -> bool:
@@ -56,18 +59,19 @@ def response_image_tool(body: dict[str, Any]) -> dict[str, object]:
 
 def extract_response_image(input_value: object) -> tuple[bytes, str] | None:
     if isinstance(input_value, dict):
+        if str(input_value.get("type") or "").strip() == "input_image":
+            images = extract_image_from_message_content([input_value])
+            return images[0] if images else None
         images = extract_image_from_message_content(input_value.get("content"))
         return images[0] if images else None
     if not isinstance(input_value, list):
         return None
     for item in reversed(input_value):
-        if isinstance(item, dict) and str(item.get("type") or "").strip() == "input_image":
-            image_url = str(item.get("image_url") or "")
-            if image_url.startswith("data:"):
-                header, _, data = image_url.partition(",")
-                mime = header.split(";")[0].removeprefix("data:")
-                return base64.b64decode(data), mime or "image/png"
         if isinstance(item, dict):
+            if str(item.get("type") or "").strip() == "input_image":
+                images = extract_image_from_message_content([item])
+                if images:
+                    return images[0]
             images = extract_image_from_message_content(item.get("content"))
             if images:
                 return images[0]
@@ -93,6 +97,31 @@ def _input_image_parts(input_value: object) -> list[dict[str, Any]]:
     return parts
 
 
+def _is_response_content_part(value: object) -> bool:
+    if not isinstance(value, dict):
+        return False
+    part_type = str(value.get("type") or "").strip()
+    return part_type in RESPONSE_CONTENT_PART_TYPES or ("image_url" in value and part_type != "message")
+
+
+def _message_content_from_response_item(item: dict[str, Any]) -> object:
+    content = item.get("content")
+    if isinstance(content, list):
+        return [dict(part) if isinstance(part, dict) else part for part in content]
+    if isinstance(content, str):
+        return content
+    return extract_response_prompt([item]) or content or ""
+
+
+def _append_response_message(messages: list[dict[str, Any]], role: object, content: object) -> None:
+    if isinstance(content, str):
+        if content.strip():
+            messages.append({"role": str(role or "user"), "content": content.strip()})
+        return
+    if isinstance(content, list) and content:
+        messages.append({"role": str(role or "user"), "content": content})
+
+
 def messages_from_input(input_value: object, instructions: object = None) -> list[dict[str, Any]]:
     messages: list[dict[str, Any]] = []
     system_text = str(instructions or "").strip()
@@ -103,23 +132,36 @@ def messages_from_input(input_value: object, instructions: object = None) -> lis
             messages.append({"role": "user", "content": input_value.strip()})
         return messages
     if isinstance(input_value, dict):
-        messages.append({
-            "role": str(input_value.get("role") or "user"),
-            "content": extract_response_prompt([input_value]) or input_value.get("content") or "",
-        })
+        if _is_response_content_part(input_value):
+            _append_response_message(messages, "user", [dict(input_value)])
+            return messages
+        _append_response_message(
+            messages,
+            input_value.get("role") or "user",
+            _message_content_from_response_item(input_value),
+        )
         return messages
     if isinstance(input_value, list):
-        if all(isinstance(item, dict) and item.get("type") for item in input_value):
-            text = extract_response_prompt(input_value)
-            if text:
-                messages.append({"role": "user", "content": text})
+        if all(_is_response_content_part(item) for item in input_value):
+            _append_response_message(messages, "user", [dict(item) for item in input_value if isinstance(item, dict)])
             return messages
+        pending_parts: list[dict[str, Any]] = []
         for item in input_value:
-            if isinstance(item, dict):
-                messages.append({
-                    "role": str(item.get("role") or "user"),
-                    "content": extract_response_prompt([item]) or item.get("content") or "",
-                })
+            if _is_response_content_part(item):
+                pending_parts.append(dict(item))
+                continue
+            if pending_parts:
+                _append_response_message(messages, "user", pending_parts)
+                pending_parts = []
+            if not isinstance(item, dict):
+                continue
+            _append_response_message(
+                messages,
+                item.get("role") or "user",
+                _message_content_from_response_item(item),
+            )
+        if pending_parts:
+            _append_response_message(messages, "user", pending_parts)
     return messages
 
 
@@ -193,7 +235,7 @@ def response_completed(
 
 def text_response_parts(body: dict[str, Any]) -> tuple[str, list[dict[str, Any]]]:
     model = str(body.get("model") or "auto").strip() or "auto"
-    messages = normalize_text_messages(messages_from_input(body.get("input"), body.get("instructions")))
+    messages = normalize_text_messages(normalize_messages(messages_from_input(body.get("input"), body.get("instructions"))))
     if has_non_image_tools(body):
         messages.insert(0, {"role": "system", "content": TOOL_UNAVAILABLE_SYSTEM_MESSAGE})
     return model, messages
@@ -217,6 +259,7 @@ def stream_text_response(backend, body: dict[str, Any], messages: list[dict[str,
     yield {"type": "response.output_item.done", "output_index": 0, "item": item}
     usage = token_usage(
         input_text_tokens=count_message_text_tokens(messages, model),
+        input_image_tokens=count_message_image_tokens(messages, model),
         output_text_tokens=count_text_tokens(full_text, model),
     )
     yield response_completed(response_id, model, created, [item], usage)

--- a/test/test_chat_completion_cache.py
+++ b/test/test_chat_completion_cache.py
@@ -3,11 +3,18 @@ from __future__ import annotations
 import unittest
 from unittest import mock
 import json
+import base64
 
 from services.config import config
 from services.protocol import openai_v1_chat_complete, openai_v1_response
 from services.protocol.chat_completion_cache import chat_completion_cache
 from services.protocol.conversation import iter_conversation_payloads, sanitize_output_text
+
+
+PNG_1X1 = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADUlEQVR4nGP8z8BQDwAFgwJ/luzl4wAAAABJRU5ErkJggg=="
+)
+PNG_1X1_DATA_URL = "data:image/png;base64," + base64.b64encode(PNG_1X1).decode("ascii")
 
 
 class ChatCompletionCacheTests(unittest.TestCase):
@@ -212,6 +219,87 @@ class ChatCompletionCacheTests(unittest.TestCase):
         self.assertEqual(model, "auto")
         self.assertEqual(messages[0]["role"], "system")
         self.assertIn("cannot execute local tools", str(messages[0]["content"]))
+
+    def test_chat_completions_accepts_remote_image_url(self) -> None:
+        class FakeImageResponse:
+            status_code = 200
+            headers = {"content-type": "image/png", "content-length": str(len(PNG_1X1))}
+            content = PNG_1X1
+
+        with mock.patch("utils.helper.requests.get", return_value=FakeImageResponse()) as request_get:
+            model, messages = openai_v1_chat_complete.text_chat_parts({
+                "model": "auto",
+                "messages": [{
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Describe this"},
+                        {"type": "image_url", "image_url": {"url": "https://example.test/image.png"}},
+                    ],
+                }],
+            })
+
+        request_get.assert_called_once()
+        self.assertEqual(model, "auto")
+        content = messages[0]["content"]
+        self.assertEqual(content[0], {"type": "text", "text": "Describe this"})
+        self.assertEqual(content[1]["type"], "image")
+        self.assertEqual(content[1]["data"], PNG_1X1)
+        self.assertEqual(content[1]["mime"], "image/png")
+
+    def test_responses_text_request_preserves_input_image(self) -> None:
+        captured = {}
+
+        def fake_stream_text_deltas(_backend, request):
+            captured["messages"] = request.messages
+            yield "red"
+
+        body = {
+            "model": "auto",
+            "input": [
+                {"type": "input_text", "text": "What color is this image?"},
+                {"type": "input_image", "image_url": PNG_1X1_DATA_URL},
+            ],
+        }
+
+        with (
+            mock.patch("services.protocol.openai_v1_response.text_backend", return_value=object()),
+            mock.patch("services.protocol.openai_v1_response.stream_text_deltas", side_effect=fake_stream_text_deltas),
+        ):
+            response = openai_v1_response.handle(body)
+
+        self.assertEqual(response["output"][0]["content"][0]["text"], "red")
+        content = captured["messages"][0]["content"]
+        self.assertEqual(content[0], {"type": "text", "text": "What color is this image?"})
+        self.assertEqual(content[1]["type"], "image")
+        self.assertEqual(content[1]["mime"], "image/png")
+        self.assertEqual(content[1]["data"], PNG_1X1)
+        self.assertGreater(response["usage"]["input_tokens_details"]["image_tokens"], 0)
+
+    def test_responses_text_request_accepts_remote_input_image_url(self) -> None:
+        class FakeImageResponse:
+            status_code = 200
+            headers = {"content-type": "image/png", "content-length": str(len(PNG_1X1))}
+            content = PNG_1X1
+
+        with mock.patch("utils.helper.requests.get", return_value=FakeImageResponse()) as request_get:
+            _model, messages = openai_v1_response.text_response_parts({
+                "model": "auto",
+                "input": [{
+                    "type": "message",
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "Describe this"},
+                        {"type": "input_image", "image_url": {"url": "https://example.test/image.png"}},
+                    ],
+                }],
+            })
+
+        request_get.assert_called_once()
+        content = messages[0]["content"]
+        self.assertEqual(content[0], {"type": "text", "text": "Describe this"})
+        self.assertEqual(content[1]["type"], "image")
+        self.assertEqual(content[1]["data"], PNG_1X1)
+        self.assertEqual(content[1]["mime"], "image/png")
 
 
 if __name__ == "__main__":

--- a/utils/helper.py
+++ b/utils/helper.py
@@ -1,14 +1,17 @@
 import base64
 import hashlib
 import json
+import mimetypes
 import re
 import time
 import uuid
 from pathlib import Path
 from typing import Any, Iterator
+from urllib.parse import urlparse
 
 from curl_cffi import requests
 from fastapi import HTTPException
+from services.proxy_service import proxy_settings
 from utils.log import logger
 
 BASE_IMAGE_MODELS = {"gpt-image-2", "codex-gpt-image-2"}
@@ -26,6 +29,7 @@ SUPPORTED_JSON_IMAGE_MIME_TYPES = {"image/png", "image/jpeg", "image/jpg", "imag
 MAX_JSON_IMAGE_BYTES = 10 * 1024 * 1024
 MAX_JSON_EDIT_IMAGES = 10
 DATA_URL_IMAGE_RE = re.compile(r"^data:(?P<mime>[-+./\w]+);base64,(?P<data>.*)$", re.DOTALL)
+REMOTE_IMAGE_TIMEOUT_SECONDS = 20
 
 
 def _image_extension(mime_type: str) -> str:
@@ -316,6 +320,49 @@ def extract_prompt_from_message_content(content: object) -> str:
     return "\n".join(parts).strip()
 
 
+def _decode_message_image_url(url: str) -> tuple[bytes, str] | None:
+    source = str(url or "").strip()
+    if source.startswith("data:"):
+        header, _, data = source.partition(",")
+        mime = header.split(";")[0].removeprefix("data:") or "image/png"
+        return base64.b64decode(data), mime
+    if not source.startswith(("http://", "https://")):
+        return None
+    parsed = urlparse(source)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return None
+
+    try:
+        response = requests.get(
+            source,
+            headers={"Accept": "image/*,*/*;q=0.8", "User-Agent": "chatgpt2api vision fetcher"},
+            timeout=REMOTE_IMAGE_TIMEOUT_SECONDS,
+            allow_redirects=True,
+            **proxy_settings.build_session_kwargs(),
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail={"error": f"image_url fetch failed: {exc}"}) from exc
+    if not 200 <= response.status_code < 300:
+        raise HTTPException(status_code=400, detail={"error": f"image_url fetch failed: HTTP {response.status_code}"})
+    content_length = str(response.headers.get("content-length") or "").strip()
+    if content_length.isdigit() and int(content_length) > MAX_JSON_IMAGE_BYTES:
+        raise HTTPException(status_code=400, detail={"error": "image_url exceeds 10MB limit"})
+    image_data = response.content
+    if not image_data:
+        raise HTTPException(status_code=400, detail={"error": "image_url returned empty content"})
+    if len(image_data) > MAX_JSON_IMAGE_BYTES:
+        raise HTTPException(status_code=400, detail={"error": "image_url exceeds 10MB limit"})
+    mime = str(response.headers.get("content-type") or "image/png").split(";", 1)[0].lower()
+    guessed_mime = mimetypes.guess_type(parsed.path)[0] or ""
+    if mime and not mime.startswith("image/") and mime not in {"application/octet-stream", "binary/octet-stream"}:
+        raise HTTPException(status_code=400, detail={"error": "image_url must point to an image"})
+    if not mime.startswith("image/") and guessed_mime.startswith("image/"):
+        mime = guessed_mime
+    if not mime.startswith("image/"):
+        mime = "image/png"
+    return image_data, mime
+
+
 def extract_image_from_message_content(content: object) -> list[tuple[bytes, str]]:
     if not isinstance(content, list):
         return []
@@ -327,16 +374,15 @@ def extract_image_from_message_content(content: object) -> list[tuple[bytes, str
         if item_type == "image_url":
             url_obj = item.get("image_url") or item
             url = str(url_obj.get("url") or "") if isinstance(url_obj, dict) else str(url_obj)
-            if url.startswith("data:"):
-                header, _, data = url.partition(",")
-                mime = header.split(";")[0].removeprefix("data:")
-                images.append((base64.b64decode(data), mime or "image/png"))
+            image = _decode_message_image_url(url)
+            if image:
+                images.append(image)
         elif item_type == "input_image":
-            image_url = str(item.get("image_url") or "")
-            if image_url.startswith("data:"):
-                header, _, data = image_url.partition(",")
-                mime = header.split(";")[0].removeprefix("data:")
-                images.append((base64.b64decode(data), mime or "image/png"))
+            url_obj = item.get("image_url") or item.get("url") or ""
+            image_url = str(url_obj.get("url") or url_obj.get("image_url") or "") if isinstance(url_obj, dict) else str(url_obj)
+            image = _decode_message_image_url(image_url)
+            if image:
+                images.append(image)
     return images
 
 


### PR DESCRIPTION
## Summary
- preserve Chat Completions remote `image_url` inputs by downloading `http(s)` image references before forwarding to the web conversation backend
- preserve Responses API `input_text` / `input_image` parts by converting them into multimodal conversation messages
- support remote `http(s)` `input_image.image_url` values in Responses text and image-generation flows
- include image input tokens in Responses text usage accounting

## Testing
- `python -m py_compile utils/helper.py services/protocol/openai_v1_response.py test/test_chat_completion_cache.py`
- `PYTHONPATH=/app /app/.venv/bin/python /tmp/test_chat_completion_cache.py` inside the project Docker environment (`Ran 12 tests ... OK`)
