### PR TITLE
feat(images): 优化并发生图与续写上下文

### DIFF
--- a/services/log_service.py
+++ b/services/log_service.py
@@ -244,9 +244,7 @@ class LoggedCall:
 
         if isinstance(result, dict):
             self.log("调用完成", result)
-            response = dict(result)
-            response.pop("_account_email", None)
-            return response
+            return _strip_internal_response_fields(result)
 
         sender = anthropic_sse_stream if sse == "anthropic" else sse_json_stream
         try:
@@ -300,7 +298,8 @@ class LoggedCall:
                          conversation_id=conversation_ids[0] if conversation_ids else "")
 
     def log(self, suffix: str, result: object = None, status: str = "success", error: str = "",
-            urls: list[str] | None = None, account_email: str = "", conversation_id: str = "") -> None:
+            urls: list[str] | None = None, account_email: str = "", conversation_id: str = "",
+            upstream_context: dict[str, Any] | None = None) -> None:
         detail = {
             "key_id": self.identity.get("id"),
             "key_name": self.identity.get("name"),
@@ -319,6 +318,10 @@ class LoggedCall:
             detail["request_shape"] = self.request_shape
         if error:
             detail["error"] = error
+        if upstream_context is None:
+            upstream_context = _collect_upstream_context(result)
+        if upstream_context:
+            detail["upstream_context"] = upstream_context
         email = str(account_email or "").strip()
         if not email:
             emails = _collect_account_emails(result)

--- a/services/openai_backend_api.py
+++ b/services/openai_backend_api.py
@@ -62,6 +62,11 @@ SEARCH_POLL_INTERVAL_SECS = 3.0
 SEARCH_DONE_STATUS = {"finished_successfully", "finished_partial_completion"}
 SEARCH_CONVERSATION_ID_RE = re.compile(r'"conversation_id"\s*:\s*"([^"]+)"')
 SEARCH_URL_RE = re.compile(r"https?://[^\s\"'<>）)\]}]+")
+NON_OUTPUT_IMAGE_FILE_IDS = {
+    "file_upload",
+    "file_upload_business_upsell",
+    "file_upload_business_upsell_get_business",
+}
 EDITABLE_FILE_MODEL = "gpt-5-5-thinking"
 EDITABLE_FILE_THINKING_EFFORT = "extended"
 EDITABLE_FILE_TIMEOUT_SECS = 1200.0
@@ -802,13 +807,20 @@ class OpenAIBackendAPI:
             retry_after = int(retry_after_header) if str(retry_after_header or "").isdigit() else None
             raise UpstreamHTTPError(path, error.code, body, retry_after=retry_after) from error
 
-    def _prepare_image_conversation(self, prompt: str, requirements: ChatRequirements, model: str) -> str:
+    def _prepare_image_conversation(
+            self,
+            prompt: str,
+            requirements: ChatRequirements,
+            model: str,
+            conversation_id: str = "",
+            parent_message_id: str = "",
+    ) -> str:
         """为图片生成准备 conduit token。"""
         path = "/backend-api/f/conversation/prepare"
         payload = {
             "action": "next",
             "fork_from_shared_post": False,
-            "parent_message_id": new_uuid(),
+            "parent_message_id": parent_message_id or new_uuid(),
             "model": self._image_model_slug(model),
             "client_prepare_state": "success",
             "timezone_offset_min": -480,
@@ -824,6 +836,8 @@ class OpenAIBackendAPI:
             "supported_encodings": ["v1"],
             "client_contextual_info": {"app_name": "chatgpt.com"},
         }
+        if conversation_id:
+            payload["conversation_id"] = conversation_id
         response = self.session.post(
             self.base_url + path,
             headers=self._image_headers(path, requirements),
@@ -907,8 +921,16 @@ class OpenAIBackendAPI:
             "height": height,
         }
 
-    def _start_image_generation(self, prompt: str, requirements: ChatRequirements, conduit_token: str, model: str,
-                                references: Optional[list[Dict[str, Any]]] = None) -> requests.Response:
+    def _start_image_generation(
+            self,
+            prompt: str,
+            requirements: ChatRequirements,
+            conduit_token: str,
+            model: str,
+            references: Optional[list[Dict[str, Any]]] = None,
+            conversation_id: str = "",
+            parent_message_id: str = "",
+    ) -> requests.Response:
         """启动图片生成或编辑的 SSE 请求。"""
         references = references or []
         parts = [{
@@ -946,7 +968,7 @@ class OpenAIBackendAPI:
                 "content": content,
                 "metadata": metadata,
             }],
-            "parent_message_id": new_uuid(),
+            "parent_message_id": parent_message_id or new_uuid(),
             "model": self._image_model_slug(model),
             "client_prepare_state": "sent",
             "timezone_offset_min": -480,
@@ -969,6 +991,8 @@ class OpenAIBackendAPI:
             "paragen_cot_summary_display_override": "allow",
             "force_parallel_switch": "auto",
         }
+        if conversation_id:
+            payload["conversation_id"] = conversation_id
         path = "/backend-api/f/conversation"
         response = self.session.post(
             self.base_url + path,
@@ -979,6 +1003,41 @@ class OpenAIBackendAPI:
         )
         ensure_ok(response, path)
         return response
+
+    def continue_image_conversation(
+            self,
+            conversation_id: str,
+            parent_message_id: str,
+            prompt: str,
+            model: str,
+    ) -> Iterator[str]:
+        """在已有图片会话里追加一条消息，用于上游只返回工具参数时兜底续生成。"""
+        if not conversation_id:
+            raise ValueError("conversation_id is required")
+        if not parent_message_id:
+            raise ValueError("parent_message_id is required")
+        self._bootstrap()
+        requirements = self._get_chat_requirements()
+        conduit_token = self._prepare_image_conversation(
+            prompt,
+            requirements,
+            model,
+            conversation_id=conversation_id,
+            parent_message_id=parent_message_id,
+        )
+        response = self._start_image_generation(
+            prompt,
+            requirements,
+            conduit_token,
+            model,
+            references=[],
+            conversation_id=conversation_id,
+            parent_message_id=parent_message_id,
+        )
+        try:
+            yield from iter_sse_payloads(response)
+        finally:
+            response.close()
 
     def _get_conversation(self, conversation_id: str) -> Dict[str, Any]:
         """获取完整 conversation 详情。"""
@@ -1075,6 +1134,73 @@ class OpenAIBackendAPI:
                 })
                 return conv_id
         return ""
+
+    @staticmethod
+    def _conversation_text_preview(message: Dict[str, Any], limit: int = 500) -> str:
+        content = message.get("content") or {}
+        parts: list[str] = []
+        if isinstance(content, dict):
+            for part in content.get("parts") or []:
+                if isinstance(part, str):
+                    parts.append(part)
+                elif isinstance(part, dict):
+                    text = part.get("text") or part.get("summary") or part.get("content")
+                    if text:
+                        parts.append(str(text))
+        elif isinstance(content, str):
+            parts.append(content)
+        text = " ".join(" ".join(parts).split())
+        return text if len(text) <= limit else text[:limit].rstrip() + "..."
+
+    def _conversation_parent_message_id(self, conversation: Dict[str, Any]) -> str:
+        mapping = conversation.get("mapping") if isinstance(conversation.get("mapping"), dict) else {}
+        current_node = str(conversation.get("current_node") or "").strip()
+        if current_node and current_node in mapping:
+            return current_node
+        candidates: list[tuple[float, str]] = []
+        for node_id, node in mapping.items():
+            message = (node or {}).get("message") or {}
+            if not isinstance(message, dict):
+                continue
+            message_id = str(message.get("id") or node_id or "").strip()
+            if message_id:
+                candidates.append((float(message.get("create_time") or 0.0), message_id))
+        return max(candidates, default=(0.0, ""))[1]
+
+    def _image_conversation_debug_snapshot(self, conversation_id: str, conversation: Dict[str, Any]) -> Dict[str, Any]:
+        mapping = conversation.get("mapping") if isinstance(conversation.get("mapping"), dict) else {}
+        messages: list[Dict[str, Any]] = []
+        for node_id, node in mapping.items():
+            message = (node or {}).get("message") or {}
+            if not isinstance(message, dict):
+                continue
+            author = message.get("author") if isinstance(message.get("author"), dict) else {}
+            metadata = message.get("metadata") if isinstance(message.get("metadata"), dict) else {}
+            content = message.get("content") if isinstance(message.get("content"), dict) else {}
+            file_ids, sediment_ids = self._extract_image_reference_ids({"content": content, "metadata": metadata})
+            messages.append({
+                "node_id": str(node_id),
+                "message_id": str(message.get("id") or node_id or ""),
+                "role": str(author.get("role") or ""),
+                "status": str(message.get("status") or ""),
+                "content_type": str(content.get("content_type") or ""),
+                "async_task_type": str(metadata.get("async_task_type") or ""),
+                "create_time": float(message.get("create_time") or 0.0),
+                "text_preview": self._conversation_text_preview(message),
+                "file_ids": [item for item in file_ids if item not in NON_OUTPUT_IMAGE_FILE_IDS],
+                "sediment_ids": sediment_ids,
+            })
+        messages.sort(key=lambda item: item["create_time"])
+        return {
+            "conversation_id": conversation_id,
+            "current_node": str(conversation.get("current_node") or ""),
+            "parent_message_id": self._conversation_parent_message_id(conversation),
+            "messages": messages[-12:],
+        }
+
+    def get_image_conversation_debug_snapshot(self, conversation_id: str) -> Dict[str, Any]:
+        """返回可写入调用日志的上游图片会话摘要，不包含图片二进制或 token。"""
+        return self._image_conversation_debug_snapshot(conversation_id, self._get_conversation(conversation_id))
 
     @staticmethod
     def _editable_prompt(fixed_prompt: str, user_prompt_text: str) -> str:
@@ -2326,7 +2452,7 @@ class OpenAIBackendAPI:
     def _resolve_image_urls(self, conversation_id: str, file_ids: list[str], sediment_ids: list[str]) -> list[str]:
         """把图片结果 id 解析成可下载 URL。"""
         urls = []
-        skip_patterns = {"file_upload"}
+        skip_patterns = NON_OUTPUT_IMAGE_FILE_IDS
         for file_id in file_ids:
             if file_id in skip_patterns:
                 logger.debug({
@@ -2405,7 +2531,7 @@ class OpenAIBackendAPI:
             poll: bool = True,
             poll_timeout_secs: float | None = None,
     ) -> list[str]:
-        file_ids = [item for item in file_ids if item != "file_upload"]
+        file_ids = [item for item in file_ids if item not in NON_OUTPUT_IMAGE_FILE_IDS]
         sediment_ids = list(sediment_ids)
         timeout = poll_timeout_secs if poll_timeout_secs is not None else config.image_poll_timeout_secs
         # 当 check-before-hit 和 settle 均已关闭，且 SSE 已给出 file_ids 时，

--- a/services/protocol/conversation.py
+++ b/services/protocol/conversation.py
@@ -6,7 +6,8 @@ import re
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
-from typing import Any, Iterable, Iterator
+from queue import Empty, Queue
+from typing import Any, Callable, Iterable, Iterator
 
 import tiktoken
 
@@ -23,6 +24,12 @@ from utils.helper import (
 )
 from utils.image_tokens import count_image_content_tokens
 from utils.log import logger
+
+NON_OUTPUT_IMAGE_FILE_IDS = {
+    "file_upload",
+    "file_upload_business_upsell",
+    "file_upload_business_upsell_get_business",
+}
 
 
 class ImageGenerationError(Exception):
@@ -222,6 +229,37 @@ def build_image_prompt(prompt: str, size: str | None, quality: str = "auto") -> 
     return f"{prompt.strip()}\n\n{''.join(hints)}" if hints else prompt
 
 
+def parse_image_tool_arguments(text: str) -> dict[str, Any] | None:
+    raw = str(text or "").strip()
+    if not raw:
+        return None
+    if raw.startswith("```"):
+        raw = re.sub(r"^```(?:json)?\s*", "", raw, flags=re.IGNORECASE)
+        raw = re.sub(r"\s*```$", "", raw)
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if not ({"prompt", "size", "n", "referenced_image_ids", "is_style_transfer"} & set(payload)):
+        return None
+    if isinstance(payload.get("error"), (str, dict, list)):
+        return None
+    return payload
+
+
+def image_continuation_prompt(original_prompt: str, tool_arguments: dict[str, Any]) -> str:
+    args_preview = json.dumps(tool_arguments, ensure_ascii=False)[:1000]
+    return (
+        "你刚才只返回了图片工具参数 JSON，没有生成图片。"
+        "请基于本会话中已经上传的参考图和原始需求，立即调用图片生成工具生成最终图片。"
+        "不要输出 JSON、参数、解释或文字说明，只生成图片。\n\n"
+        f"原始需求：{original_prompt.strip()}\n\n"
+        f"刚才错误返回的参数：{args_preview}"
+    )
+
+
 def encoding_for_model(model: str):
     try:
         return tiktoken.encoding_for_model(model)
@@ -331,6 +369,7 @@ class ImageOutput:
     data: list[dict[str, Any]] = field(default_factory=list)
     account_email: str = ""
     conversation_id: str = ""
+    upstream_context: dict[str, Any] = field(default_factory=dict)
 
     def to_chunk(self) -> dict[str, Any]:
         chunk: dict[str, Any] = {
@@ -803,6 +842,16 @@ def stream_image_outputs(
     file_ids = [str(item) for item in last.get("file_ids") or []]
     sediment_ids = [str(item) for item in last.get("sediment_ids") or []]
     message = str(last.get("text") or "").strip()
+    upstream_context = {
+        "conversation_id": conversation_id,
+        "file_ids": file_ids,
+        "sediment_ids": sediment_ids,
+        "tool_invoked": last.get("tool_invoked"),
+        "turn_use_case": last.get("turn_use_case"),
+        "blocked": last.get("blocked"),
+    }
+    if message:
+        upstream_context["message_preview"] = message[:1000]
     logger.info({
         "event": "image_stream_resolve_start",
         "conversation_id": conversation_id,
@@ -1535,10 +1584,13 @@ def collect_image_outputs(outputs: Iterable[ImageOutput]) -> dict[str, Any]:
     message = ""
     progress_parts: list[str] = []
     account_email = ""
+    upstream_context: dict[str, Any] = {}
     for output in outputs:
         created = created or output.created
         if output.account_email and not account_email:
             account_email = output.account_email
+        if output.upstream_context:
+            upstream_context = output.upstream_context
         if output.kind == "progress" and output.text:
             progress_parts.append(output.text)
         elif output.kind == "message":
@@ -1553,4 +1605,6 @@ def collect_image_outputs(outputs: Iterable[ImageOutput]) -> dict[str, Any]:
             result["message"] = text
     if account_email:
         result["_account_email"] = account_email
+    if upstream_context:
+        result["_upstream_context"] = upstream_context
     return result

--- a/test/test_image_generation_concurrency.py
+++ b/test/test_image_generation_concurrency.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import threading
+import time
+import unittest
+from unittest import mock
+
+from services.protocol import conversation
+from services.protocol.conversation import ConversationRequest, ImageOutput
+
+
+class FakeAccountService:
+    def __init__(self) -> None:
+        self._next = 0
+        self._lock = threading.Lock()
+        self.marked: list[tuple[str, bool]] = []
+
+    def get_available_access_token(
+        self,
+        plan_type: str | None = None,
+        source_type: str | None = None,
+        plan_types: tuple[str, ...] | None = None,
+    ) -> str:
+        with self._lock:
+            self._next += 1
+            return f"token-{self._next}"
+
+    def get_account(self, access_token: str) -> dict[str, str]:
+        return {"email": f"{access_token}@example.com"}
+
+    def mark_image_result(self, access_token: str, success: bool) -> None:
+        with self._lock:
+            self.marked.append((access_token, success))
+
+    def remove_invalid_token(self, access_token: str, event: str) -> bool:
+        return False
+
+
+class ImageGenerationConcurrencyTests(unittest.TestCase):
+    def test_multiple_requested_images_start_concurrently_and_return_in_index_order(self) -> None:
+        active = 0
+        max_active = 0
+        lock = threading.Lock()
+
+        def fake_stream_image_outputs(_backend, request: ConversationRequest, index: int, total: int):
+            nonlocal active, max_active
+            with lock:
+                active += 1
+                max_active = max(max_active, active)
+            yield ImageOutput(
+                kind="progress",
+                model=request.model,
+                index=index,
+                total=total,
+                text=f"progress-{index}",
+            )
+            time.sleep(0.2)
+            with lock:
+                active -= 1
+            yield ImageOutput(
+                kind="result",
+                model=request.model,
+                index=index,
+                total=total,
+                data=[{"b64_json": f"image-{index}"}],
+            )
+
+        fake_accounts = FakeAccountService()
+        with (
+            mock.patch.object(conversation, "account_service", fake_accounts),
+            mock.patch.object(conversation, "OpenAIBackendAPI", lambda access_token: object()),
+            mock.patch.object(conversation, "stream_image_outputs", fake_stream_image_outputs),
+        ):
+            outputs = list(conversation.stream_image_outputs_with_pool(ConversationRequest(
+                prompt="cat",
+                model="gpt-image-2",
+                n=3,
+            )))
+
+        self.assertGreaterEqual(max_active, 2)
+        self.assertEqual(len([output for output in outputs if output.kind == "progress"]), 3)
+        self.assertEqual([output.index for output in outputs if output.kind == "result"], [1, 2, 3])
+        self.assertEqual(len(fake_accounts.marked), 3)
+        self.assertTrue(all(success for _, success in fake_accounts.marked))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_multi_image_results.py
+++ b/test/test_multi_image_results.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
 import base64
+import json
 import unittest
 from unittest import mock
 
 from services.config import config
 from services.openai_backend_api import OpenAIBackendAPI
-from services.protocol.conversation import ImageOutput, extract_conversation_ids
+from services.protocol.conversation import (
+    ConversationRequest,
+    ImageOutput,
+    collect_image_outputs,
+    extract_conversation_ids,
+    stream_image_outputs,
+)
 from services.protocol.openai_v1_response import stream_image_response
 
 
@@ -47,6 +54,64 @@ class FakeBackend(OpenAIBackendAPI):
 
     def _get_attachment_download_url(self, conversation_id: str, attachment_id: str) -> str:
         return self.sediment_urls.get(attachment_id, "")
+
+
+class ContinuationBackend(OpenAIBackendAPI):
+    def __init__(self) -> None:
+        self.continued = False
+        self.followup_prompt = ""
+
+    def stream_conversation(self, **_kwargs):
+        yield json.dumps({
+            "type": "server_ste_metadata",
+            "conversation_id": "conv-1",
+            "metadata": {"tool_invoked": False, "turn_use_case": "image gen"},
+        })
+        yield json.dumps({
+            "conversation_id": "conv-1",
+            "p": "/message/content/parts/0",
+            "o": "append",
+            "v": '{"size":"1792x1024","n":1}',
+        })
+        yield "[DONE]"
+
+    def get_image_conversation_debug_snapshot(self, conversation_id: str) -> dict:
+        return {
+            "conversation_id": conversation_id,
+            "current_node": "assistant-1",
+            "parent_message_id": "assistant-1",
+            "messages": [{"message_id": "assistant-1", "role": "assistant", "text_preview": '{"size":"1792x1024","n":1}'}],
+        }
+
+    def continue_image_conversation(self, conversation_id: str, parent_message_id: str, prompt: str, model: str):
+        self.continued = True
+        self.followup_prompt = prompt
+        self.assert_values = (conversation_id, parent_message_id, model)
+        yield json.dumps({
+            "type": "server_ste_metadata",
+            "conversation_id": "conv-1",
+            "metadata": {"tool_invoked": True, "turn_use_case": "image gen"},
+        })
+        yield json.dumps({
+            "conversation_id": "conv-1",
+            "v": {
+                "message": {
+                    "author": {"role": "tool"},
+                    "metadata": {"async_task_type": "image_gen"},
+                    "content": {
+                        "content_type": "multimodal_text",
+                        "parts": [{"content_type": "image_asset_pointer", "asset_pointer": "file-service://file-out"}],
+                    },
+                },
+            },
+        })
+        yield "[DONE]"
+
+    def resolve_conversation_image_urls(self, conversation_id: str, file_ids: list[str], sediment_ids: list[str], poll: bool = True) -> list[str]:
+        return ["https://files.test/out.png"] if conversation_id == "conv-1" and file_ids == ["file-out"] else []
+
+    def download_image_bytes(self, urls: list[str]) -> list[bytes]:
+        return [b"out"] if urls == ["https://files.test/out.png"] else []
 
 
 class MultiImageResultTests(unittest.TestCase):
@@ -153,6 +218,29 @@ class MultiImageResultTests(unittest.TestCase):
             urls = backend.resolve_conversation_image_urls("conv-1", ["file-one"], [], poll=True)
 
         self.assertEqual(urls, ["https://files.test/one.png"])
+
+    def test_tool_argument_text_continues_same_conversation(self) -> None:
+        backend = ContinuationBackend()
+
+        outputs = list(stream_image_outputs(
+            backend,
+            ConversationRequest(
+                prompt="把截图改成详情页",
+                model="gpt-image-2",
+                images=["input-image"],
+                response_format="b64_json",
+            ),
+        ))
+        result = collect_image_outputs(outputs)
+
+        self.assertTrue(backend.continued)
+        self.assertIn("不要输出 JSON", backend.followup_prompt)
+        self.assertEqual(len(result["data"]), 1)
+        context = result["_upstream_context"]
+        self.assertEqual(context["conversation_id"], "conv-1")
+        self.assertEqual(context["continuation"]["status"], "success")
+        self.assertEqual(context["continuation"]["parent_message_id"], "assistant-1")
+        self.assertEqual(context["continuation"]["after_stream"]["file_ids"], ["file-out"])
 
     def test_responses_stream_emits_all_image_output_items(self) -> None:
         first = base64.b64encode(b"first").decode("ascii")

--- a/test/test_v1_images_edits_api.py
+++ b/test/test_v1_images_edits_api.py
@@ -8,6 +8,8 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 import api.ai as ai_module
+from services import log_service as log_module
+from services.protocol.conversation import ImageGenerationError
 
 
 AUTH_HEADERS = {"Authorization": "Bearer chatgpt2api"}
@@ -51,6 +53,35 @@ class ImagesEditsApiTests(unittest.TestCase):
         self.assertEqual(payload["n"], 1)
         self.assertEqual(payload["images"], [(PNG_BYTES, "image_url.png", "image/png")])
 
+    def test_edit_success_logs_but_hides_upstream_context(self):
+        """测试会话调试上下文只写日志，不暴露给接口调用方。"""
+        records = []
+
+        def handle_with_context(_payload):
+            return {
+                "created": 1,
+                "data": [{"b64_json": base64.b64encode(b"out").decode("ascii")}],
+                "_upstream_context": {"conversation_id": "conv-1"},
+            }
+
+        with (
+            mock.patch.object(ai_module.openai_v1_image_edit, "handle", handle_with_context),
+            mock.patch.object(
+                log_module.log_service,
+                "add",
+                lambda type, summary="", detail=None, **data: records.append((type, summary, detail or data)),
+            ),
+        ):
+            response = self.client.post(
+                "/v1/images/edits",
+                headers=AUTH_HEADERS,
+                json={"model": "gpt-image-2", "prompt": "edit", "images": [{"image_url": DATA_IMAGE_URL}]},
+            )
+
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertNotIn("_upstream_context", response.json())
+        self.assertEqual(records[0][2]["upstream_context"]["conversation_id"], "conv-1")
+
     def test_edit_rejects_file_id_reference(self):
         """测试图片编辑接口对暂不支持的 file_id 返回明确错误。"""
         response = self.client.post(
@@ -66,6 +97,47 @@ class ImagesEditsApiTests(unittest.TestCase):
         self.assertEqual(response.status_code, 400, response.text)
         self.assertIn("file_id image references are not supported", response.text)
         self.assertEqual(self.handle_calls, [])
+
+    def test_edit_failure_logs_upstream_context(self):
+        """测试上游返回文本失败时，调用日志保留上游会话上下文。"""
+        records = []
+
+        def fail_handle(_payload):
+            raise ImageGenerationError(
+                '{"size":"1792x1024","n":1}',
+                status_code=400,
+                error_type="invalid_request_error",
+                code="content_policy_violation",
+                account_email="account@example.test",
+                upstream_context={
+                    "conversation_id": "conv-1",
+                    "tool_invoked": False,
+                    "turn_use_case": "image gen",
+                    "message_preview": '{"size":"1792x1024","n":1}',
+                },
+            )
+
+        with (
+            mock.patch.object(ai_module.openai_v1_image_edit, "handle", fail_handle),
+            mock.patch.object(
+                log_module.log_service,
+                "add",
+                lambda type, summary="", detail=None, **data: records.append((type, summary, detail or data)),
+            ),
+        ):
+            response = self.client.post(
+                "/v1/images/edits",
+                headers=AUTH_HEADERS,
+                json={"model": "gpt-image-2", "prompt": "edit", "images": [{"image_url": DATA_IMAGE_URL}]},
+            )
+
+        self.assertEqual(response.status_code, 400, response.text)
+        self.assertEqual(len(records), 1)
+        detail = records[0][2]
+        self.assertEqual(detail["error"], '{"size":"1792x1024","n":1}')
+        self.assertEqual(detail["account_email"], "account@example.test")
+        self.assertEqual(detail["upstream_context"]["conversation_id"], "conv-1")
+        self.assertEqual(detail["upstream_context"]["message_preview"], '{"size":"1792x1024","n":1}')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Cherry-picked from QWiseDev/chatgpt2api commit `e478ab3` only.

Changes:
- preserve concurrent image generation result ordering
- keep image continuation context for follow-up requests
- add regression coverage for multi-image and image edit flows

Validation:
- `git rev-list --count basketikun/main..HEAD` -> `1`
- `git diff basketikun/main..HEAD` matches the patch-id of `e478ab3`
