### PR TITLE
fix: narrow except Exception to specific exception types

### DIFF
--- a/services/account_service.py
+++ b/services/account_service.py
@@ -54,14 +54,14 @@ class AccountService:
             f = self._get_cumulative_file()
             if f.exists():
                 return int(f.read_text().strip())
-        except Exception:
+        except (OSError, ValueError):
             pass
         return len(self._accounts)
 
     def _save_cumulative_total(self) -> None:
         try:
             self._get_cumulative_file().write_text(str(self._cumulative_total))
-        except Exception:
+        except OSError:
             pass
 
     @staticmethod

--- a/services/auth_service.py
+++ b/services/auth_service.py
@@ -244,7 +244,7 @@ class AuthService:
                     try:
                         self._save()
                         self._last_used_flush_at[item_id] = now
-                    except Exception:
+                    except OSError:
                         pass
                 return self._public_item(next_item)
         return None

--- a/services/cpa_service.py
+++ b/services/cpa_service.py
@@ -82,7 +82,7 @@ class CPAConfig:
                 return [pool] if pool["base_url"] else []
             if isinstance(raw, list):
                 return [_normalize_pool(item) for item in raw if isinstance(item, dict)]
-        except Exception:
+        except (json.JSONDecodeError, OSError):
             pass
         return []
 

--- a/services/image_service.py
+++ b/services/image_service.py
@@ -250,7 +250,7 @@ def compress_images(quality: int = 60) -> dict:
                 count += 1
             else:
                 Path(str(p) + ".tmp").unlink()
-        except Exception:
+        except (OSError, ValueError):
             pass
     return {"compressed": count, "saved_bytes": saved, "saved_mb": saved // (1024 * 1024)}
 
@@ -346,7 +346,7 @@ def _auto_cleanup_worker(stop_event: threading.Event) -> None:
                 logger.info({"event": "image_auto_cleanup", "free_mb": free_mb, "min_free_mb": min_free_mb})
                 result = delete_to_target(min_free_mb)
                 logger.info({"event": "image_auto_cleanup_done", **result})
-        except Exception:
+        except (OSError, ValueError):
             pass
 
 

--- a/services/register/mail_provider.py
+++ b/services/register/mail_provider.py
@@ -27,7 +27,7 @@ def _load_ddg_aliases() -> set[str]:
             data = json.loads(DDG_ALIASES_FILE.read_text(encoding="utf-8"))
             if isinstance(data, list):
                 return {str(item).strip().lower() for item in data if str(item).strip()}
-    except Exception:
+    except (json.JSONDecodeError, OSError):
         pass
     return set()
 
@@ -123,7 +123,7 @@ def _parse_received_at(value: Any) -> datetime | None:
     try:
         date = datetime.fromisoformat(text[:-1] + "+00:00" if text.endswith("Z") else text)
         return date if date.tzinfo else date.replace(tzinfo=timezone.utc)
-    except Exception:
+    except (ValueError, OverflowError):
         pass
     try:
         date = parsedate_to_datetime(text)

--- a/services/register/openai_register.py
+++ b/services/register/openai_register.py
@@ -35,7 +35,7 @@ register_config_file = base_dir.parents[1] / "data" / "register.json"
 try:
     saved_config = json.loads(register_config_file.read_text(encoding="utf-8"))
     config.update({key: saved_config[key] for key in ("mail", "proxy", "total", "threads") if key in saved_config})
-except Exception:
+except (json.JSONDecodeError, OSError):
     pass
 
 auth_base = "https://auth.openai.com"

--- a/services/sub2api_service.py
+++ b/services/sub2api_service.py
@@ -83,7 +83,7 @@ class Sub2APIConfig:
             raw = json.loads(self._store_file.read_text(encoding="utf-8"))
             if isinstance(raw, list):
                 return [_normalize_server(item) for item in raw if isinstance(item, dict)]
-        except Exception:
+        except (json.JSONDecodeError, OSError):
             pass
         return []
 

--- a/utils/helper.py
+++ b/utils/helper.py
@@ -180,7 +180,7 @@ def ensure_ok(response: requests.Response, context: str) -> None:
     body: Any = response.text
     try:
         body = response.json()
-    except Exception:
+    except (ValueError, TypeError, AttributeError):
         pass
     retry_after_header = response.headers.get("Retry-After") if hasattr(response, "headers") else None
     retry_after: int | None = None


### PR DESCRIPTION
Replace 8 broad `except Exception: pass` blocks with specific exception types:

- **JSON file reads**: `except (json.JSONDecodeError, OSError)` — cpa_service, sub2api_service, mail_provider, openai_register
- **File reads/writes**: `except (OSError, ValueError)` or `except OSError` — account_service, auth_service, image_service
- **datetime parsing**: `except (ValueError, OverflowError)` — mail_provider
- **HTTP response parsing**: `except (ValueError, TypeError, AttributeError)` — helper.py

Using broad `except Exception: pass` silently swallows unexpected errors (SystemExit, KeyboardInterrupt, MemoryError, etc.), making debugging harder. These changes scope handlers to only the expected error types.