### PR TITLE
Fix image TLS impersonation defaults

### DIFF
--- a/services/account_service.py
+++ b/services/account_service.py
@@ -359,7 +359,7 @@ class AccountService:
         from curl_cffi import requests
         from services.proxy_service import proxy_settings
 
-        session = requests.Session(**proxy_settings.build_session_kwargs(account=account, impersonate="chrome", verify=True))
+        session = requests.Session(**proxy_settings.build_session_kwargs(account=account, impersonate="chrome110", verify=True))
         try:
             response = session.post(
                 self._OAUTH_TOKEN_URL,

--- a/services/openai_backend_api.py
+++ b/services/openai_backend_api.py
@@ -222,7 +222,7 @@ class OpenAIBackendAPI:
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
             "(KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36 Edg/143.0.0.0",
         )
-        fp.setdefault("impersonate", "edge101")
+        fp.setdefault("impersonate", "chrome110")
         fp.setdefault("oai-device-id", new_uuid())
         fp.setdefault("oai-session-id", new_uuid())
         fp.setdefault("sec-ch-ua", '"Microsoft Edge";v="143", "Chromium";v="143", "Not A(Brand";v="24"')


### PR DESCRIPTION
## Summary
- use `chrome110` impersonation for OAuth token refresh before image generation
- use `chrome110` as the default backend API impersonation for image requests
- avoid Docker deployments surfacing curl_cffi TLS failures as misleading `no available image quota` errors

## Background
In Docker/Colima on macOS, image generation failed before reaching the upstream image flow. The account was detected as Pro with active subscription, but `fetch_remote_info()` swallowed a curl_cffi TLS failure from the preflight refresh path and later returned `no available image quota`.

The direct failure was:

```text
curl: (35) TLS connect error: error:00000000:invalid library (0):OPENSSL_internal:invalid library (0)
```

Using `chrome110` works in the same container, while the previous defaults failed on the affected paths.

## Test
- `docker-compose run --rm --no-deps -v "$PWD:/app" app uv run --with pytest pytest test/test_account_image_capabilities.py`
- Manually verified `/v1/images/generations` returns `200 OK` with `gpt-image-2` after rebuilding the Docker image.

Related to #236.
