### PR TITLE
feat: 号池管理页展示账号正在生成图片数量(image_inflight)

### DIFF
--- a/services/account_service.py
+++ b/services/account_service.py
@@ -1053,8 +1053,19 @@ class AccountService:
             return dict(account) if account else None
 
     def list_accounts(self) -> list[dict]:
+        """返回所有账号的副本，并为每个账号附加当前图片在途数 image_inflight。
+
+        image_inflight 为内存态并发计数(账号正在生成、尚未结束的图片数)。号池空闲时
+        若某账号该值持续 > 0，说明其并发槽位泄漏、已被静默排除出调度，可借此在 UI 上诊断。
+        """
         with self._lock:
-            return [dict(item) for item in self._accounts.values()]
+            result = []
+            for item in self._accounts.values():
+                account = dict(item)
+                token = account.get("access_token") or ""
+                account["image_inflight"] = int(self._image_inflight.get(token, 0))
+                result.append(account)
+            return result
 
     def list_limited_tokens(self) -> list[str]:
         with self._lock:

--- a/web/src/app/accounts/page.tsx
+++ b/web/src/app/accounts/page.tsx
@@ -1082,6 +1082,7 @@ function AccountsPageContent() {
                     <th className="w-32 px-4 py-3">创建时间</th>
                     <th className="w-24 px-4 py-3">额度</th>
                     <th className="w-40 px-4 py-3">恢复时间</th>
+                    <th className="w-18 px-4 py-3">在途</th>
                     <th className="w-18 px-4 py-3">成功</th>
                     <th className="w-18 px-4 py-3">失败</th>
                     <th className="w-24 px-4 py-3">操作</th>
@@ -1172,6 +1173,27 @@ function AccountsPageContent() {
                                 {restore.relative ? <div className="font-medium text-stone-700">{restore.relative}</div> : null}
                                 <div>{restore.absolute}</div>
                               </div>
+                            );
+                          })()}
+                        </td>
+                        <td className="px-4 py-3">
+                          {(() => {
+                            const inflight = account.image_inflight ?? 0;
+                            return (
+                              <span
+                                className={
+                                  inflight > 0
+                                    ? "font-semibold text-amber-600"
+                                    : "text-stone-400"
+                                }
+                                title={
+                                  inflight > 0
+                                    ? "当前正在生成的图片数。号池空闲时此值持续 > 0，说明并发槽位泄漏、该账号已被静默排除出调度"
+                                    : "当前无在途生图任务"
+                                }
+                              >
+                                {inflight}
+                              </span>
                             );
                           })()}
                         </td>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -34,6 +34,8 @@ export type Account = {
   restore_at?: string | null;
   success: number;
   fail: number;
+  /** 当前图片在途数(正在生成、尚未结束的图片数)。号池空闲时持续 > 0 表示并发槽位泄漏。 */
+  image_inflight?: number;
   last_used_at?: string | null;
   proxy?: string | null;
 };


### PR DESCRIPTION
## 背景
长时间运行后,部分账号在 /accounts 页显示「正常」却完全不被调度去生图,仅 `docker restart` 后恢复。根因是每账号的并发计数 `_image_inflight`(在途生图数)在某些路径下泄漏(只加不减),累积到 `image_account_concurrency` 上限后该账号被
`_acquire_next_candidate_token` 静默排除出调度;而该计数是纯内存态、不暴露给前端,所以 UI 上看不出异常。

## 本 PR 做了什么
把 `image_inflight` 暴露到号池管理页,作为可观测/诊断手段(不改调度逻辑):
- `list_accounts` 为每个账号附加 `image_inflight`,经 `GET /api/accounts` 透传
- 前端 `Account` 类型新增可选字段 `image_inflight`
- 账号列表新增「在途」列:值 > 0 时琥珀色高亮并附悬停说明,为 0 时灰色

## 如何用它诊断
号池空闲时,正常账号「在途」应为 0;若某账号持续 > 0(尤其等于并发上限),
即槽位泄漏、已被静默排除出调度。

## 测试
本地 `docker compose -f docker-compose.local.yml up -d --build` 构建通过,
/accounts 页正确渲染「在途」列,`GET /api/accounts` 返回含 `image_inflight`。