### PR TITLE
修复号池手动刷新未移除失效账号

### DIFF
--- a/api/accounts.py
+++ b/api/accounts.py
@@ -259,7 +259,7 @@ def create_router() -> APIRouter:
 
         async def _do_refresh():
             try:
-                await run_in_threadpool(account_service.refresh_accounts, access_tokens, progress_id)
+                await run_in_threadpool(account_service.refresh_accounts, access_tokens, progress_id, False)
             except Exception as e:
                 account_service.finish_refresh_progress(progress_id, error=str(e))
 

--- a/services/account_service.py
+++ b/services/account_service.py
@@ -1229,14 +1229,20 @@ class AccountService:
             return True
         return False
 
-    def _record_invalid_token_seen(self, access_token: str, event: str, error: str) -> bool:
+    def _record_invalid_token_seen(
+        self,
+        access_token: str,
+        event: str,
+        error: str,
+        defer_invalid_removal: bool = True,
+    ) -> bool:
         now = datetime.now(timezone.utc)
         with self._lock:
             access_token = self._resolve_access_token_locked(access_token)
             current = self._accounts.get(access_token)
             if current is None:
                 return True
-            should_defer = self._should_defer_invalid_token(current, now)
+            should_defer = defer_invalid_removal and self._should_defer_invalid_token(current, now)
             next_item = dict(current)
             next_item["invalid_count"] = int(next_item.get("invalid_count") or 0) + 1
             next_item["last_invalid_at"] = now.isoformat()
@@ -1291,7 +1297,12 @@ class AccountService:
             return dict(account)
         return None
 
-    def fetch_remote_info(self, access_token: str, event: str = "fetch_remote_info") -> dict[str, Any] | None:
+    def fetch_remote_info(
+        self,
+        access_token: str,
+        event: str = "fetch_remote_info",
+        defer_invalid_removal: bool = True,
+    ) -> dict[str, Any] | None:
         if not access_token:
             raise ValueError("access_token is required")
 
@@ -1305,12 +1316,22 @@ class AccountService:
                 try:
                     result = OpenAIBackendAPI(refreshed_token).get_user_info()
                 except InvalidAccessTokenError as retry_exc:
-                    if self._record_invalid_token_seen(refreshed_token, event, str(retry_exc)):
+                    if self._record_invalid_token_seen(
+                        refreshed_token,
+                        event,
+                        str(retry_exc),
+                        defer_invalid_removal=defer_invalid_removal,
+                    ):
                         self.remove_invalid_token(refreshed_token, event)
                     raise
                 active_token = refreshed_token
             else:
-                if self._record_invalid_token_seen(active_token, event, str(exc)):
+                if self._record_invalid_token_seen(
+                    active_token,
+                    event,
+                    str(exc),
+                    defer_invalid_removal=defer_invalid_removal,
+                ):
                     self.remove_invalid_token(active_token, event)
                 raise
         self._record_refresh_success(active_token)
@@ -1416,7 +1437,12 @@ class AccountService:
         with self._relogin_progress_lock:
             self._relogin_progress.pop(progress_id, None)
 
-    def refresh_accounts(self, access_tokens: list[str], progress_id: str | None = None) -> dict[str, Any]:
+    def refresh_accounts(
+        self,
+        access_tokens: list[str],
+        progress_id: str | None = None,
+        defer_invalid_removal: bool = True,
+    ) -> dict[str, Any]:
         access_tokens = list(dict.fromkeys(token for token in access_tokens if token))
         if not access_tokens:
             items = self.list_accounts()
@@ -1435,7 +1461,7 @@ class AccountService:
         executor = ThreadPoolExecutor(max_workers=max_workers)
         try:
             futures = {
-                executor.submit(self.fetch_remote_info, token, "refresh_accounts"): token
+                executor.submit(self.fetch_remote_info, token, "refresh_accounts", defer_invalid_removal): token
                 for token in access_tokens
             }
             for future in as_completed(futures):

--- a/test/test_account_image_capabilities.py
+++ b/test/test_account_image_capabilities.py
@@ -4,11 +4,14 @@ import os
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 os.environ.setdefault("CHATGPT2API_AUTH_KEY", "test-auth")
 
 from services.account_service import AccountService
 from services.auth_service import AuthService
+from services.config import config
+from services.openai_backend_api import InvalidAccessTokenError
 from services.storage.json_storage import JSONStorageBackend
 from utils.helper import anonymize_token, split_image_model
 
@@ -93,6 +96,55 @@ class AccountCapabilityTests(unittest.TestCase):
 
             self.assertEqual(plus_token, "token-plus")
             self.assertEqual(pro_token, "token-pro")
+
+    def test_refresh_accounts_can_remove_invalid_token_without_confirmation_delay(self) -> None:
+        original_value = config.data.get("auto_remove_invalid_accounts")
+        config.data["auto_remove_invalid_accounts"] = True
+        try:
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                service = AccountService(JSONStorageBackend(Path(tmp_dir) / "accounts.json"))
+                service.add_account_items([{"access_token": "invalid-token", "status": "正常"}])
+
+                with patch(
+                    "services.openai_backend_api.OpenAIBackendAPI.get_user_info",
+                    side_effect=InvalidAccessTokenError("token invalidated (/backend-api/me)"),
+                ):
+                    result = service.refresh_accounts(["invalid-token"], defer_invalid_removal=False)
+
+                self.assertEqual(result["refreshed"], 0)
+                self.assertEqual(len(result["errors"]), 1)
+                self.assertEqual(result["items"], [])
+                self.assertIsNone(service.get_account("invalid-token"))
+        finally:
+            if original_value is None:
+                config.data.pop("auto_remove_invalid_accounts", None)
+            else:
+                config.data["auto_remove_invalid_accounts"] = original_value
+
+    def test_refresh_accounts_defers_invalid_token_removal_by_default(self) -> None:
+        original_value = config.data.get("auto_remove_invalid_accounts")
+        config.data["auto_remove_invalid_accounts"] = True
+        try:
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                service = AccountService(JSONStorageBackend(Path(tmp_dir) / "accounts.json"))
+                service.add_account_items([{"access_token": "invalid-token", "status": "正常"}])
+
+                with patch(
+                    "services.openai_backend_api.OpenAIBackendAPI.get_user_info",
+                    side_effect=InvalidAccessTokenError("token invalidated (/backend-api/me)"),
+                ):
+                    result = service.refresh_accounts(["invalid-token"])
+
+                account = service.get_account("invalid-token")
+                self.assertEqual(result["refreshed"], 0)
+                self.assertEqual(len(result["errors"]), 1)
+                self.assertIsNotNone(account)
+                self.assertEqual(account["invalid_count"], 1)
+        finally:
+            if original_value is None:
+                config.data.pop("auto_remove_invalid_accounts", None)
+            else:
+                config.data["auto_remove_invalid_accounts"] = original_value
 
 
 class TokenLogTests(unittest.TestCase):


### PR DESCRIPTION
## 问题

号池管理页面点击「一键刷新所有账号信息和额度」时，如果某个账号返回 `token invalidated (/backend-api/me)`，接口会提示失败账号数量，但账号列表里仍保留该无效账号。用户需要再逐个点击账号行内刷新按钮，才会触发移除，和页面预期以及自动移除失效账号配置不一致。

## 原因

`AccountService.refresh_accounts()` 复用后台刷新逻辑。遇到 `InvalidAccessTokenError` 时会经过 `_should_defer_invalid_token()` 的确认缓冲，首次失效只记录 `invalid_count` 和错误信息，不会立刻调用 `remove_invalid_token()`。

这个保护适合后台自动取号/生成过程，避免偶发状态误删；但号池管理里的手动刷新属于用户显式校验，已经确认 `/backend-api/me` 返回 token 失效时，应按配置立即移除或标记异常。

## 修改

- 给 `fetch_remote_info()` / `_record_invalid_token_seen()` / `refresh_accounts()` 增加 `defer_invalid_removal` 参数，默认保持原有缓冲行为。
- 号池管理 `/api/accounts/refresh` 手动刷新入口传入 `False`，使一键刷新和单账号刷新在失效账号处理上行为一致。
- 增加回归测试：
  - 显式刷新遇到失效 token 会立即移除。
  - 默认后台路径仍保留失效确认缓冲。

## 验证

- `uv run python -m unittest test.test_account_image_capabilities`
- `uv run python -m py_compile services/account_service.py api/accounts.py test/test_account_image_capabilities.py`