### PR TITLE
新增 Outlook/Hotmail refresh_token 邮箱注册支持

### DIFF
--- a/api/register.py
+++ b/api/register.py
@@ -22,6 +22,10 @@ class RegisterConfigRequest(BaseModel):
     check_interval: int | None = None
 
 
+class OutlookPoolResetRequest(BaseModel):
+    scope: str | None = None
+
+
 def create_router() -> APIRouter:
     router = APIRouter()
 
@@ -49,6 +53,11 @@ def create_router() -> APIRouter:
     async def reset_register(authorization: str | None = Header(default=None)):
         require_admin(authorization)
         return {"register": register_service.reset()}
+
+    @router.post("/api/register/outlook-pool/reset")
+    async def reset_outlook_pool(body: OutlookPoolResetRequest, authorization: str | None = Header(default=None)):
+        require_admin(authorization)
+        return {"register": register_service.reset_outlook_pool(body.scope or "all")}
 
     @router.get("/api/register/events")
     async def register_events(token: str = ""):

--- a/scripts/test_outlook_token_mailbox.py
+++ b/scripts/test_outlook_token_mailbox.py
@@ -1,0 +1,385 @@
+from __future__ import annotations
+
+import argparse
+import imaplib
+import json
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from email import message_from_bytes, policy
+from email.header import decode_header, make_header
+from email.message import Message
+from email.utils import parsedate_to_datetime
+from pathlib import Path
+from typing import Any
+
+
+TOKEN_URL = "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+GRAPH_MESSAGES_URL = "https://graph.microsoft.com/v1.0/me/messages"
+GRAPH_SCOPE = "offline_access https://graph.microsoft.com/Mail.Read"
+IMAP_SCOPE = "offline_access https://outlook.office.com/IMAP.AccessAsUser.All"
+DEFAULT_IMAP_HOST = "outlook.office365.com"
+
+
+@dataclass(frozen=True)
+class OutlookCredential:
+    email: str
+    password: str
+    client_id: str
+    refresh_token: str
+    line_number: int
+
+
+@dataclass(frozen=True)
+class HttpResponse:
+    status_code: int
+    text: str
+
+    def json(self) -> Any:
+        return json.loads(self.text)
+
+
+def _clean(value: str) -> str:
+    return value.replace("\ufeff", "").replace("\u00a0", " ").strip()
+
+
+def _redact_email(email: str) -> str:
+    local, sep, domain = email.partition("@")
+    if not sep:
+        return "***"
+    if len(local) <= 2:
+        masked = local[:1] + "***"
+    else:
+        masked = local[:2] + "***" + local[-1:]
+    return f"{masked}@{domain}"
+
+
+def parse_credentials(path: Path) -> list[OutlookCredential]:
+    credentials: list[OutlookCredential] = []
+    for line_number, raw_line in enumerate(path.read_text(encoding="utf-8-sig").splitlines(), start=1):
+        line = _clean(raw_line)
+        if not line or "----" not in line:
+            continue
+        parts = [_clean(part) for part in line.split("----", 3)]
+        if len(parts) != 4:
+            continue
+        email, password, client_id, refresh_token = parts
+        if "@" not in email or not client_id or not refresh_token:
+            continue
+        credentials.append(
+            OutlookCredential(
+                email=email,
+                password=password,
+                client_id=client_id,
+                refresh_token=refresh_token,
+                line_number=line_number,
+            )
+        )
+    return credentials
+
+
+def _http_request(
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    data: dict[str, str] | None = None,
+    params: dict[str, Any] | None = None,
+    timeout: float = 30,
+) -> HttpResponse:
+    target = url
+    if params:
+        query = urllib.parse.urlencode(params)
+        target = f"{url}?{query}"
+
+    body: bytes | None = None
+    request_headers = dict(headers or {})
+    if data is not None:
+        body = urllib.parse.urlencode(data).encode("utf-8")
+        request_headers.setdefault("Content-Type", "application/x-www-form-urlencoded")
+
+    request = urllib.request.Request(target, data=body, headers=request_headers, method=method.upper())
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return HttpResponse(
+                status_code=int(response.status),
+                text=response.read().decode("utf-8", errors="replace"),
+            )
+    except urllib.error.HTTPError as error:
+        return HttpResponse(
+            status_code=int(error.code),
+            text=error.read().decode("utf-8", errors="replace"),
+        )
+
+
+def exchange_refresh_token(credential: OutlookCredential, scope: str, timeout: float) -> str:
+    response = _http_request(
+        "POST",
+        TOKEN_URL,
+        data={
+            "client_id": credential.client_id,
+            "grant_type": "refresh_token",
+            "refresh_token": credential.refresh_token,
+            "scope": scope,
+        },
+        timeout=timeout,
+    )
+    try:
+        data = response.json()
+    except Exception:
+        data = {}
+    if response.status_code != 200:
+        detail = data.get("error_description") or data.get("error") or response.text[:300]
+        raise RuntimeError(f"token refresh failed: HTTP {response.status_code}, {detail}")
+    access_token = str(data.get("access_token") or "").strip()
+    if not access_token:
+        raise RuntimeError("token refresh response did not include access_token")
+    return access_token
+
+
+def _graph_sender(message: dict[str, Any]) -> str:
+    sender = message.get("from") or {}
+    if isinstance(sender, dict):
+        address = sender.get("emailAddress") or {}
+        if isinstance(address, dict):
+            return str(address.get("address") or address.get("name") or "")
+    return ""
+
+
+def read_graph_messages(access_token: str, limit: int, timeout: float) -> list[dict[str, str]]:
+    response = _http_request(
+        "GET",
+        GRAPH_MESSAGES_URL,
+        headers={"Authorization": f"Bearer {access_token}", "Accept": "application/json"},
+        params={
+            "$top": max(1, min(limit, 50)),
+            "$orderby": "receivedDateTime desc",
+            "$select": "subject,receivedDateTime,from,bodyPreview",
+        },
+        timeout=timeout,
+    )
+    try:
+        data = response.json()
+    except Exception:
+        data = {}
+    if response.status_code != 200:
+        detail = data.get("error", {}).get("message") if isinstance(data.get("error"), dict) else response.text[:300]
+        raise RuntimeError(f"graph messages failed: HTTP {response.status_code}, {detail}")
+    items = data.get("value") if isinstance(data, dict) else None
+    if not isinstance(items, list):
+        raise RuntimeError("graph messages response did not include value[]")
+    return [
+        {
+            "received": str(item.get("receivedDateTime") or ""),
+            "from": _graph_sender(item),
+            "subject": str(item.get("subject") or ""),
+            "preview": str(item.get("bodyPreview") or ""),
+        }
+        for item in items
+        if isinstance(item, dict)
+    ]
+
+
+def _decode_header(value: str | None) -> str:
+    if not value:
+        return ""
+    try:
+        return str(make_header(decode_header(value)))
+    except Exception:
+        return value
+
+
+def _message_text_preview(message: Message, limit: int = 240) -> str:
+    text_parts: list[str] = []
+    parts = message.walk() if message.is_multipart() else [message]
+    for part in parts:
+        if part.get_content_maintype() == "multipart":
+            continue
+        content_type = part.get_content_type()
+        if content_type not in {"text/plain", "text/html"}:
+            continue
+        try:
+            payload = part.get_content()
+        except Exception:
+            continue
+        if payload:
+            text_parts.append(str(payload))
+        if content_type == "text/plain" and text_parts:
+            break
+    text = "\n".join(text_parts)
+    text = re.sub(r"<[^>]+>", " ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text[:limit]
+
+
+def _parse_imap_message(raw: bytes, include_preview: bool) -> dict[str, str]:
+    message = message_from_bytes(raw, policy=policy.default)
+    received = ""
+    try:
+        parsed = parsedate_to_datetime(str(message.get("Date") or ""))
+        received = parsed.isoformat()
+    except Exception:
+        received = str(message.get("Date") or "")
+    return {
+        "received": received,
+        "from": _decode_header(str(message.get("From") or "")),
+        "subject": _decode_header(str(message.get("Subject") or "")),
+        "preview": _message_text_preview(message) if include_preview else "",
+    }
+
+
+def read_imap_messages(access_token: str, email: str, host: str, limit: int, include_preview: bool) -> list[dict[str, str]]:
+    auth_string = f"user={email}\x01auth=Bearer {access_token}\x01\x01"
+    mailbox = imaplib.IMAP4_SSL(host)
+    try:
+        mailbox.authenticate("XOAUTH2", lambda _: auth_string.encode("utf-8"))
+        status, _ = mailbox.select("INBOX", readonly=True)
+        if status != "OK":
+            raise RuntimeError("imap select INBOX failed")
+        status, data = mailbox.uid("search", None, "ALL")
+        if status != "OK" or not data or not data[0]:
+            return []
+        uids = data[0].split()[-max(1, limit) :]
+        messages: list[dict[str, str]] = []
+        for uid in reversed(uids):
+            status, fetched = mailbox.uid("fetch", uid, "(RFC822)")
+            if status != "OK":
+                continue
+            raw_payload = next((item[1] for item in fetched if isinstance(item, tuple) and isinstance(item[1], bytes)), b"")
+            if raw_payload:
+                messages.append(_parse_imap_message(raw_payload, include_preview))
+        return messages
+    finally:
+        try:
+            mailbox.logout()
+        except Exception:
+            pass
+
+
+def print_messages(messages: list[dict[str, str]], include_preview: bool) -> None:
+    if not messages:
+        print("  no recent messages")
+        return
+    for index, message in enumerate(messages, start=1):
+        print(f"  {index}. {message['received']} | {message['from']} | {message['subject']}")
+        if include_preview and message.get("preview"):
+            print(f"     preview: {message['preview']}")
+
+
+def test_credential(
+    credential: OutlookCredential,
+    mode: str,
+    limit: int,
+    timeout: float,
+    imap_host: str,
+    include_preview: bool,
+    show_email: bool,
+) -> bool:
+    label = credential.email if show_email else _redact_email(credential.email)
+    print(f"[line {credential.line_number}] {label}")
+    errors: list[str] = []
+
+    if mode in {"graph", "auto"}:
+        try:
+            access_token = exchange_refresh_token(credential, GRAPH_SCOPE, timeout)
+            messages = read_graph_messages(access_token, limit, timeout)
+            print("  graph: ok")
+            print_messages(messages, include_preview)
+            return True
+        except Exception as error:
+            errors.append(f"graph: {error}")
+            if mode == "graph":
+                print(f"  graph: failed - {error}")
+                return False
+
+    if mode in {"imap", "auto"}:
+        try:
+            access_token = exchange_refresh_token(credential, IMAP_SCOPE, timeout)
+            messages = read_imap_messages(access_token, credential.email, imap_host, limit, include_preview)
+            print("  imap: ok")
+            print_messages(messages, include_preview)
+            return True
+        except Exception as error:
+            errors.append(f"imap: {error}")
+            if mode == "imap":
+                print(f"  imap: failed - {error}")
+                return False
+
+    print("  failed")
+    for error in errors:
+        print(f"  - {error}")
+    return False
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Test Outlook/Hotmail mailbox access from lines formatted as email----password----client_id----refresh_token.",
+    )
+    parser.add_argument("--file", default=r"D:\Desktop\yx.txt", help="Credential text file path.")
+    parser.add_argument("--mode", choices=("auto", "graph", "imap"), default="auto", help="Mailbox read method.")
+    parser.add_argument("--limit-accounts", type=int, default=1, help="How many accounts to test.")
+    parser.add_argument("--message-limit", type=int, default=5, help="How many recent messages to list per account.")
+    parser.add_argument("--timeout", type=float, default=30, help="HTTP request timeout in seconds.")
+    parser.add_argument("--imap-host", default=DEFAULT_IMAP_HOST, help="IMAP host for XOAUTH2 mode.")
+    parser.add_argument("--preview", action="store_true", help="Print body preview/snippet. Disabled by default.")
+    parser.add_argument("--show-email", action="store_true", help="Print full email address. Secrets are never printed.")
+    parser.add_argument("--json", action="store_true", help="Only parse the file and print non-secret account metadata as JSON.")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    path = Path(args.file)
+    if not path.exists():
+        print(f"file not found: {path}", file=sys.stderr)
+        return 2
+
+    credentials = parse_credentials(path)
+    if not credentials:
+        print(f"no valid credentials parsed from: {path}", file=sys.stderr)
+        return 2
+
+    limit_accounts = max(1, int(args.limit_accounts or 1))
+    selected = credentials[:limit_accounts]
+
+    if args.json:
+        print(
+            json.dumps(
+                [
+                    {
+                        "line": item.line_number,
+                        "email": item.email if args.show_email else _redact_email(item.email),
+                        "client_id": item.client_id,
+                        "has_password": bool(item.password),
+                        "has_refresh_token": bool(item.refresh_token),
+                    }
+                    for item in selected
+                ],
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
+        return 0
+
+    print(f"parsed {len(credentials)} credential(s), testing {len(selected)}")
+    success = 0
+    for credential in selected:
+        if test_credential(
+            credential=credential,
+            mode=str(args.mode),
+            limit=max(1, int(args.message_limit or 1)),
+            timeout=max(1.0, float(args.timeout or 30)),
+            imap_host=str(args.imap_host),
+            include_preview=bool(args.preview),
+            show_email=bool(args.show_email),
+        ):
+            success += 1
+    print(f"summary: {success}/{len(selected)} account(s) readable")
+    return 0 if success == len(selected) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/register/mail_provider.py
+++ b/services/register/mail_provider.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 import hashlib
+import imaplib
 import json
 import random
 import re
 import string
 import time
 from datetime import datetime, timezone
-from email import message_from_string, policy
+from email import message_from_bytes, message_from_string, policy
+from email.header import decode_header, make_header
 from email.utils import parsedate_to_datetime
 from threading import Lock
 from typing import Any, Callable, TypeVar
@@ -19,6 +21,12 @@ from services.config import DATA_DIR
 
 DDG_ALIASES_FILE = DATA_DIR / "ddg_aliases.json"
 _ddg_aliases_lock = Lock()
+
+OUTLOOK_TOKEN_USED_FILE = DATA_DIR / "outlook_token_used.json"
+_outlook_token_state_lock = Lock()
+# in_use 超过该秒数视为陈旧（注册进程崩溃残留），可被重新领用
+OUTLOOK_IN_USE_STALE_SECONDS = 3600
+OUTLOOK_UNAVAILABLE_STATES = {"used", "token_invalid", "failed"}
 
 
 def _load_ddg_aliases() -> set[str]:
@@ -54,6 +62,127 @@ def _record_ddg_alias(address: str) -> None:
         used = _load_ddg_aliases()
         used.add(target)
         _save_ddg_aliases(used)
+
+
+def _load_outlook_token_state() -> dict[str, dict[str, Any]]:
+    """读取邮箱池状态文件，返回 {email_lower: {state, reason, updated_at}}。
+
+    兼容旧格式：纯字符串列表（历史的“已用邮箱”）会被解释为 used。
+    """
+    try:
+        if not OUTLOOK_TOKEN_USED_FILE.exists():
+            return {}
+        data = json.loads(OUTLOOK_TOKEN_USED_FILE.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    state: dict[str, dict[str, Any]] = {}
+    if isinstance(data, list):
+        for item in data:
+            key = str(item).strip().lower()
+            if key:
+                state[key] = {"state": "used", "reason": "", "updated_at": ""}
+    elif isinstance(data, dict):
+        for key, value in data.items():
+            email = str(key).strip().lower()
+            if not email:
+                continue
+            if isinstance(value, dict):
+                state[email] = {
+                    "state": str(value.get("state") or "used").strip() or "used",
+                    "reason": str(value.get("reason") or ""),
+                    "updated_at": str(value.get("updated_at") or ""),
+                }
+            else:
+                state[email] = {"state": str(value or "used").strip() or "used", "reason": "", "updated_at": ""}
+    return state
+
+
+def _save_outlook_token_state(state: dict[str, dict[str, Any]]) -> None:
+    OUTLOOK_TOKEN_USED_FILE.parent.mkdir(parents=True, exist_ok=True)
+    ordered = {key: state[key] for key in sorted(state)}
+    OUTLOOK_TOKEN_USED_FILE.write_text(json.dumps(ordered, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _outlook_entry_available(entry: dict[str, Any] | None) -> bool:
+    """该邮箱当前是否可领用：未记录、或 in_use 已陈旧、或非终态时可用。"""
+    if not isinstance(entry, dict):
+        return True
+    current = str(entry.get("state") or "")
+    if current in OUTLOOK_UNAVAILABLE_STATES:
+        return False
+    if current == "in_use":
+        updated_at = str(entry.get("updated_at") or "")
+        try:
+            ts = datetime.fromisoformat(updated_at)
+            age = (datetime.now(timezone.utc) - (ts if ts.tzinfo else ts.replace(tzinfo=timezone.utc))).total_seconds()
+            return age >= OUTLOOK_IN_USE_STALE_SECONDS
+        except Exception:
+            return True
+    return True
+
+
+def _set_outlook_token_state(address: str, state: str, reason: str = "") -> None:
+    target = str(address or "").strip().lower()
+    if not target:
+        return
+    with _outlook_token_state_lock:
+        store = _load_outlook_token_state()
+        store[target] = {"state": str(state), "reason": str(reason or ""), "updated_at": datetime.now(timezone.utc).isoformat()}
+        _save_outlook_token_state(store)
+
+
+def _release_outlook_token_state(address: str) -> None:
+    """把 in_use 释放回未使用（仅当当前确实是 in_use 时）。"""
+    target = str(address or "").strip().lower()
+    if not target:
+        return
+    with _outlook_token_state_lock:
+        store = _load_outlook_token_state()
+        entry = store.get(target)
+        if isinstance(entry, dict) and str(entry.get("state") or "") == "in_use":
+            store.pop(target, None)
+            _save_outlook_token_state(store)
+
+
+def reset_outlook_token_pool_state(scope: str = "all") -> int:
+    """重置邮箱池状态文件。
+
+    scope=all 清空所有记录；scope=failed 仅清除 failed/token_invalid/in_use（保留 used）。
+    返回被清除的条目数。
+    """
+    with _outlook_token_state_lock:
+        store = _load_outlook_token_state()
+        if not store:
+            return 0
+        if str(scope) == "failed":
+            remove = {key for key, value in store.items() if str(value.get("state") or "") in {"failed", "token_invalid", "in_use"}}
+            for key in remove:
+                store.pop(key, None)
+            _save_outlook_token_state(store)
+            return len(remove)
+        count = len(store)
+        _save_outlook_token_state({})
+        return count
+
+
+def outlook_token_pool_stats(pool: list[dict[str, str]] | None = None) -> dict[str, int]:
+    """统计邮箱池各状态数量。pool 为该 provider 当前导入的邮箱列表（用于算 unused）。"""
+    store = _load_outlook_token_state()
+    counts = {"unused": 0, "in_use": 0, "used": 0, "token_invalid": 0, "failed": 0}
+    if pool:
+        for credential in pool:
+            entry = store.get(str(credential.get("email") or "").strip().lower())
+            state = str(entry.get("state") or "") if isinstance(entry, dict) else ""
+            if state in counts:
+                counts[state] += 1
+            else:
+                counts["unused"] += 1
+    else:
+        for entry in store.values():
+            state = str(entry.get("state") or "") if isinstance(entry, dict) else ""
+            if state in counts:
+                counts[state] += 1
+    return counts
 
 
 ResultT = TypeVar("ResultT")
@@ -913,6 +1042,311 @@ class YydsMailProvider(BaseMailProvider):
         self.session.close()
 
 
+OUTLOOK_TOKEN_URL = "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+OUTLOOK_GRAPH_MESSAGES_URL = "https://graph.microsoft.com/v1.0/me/messages"
+OUTLOOK_GRAPH_SCOPE = "offline_access https://graph.microsoft.com/Mail.Read"
+OUTLOOK_IMAP_SCOPE = "offline_access https://outlook.office.com/IMAP.AccessAsUser.All"
+OUTLOOK_DEFAULT_IMAP_HOST = "outlook.office365.com"
+
+
+class OutlookTokenError(RuntimeError):
+    """refresh_token 换取 access_token 失败（凭据失效/权限不对），与“读邮件失败”区分。"""
+
+
+def _clean_outlook_value(value: str) -> str:
+    return str(value or "").replace("﻿", "").replace(" ", " ").strip()
+
+
+def parse_outlook_credentials(text: str) -> list[dict[str, str]]:
+    """解析邮箱池文本，每行格式：email----password----client_id----refresh_token。"""
+    credentials: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for raw_line in str(text or "").splitlines():
+        line = _clean_outlook_value(raw_line)
+        if not line or "----" not in line:
+            continue
+        parts = [_clean_outlook_value(part) for part in line.split("----", 3)]
+        if len(parts) != 4:
+            continue
+        email, password, client_id, refresh_token = parts
+        if "@" not in email or not client_id or not refresh_token:
+            continue
+        key = email.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        credentials.append({"email": email, "password": password, "client_id": client_id, "refresh_token": refresh_token})
+    return credentials
+
+
+def _normalize_outlook_pool(value: Any) -> list[dict[str, str]]:
+    """邮箱池既支持纯文本（每行一条），也支持已解析的对象列表。"""
+    if isinstance(value, str):
+        return parse_outlook_credentials(value)
+    if isinstance(value, list):
+        items: list[dict[str, str]] = []
+        for item in value:
+            if isinstance(item, str):
+                items.extend(parse_outlook_credentials(item))
+            elif isinstance(item, dict):
+                email = _clean_outlook_value(item.get("email") or item.get("address") or "")
+                client_id = _clean_outlook_value(item.get("client_id") or "")
+                refresh_token = _clean_outlook_value(item.get("refresh_token") or "")
+                if "@" in email and client_id and refresh_token:
+                    items.append({"email": email, "password": _clean_outlook_value(item.get("password") or ""), "client_id": client_id, "refresh_token": refresh_token})
+        return items
+    return []
+
+
+class OutlookTokenProvider(BaseMailProvider):
+    """使用 refresh_token 读取 Outlook/Hotmail 邮箱验证码。
+
+    邮箱池在应用配置里维护（mailboxes 字段，每行 email----password----client_id----refresh_token），
+    create_mailbox() 从池中取下一个未使用的邮箱，wait_for_code() 用 refresh_token 换取 access_token
+    后通过 Graph/IMAP 读取最新邮件。
+    """
+
+    name = "outlook_token"
+
+    def __init__(self, entry: dict, conf: dict):
+        super().__init__(conf, str(entry.get("provider_ref") or ""))
+        self.label = str(entry.get("label") or self.provider_ref)
+        self.pool = _normalize_outlook_pool(entry.get("mailboxes") or entry.get("pool"))
+        self.mode = str(entry.get("mode") or "graph").strip().lower() or "graph"
+        if self.mode not in {"graph", "imap", "auto"}:
+            self.mode = "graph"
+        self.imap_host = str(entry.get("imap_host") or OUTLOOK_DEFAULT_IMAP_HOST).strip() or OUTLOOK_DEFAULT_IMAP_HOST
+        self.message_limit = max(1, int(entry.get("message_limit") or 10))
+        self.session = _create_session(conf)
+
+    def close(self) -> None:
+        self.session.close()
+
+    def _exchange_refresh_token(self, client_id: str, refresh_token: str, scope: str) -> str:
+        resp = self.session.post(
+            OUTLOOK_TOKEN_URL,
+            data={"client_id": client_id, "grant_type": "refresh_token", "refresh_token": refresh_token, "scope": scope},
+            headers={"Content-Type": "application/x-www-form-urlencoded", "User-Agent": self.conf["user_agent"]},
+            timeout=self.conf["request_timeout"],
+            verify=False,
+        )
+        try:
+            data = resp.json()
+        except Exception:
+            data = {}
+        if resp.status_code != 200:
+            detail = data.get("error_description") or data.get("error") or resp.text[:300]
+            raise OutlookTokenError(f"OutlookToken 刷新失败: HTTP {resp.status_code}, {detail}")
+        access_token = str(data.get("access_token") or "").strip()
+        if not access_token:
+            raise OutlookTokenError("OutlookToken 刷新响应缺少 access_token")
+        return access_token
+
+    def _access_token(self, mailbox: dict[str, Any], client_id: str, refresh_token: str, scope: str) -> str:
+        """缓存 access_token 复用：避免 wait_for_code 轮询时每次都换 token 触发限流。"""
+        cache = mailbox.get("_outlook_token_cache")
+        if not isinstance(cache, dict):
+            cache = {}
+            mailbox["_outlook_token_cache"] = cache
+        cached = cache.get(scope)
+        if isinstance(cached, tuple) and len(cached) == 2 and time.monotonic() < cached[1]:
+            return str(cached[0])
+        token = self._exchange_refresh_token(client_id, refresh_token, scope)
+        cache[scope] = (token, time.monotonic() + 600)
+        return token
+
+    def create_mailbox(self, username: str | None = None) -> dict[str, Any]:
+        if not self.pool:
+            raise RuntimeError("OutlookToken 邮箱池为空，请在邮箱配置中导入 email----password----client_id----refresh_token")
+        with _outlook_token_state_lock:
+            store = _load_outlook_token_state()
+            credential = next((item for item in self.pool if _outlook_entry_available(store.get(item["email"].strip().lower()))), None)
+            if credential is None:
+                raise RuntimeError(f"[{self.label}] OutlookToken 邮箱池暂无可用邮箱（共 {len(self.pool)} 个，已用尽或全部占用/失效），请导入新邮箱或重置池状态")
+            store[credential["email"].strip().lower()] = {"state": "in_use", "reason": "", "updated_at": datetime.now(timezone.utc).isoformat()}
+            _save_outlook_token_state(store)
+        return {
+            "provider": self.name,
+            "provider_ref": self.provider_ref,
+            "address": credential["email"],
+            "label": self.label,
+            "client_id": credential["client_id"],
+            "refresh_token": credential["refresh_token"],
+        }
+
+    def _read_graph(self, access_token: str) -> list[dict[str, Any]]:
+        resp = self.session.get(
+            OUTLOOK_GRAPH_MESSAGES_URL,
+            headers={"Authorization": f"Bearer {access_token}", "Accept": "application/json", "User-Agent": self.conf["user_agent"]},
+            params={"$top": self.message_limit, "$orderby": "receivedDateTime desc", "$select": "subject,receivedDateTime,from,body,bodyPreview"},
+            timeout=self.conf["request_timeout"],
+            verify=False,
+        )
+        try:
+            data = resp.json()
+        except Exception:
+            data = {}
+        if resp.status_code != 200:
+            detail = data.get("error", {}).get("message") if isinstance(data.get("error"), dict) else resp.text[:300]
+            raise RuntimeError(f"OutlookToken Graph 失败: HTTP {resp.status_code}, {detail}")
+        items = data.get("value") if isinstance(data, dict) else None
+        return [item for item in items if isinstance(item, dict)] if isinstance(items, list) else []
+
+    @staticmethod
+    def _graph_sender(message: dict[str, Any]) -> str:
+        sender = message.get("from") or {}
+        if isinstance(sender, dict):
+            address = sender.get("emailAddress") or {}
+            if isinstance(address, dict):
+                return str(address.get("address") or address.get("name") or "")
+        return ""
+
+    def _normalize_graph_item(self, mailbox: dict[str, Any], item: dict[str, Any]) -> dict[str, Any]:
+        body = item.get("body") if isinstance(item.get("body"), dict) else {}
+        content_type = str(body.get("contentType") or "").lower()
+        content = str(body.get("content") or "")
+        text_content = content if content_type != "html" else str(item.get("bodyPreview") or "")
+        html_content = content if content_type == "html" else ""
+        return {
+            "provider": self.name,
+            "mailbox": mailbox["address"],
+            "message_id": str(item.get("id") or ""),
+            "subject": str(item.get("subject") or ""),
+            "sender": self._graph_sender(item),
+            "text_content": text_content,
+            "html_content": html_content,
+            "received_at": _parse_received_at(item.get("receivedDateTime")),
+            "raw": item,
+        }
+
+    def _graph_messages(self, mailbox: dict[str, Any], access_token: str) -> list[dict[str, Any]]:
+        """返回最近 N 封邮件（Graph 已按 receivedDateTime desc 排序，最新在前）。"""
+        return [self._normalize_graph_item(mailbox, item) for item in self._read_graph(access_token)]
+
+    def _imap_messages(self, mailbox: dict[str, Any], access_token: str) -> list[dict[str, Any]]:
+        """返回最近 N 封邮件，最新在前。"""
+        auth_string = f"user={mailbox['address']}\x01auth=Bearer {access_token}\x01\x01"
+        imap = imaplib.IMAP4_SSL(self.imap_host)
+        try:
+            imap.authenticate("XOAUTH2", lambda _: auth_string.encode("utf-8"))
+            status, _ = imap.select("INBOX", readonly=True)
+            if status != "OK":
+                raise RuntimeError("OutlookToken IMAP select INBOX 失败")
+            status, data = imap.uid("search", None, "ALL")
+            if status != "OK" or not data or not data[0]:
+                return []
+            uids = data[0].split()[-self.message_limit :]
+            messages: list[dict[str, Any]] = []
+            for uid in reversed(uids):  # 最新在前
+                status, fetched = imap.uid("fetch", uid, "(RFC822)")
+                if status != "OK":
+                    continue
+                raw_payload = next((part[1] for part in fetched if isinstance(part, tuple) and isinstance(part[1], bytes)), b"")
+                if raw_payload:
+                    messages.append(self._parse_imap_message(mailbox, raw_payload))
+            return messages
+        finally:
+            try:
+                imap.logout()
+            except Exception:
+                pass
+
+    def _parse_imap_message(self, mailbox: dict[str, Any], raw: bytes) -> dict[str, Any]:
+        message = message_from_bytes(raw, policy=policy.default)
+        try:
+            received = _parse_received_at(parsedate_to_datetime(str(message.get("Date") or "")))
+        except Exception:
+            received = None
+        plain: list[str] = []
+        html: list[str] = []
+        for part in (message.walk() if message.is_multipart() else [message]):
+            if part.get_content_maintype() == "multipart":
+                continue
+            try:
+                payload = part.get_content()
+            except Exception:
+                continue
+            if not payload:
+                continue
+            if part.get_content_type() == "text/html":
+                html.append(str(payload))
+            else:
+                plain.append(str(payload))
+
+        def _decode(value: str | None) -> str:
+            if not value:
+                return ""
+            try:
+                return str(make_header(decode_header(value)))
+            except Exception:
+                return value
+
+        return {
+            "provider": self.name,
+            "mailbox": mailbox["address"],
+            "message_id": _decode(str(message.get("Message-ID") or "")),
+            "subject": _decode(str(message.get("Subject") or "")),
+            "sender": _decode(str(message.get("From") or "")),
+            "text_content": "\n".join(plain).strip(),
+            "html_content": "\n".join(html).strip(),
+            "received_at": received,
+            "raw": None,
+        }
+
+    def fetch_recent_messages(self, mailbox: dict[str, Any]) -> list[dict[str, Any]]:
+        """拉取最近 N 封邮件（最新在前），供 wait_for_code 逐封扫描验证码。"""
+        client_id = str(mailbox.get("client_id") or "").strip()
+        refresh_token = str(mailbox.get("refresh_token") or "").strip()
+        if not client_id or not refresh_token:
+            raise RuntimeError("OutlookToken mailbox 缺少 client_id 或 refresh_token")
+        errors: list[str] = []
+        if self.mode in {"graph", "auto"}:
+            try:
+                access_token = self._access_token(mailbox, client_id, refresh_token, OUTLOOK_GRAPH_SCOPE)
+                return self._graph_messages(mailbox, access_token)
+            except Exception as error:
+                if self.mode == "graph":
+                    raise
+                errors.append(f"graph: {error}")
+        if self.mode in {"imap", "auto"}:
+            try:
+                access_token = self._access_token(mailbox, client_id, refresh_token, OUTLOOK_IMAP_SCOPE)
+                return self._imap_messages(mailbox, access_token)
+            except Exception as error:
+                if self.mode == "imap":
+                    raise
+                errors.append(f"imap: {error}")
+        if errors:
+            raise RuntimeError("; ".join(errors))
+        return []
+
+    def fetch_latest_message(self, mailbox: dict[str, Any]) -> dict[str, Any] | None:
+        messages = self.fetch_recent_messages(mailbox)
+        return messages[0] if messages else None
+
+    def wait_for_code(self, mailbox: dict[str, Any]) -> str | None:
+        """轮询时遍历最近 N 封邮件，逐封提取验证码，避免最新一封是广告/安全提醒时错过验证码。"""
+        seen_value = mailbox.setdefault("_seen_code_message_refs", [])
+        if not isinstance(seen_value, list):
+            seen_value = []
+            mailbox["_seen_code_message_refs"] = seen_value
+        seen_refs = {str(item) for item in seen_value}
+
+        deadline = time.monotonic() + self.conf["wait_timeout"]
+        while time.monotonic() < deadline:
+            for message in self.fetch_recent_messages(mailbox):
+                ref = _message_tracking_ref(message)
+                if ref in seen_refs:
+                    continue
+                code = _extract_code(message)
+                if code:
+                    seen_value.append(ref)
+                    return code
+                seen_refs.add(ref)
+            time.sleep(max(0.2, self.conf["wait_interval"]))
+        return None
+
+
 def _entries(mail_config: dict) -> list[dict]:
     result: list[dict] = []
     counters: dict[str, int] = {}
@@ -966,6 +1400,8 @@ def _create_provider(mail_config: dict, provider: str = "", provider_ref: str = 
         return InbucketMailProvider(entry, conf)
     if entry["type"] == "yyds_mail":
         return YydsMailProvider(entry, conf)
+    if entry["type"] == "outlook_token":
+        return OutlookTokenProvider(entry, conf)
     raise RuntimeError(f"不支持的 mail.provider: {entry['type']}")
 
 
@@ -997,6 +1433,34 @@ def wait_for_code(mail_config: dict, mailbox: dict) -> str | None:
         return provider.wait_for_code(mailbox)
     finally:
         provider.close()
+
+
+def mark_mailbox_result(mailbox: dict, *, success: bool, error: Exception | str | None = None) -> None:
+    """注册流程结束后更新邮箱池状态。
+
+    仅对 outlook_token 邮箱生效：成功标记 used；失败时若是 token 失效标记 token_invalid，
+    其余失败标记 failed（保留邮箱占用以便排查，可通过重置释放）。
+    """
+    if str(mailbox.get("provider") or "") != OutlookTokenProvider.name:
+        return
+    address = str(mailbox.get("address") or "").strip()
+    if not address:
+        return
+    if success:
+        _set_outlook_token_state(address, "used")
+        return
+    reason = str(error or "").strip()
+    if isinstance(error, OutlookTokenError) or "OutlookToken 刷新失败" in reason or "access_token" in reason:
+        _set_outlook_token_state(address, "token_invalid", reason[:300])
+    else:
+        _set_outlook_token_state(address, "failed", reason[:300])
+
+
+def release_mailbox(mailbox: dict) -> None:
+    """把 outlook_token 邮箱从 in_use 释放回未使用（用于流程主动放弃且未消费验证码时）。"""
+    if str(mailbox.get("provider") or "") != OutlookTokenProvider.name:
+        return
+    _release_outlook_token_state(str(mailbox.get("address") or ""))
 
 
 def get_existing_mailbox(mail_config: dict, email: str) -> dict:

--- a/services/register/mail_provider.py
+++ b/services/register/mail_provider.py
@@ -26,6 +26,7 @@ OUTLOOK_TOKEN_USED_FILE = DATA_DIR / "outlook_token_used.json"
 _outlook_token_state_lock = Lock()
 # in_use 超过该秒数视为陈旧（注册进程崩溃残留），可被重新领用
 OUTLOOK_IN_USE_STALE_SECONDS = 3600
+OUTLOOK_RECORDED_STATES = {"used", "in_use", "token_invalid", "failed"}
 OUTLOOK_UNAVAILABLE_STATES = {"used", "token_invalid", "failed"}
 
 
@@ -163,6 +164,23 @@ def reset_outlook_token_pool_state(scope: str = "all") -> int:
         count = len(store)
         _save_outlook_token_state({})
         return count
+
+
+def prune_outlook_unused_credentials(credentials: list[dict[str, str]]) -> tuple[list[dict[str, str]], int]:
+    """Return credentials with recorded state, plus the number pruned as unused."""
+    with _outlook_token_state_lock:
+        store = _load_outlook_token_state()
+    kept: list[dict[str, str]] = []
+    removed = 0
+    for credential in credentials:
+        key = str(credential.get("email") or "").strip().lower()
+        entry = store.get(key) if key else None
+        state = str(entry.get("state") or "") if isinstance(entry, dict) else ""
+        if state in OUTLOOK_RECORDED_STATES:
+            kept.append(credential)
+        else:
+            removed += 1
+    return kept, removed
 
 
 def outlook_token_pool_stats(pool: list[dict[str, str]] | None = None) -> dict[str, int]:

--- a/services/register/openai_register.py
+++ b/services/register/openai_register.py
@@ -203,6 +203,27 @@ def _is_cloudflare_challenge(resp) -> bool:
     )
 
 
+def _authorize_landed_page(resp) -> str:
+    """诊断用：粗判 authorize 之后落在哪个页面。返回 signup / login / "" 仅供日志。
+
+    注意：email-verification / email_otp_verification 在注册和登录流程里都会出现，
+    无法据此可靠区分，所以这里只用于打日志，绝不据此中断注册流程。
+    """
+    if resp is None:
+        return ""
+    final_url = str(getattr(resp, "url", "") or "").lower()
+    data = _response_json(resp)
+    page_type = ""
+    page = data.get("page") if isinstance(data, dict) else None
+    if isinstance(page, dict):
+        page_type = str(page.get("type") or "").lower()
+    if "create-account" in final_url or "signup" in final_url or "create_account" in page_type:
+        return "signup"
+    if "/log-in" in final_url or "/login" in final_url or page_type in {"login", "password_verification"}:
+        return "login"
+    return ""
+
+
 def create_mailbox(username: str | None = None) -> dict:
     return mail_provider.create_mailbox(config["mail"], username)
 
@@ -336,7 +357,10 @@ class PlatformRegistrar:
             "audience": platform_oauth_audience,
             "redirect_uri": platform_oauth_redirect_uri,
             "device_id": self.device_id,
-            "screen_hint": "login_or_signup",
+            # 注册流程显式声明 signup：throwaway 域名 OpenAI 会自动当新账号走注册，
+            # 但 @outlook.com/@hotmail.com 这类真实消费邮箱会被 login_or_signup 路由到登录分支，
+            # 后续 user/register 落在错误的 auth step 上报 invalid_auth_step。
+            "screen_hint": "signup",
             "max_age": "0",
             "login_hint": email,
             "scope": "openid profile email offline_access",
@@ -357,7 +381,10 @@ class PlatformRegistrar:
             debug = _response_debug_detail(resp)
             status = getattr(resp, "status_code", "unknown")
             raise RuntimeError(error or f"platform_authorize_http_{status}{detail}, {debug}")
-        step(index, "platform authorize 完成")
+        landed = _authorize_landed_page(resp)
+        # 仅打日志，不据此中断：authorize 落地页无法可靠区分注册/登录，
+        # 真正的判定交给 user/register（失败会 dump 完整响应）。
+        step(index, f"platform authorize 完成[{landed or '?'}] url={str(getattr(resp, 'url', '') or '')[:160]}")
 
     def _register_user(self, email: str, password: str, index: int) -> None:
         step(index, "开始提交注册密码")

--- a/services/register/openai_register.py
+++ b/services/register/openai_register.py
@@ -420,22 +420,28 @@ class PlatformRegistrar:
         mailbox = create_mailbox()
         email = str(mailbox.get("address") or "").strip()
         if not email:
+            mail_provider.release_mailbox(mailbox)
             raise RuntimeError("邮箱服务未返回 address")
         label = str(mailbox.get("label") or "")
         step(index, f"邮箱创建完成[{label}]: {email}")
-        password = _random_password()
-        first_name, last_name = _random_name()
-        self._platform_authorize(email, index)
-        self._register_user(email, password, index)
-        self._send_otp(index)
-        step(index, "开始等待注册验证码")
-        code = wait_for_code(mailbox)
-        if not code:
-            raise RuntimeError("等待注册验证码超时")
-        step(index, f"收到注册验证码: {code}")
-        self._validate_otp(code, index)
-        self._create_account(f"{first_name} {last_name}", _random_birthdate(), index)
-        tokens = self._exchange_registered_tokens(index)
+        try:
+            password = _random_password()
+            first_name, last_name = _random_name()
+            self._platform_authorize(email, index)
+            self._register_user(email, password, index)
+            self._send_otp(index)
+            step(index, "开始等待注册验证码")
+            code = wait_for_code(mailbox)
+            if not code:
+                raise RuntimeError("等待注册验证码超时")
+            step(index, f"收到注册验证码: {code}")
+            self._validate_otp(code, index)
+            self._create_account(f"{first_name} {last_name}", _random_birthdate(), index)
+            tokens = self._exchange_registered_tokens(index)
+        except Exception as error:
+            mail_provider.mark_mailbox_result(mailbox, success=False, error=error)
+            raise
+        mail_provider.mark_mailbox_result(mailbox, success=True)
         return {
             "email": email,
             "password": password,

--- a/services/register_service.py
+++ b/services/register_service.py
@@ -10,10 +10,26 @@ from pathlib import Path
 
 from services.account_service import account_service
 from services.config import DATA_DIR
-from services.register import openai_register
+from services.register import mail_provider, openai_register
 
 
 REGISTER_FILE = DATA_DIR / "register.json"
+
+
+def _serialize_outlook_pool(credentials: list[dict]) -> str:
+    return "\n".join(
+        f'{c["email"]}----{c.get("password", "")}----{c["client_id"]}----{c["refresh_token"]}' for c in credentials
+    )
+
+
+def _merge_outlook_pool(old_text: str, new_text: str) -> str:
+    """合并已存邮箱池与新导入文本，按邮箱去重，新导入的同名邮箱覆盖旧凭据。"""
+    merged: dict[str, dict] = {}
+    for credential in mail_provider.parse_outlook_credentials(old_text or ""):
+        merged[credential["email"].strip().lower()] = credential
+    for credential in mail_provider.parse_outlook_credentials(new_text or ""):
+        merged[credential["email"].strip().lower()] = credential
+    return _serialize_outlook_pool(list(merged.values()))
 
 
 def _now() -> str:
@@ -64,15 +80,67 @@ class RegisterService:
 
     def get(self) -> dict:
         with self._lock:
-            return json.loads(json.dumps({**self._config, "logs": self._logs[-300:]}, ensure_ascii=False))
+            snapshot = json.loads(json.dumps({**self._config, "logs": self._logs[-300:]}, ensure_ascii=False))
+        self._redact_outlook_pools(snapshot)
+        return snapshot
+
+    @staticmethod
+    def _mask_email(email: str) -> str:
+        local, sep, domain = str(email or "").partition("@")
+        if not sep:
+            return "***"
+        masked = (local[:2] + "***" + local[-1:]) if len(local) > 2 else (local[:1] + "***")
+        return f"{masked}@{domain}"
+
+    def _redact_outlook_pools(self, snapshot: dict) -> None:
+        """把 outlook_token 邮箱池里的密码/refresh_token 从对外输出中抹掉，仅保留脱敏预览与统计。
+
+        mailboxes 改为只写导入框（输出为空），避免把密码与 refresh_token 通过 GET/SSE 反复广播。
+        """
+        mail = snapshot.get("mail")
+        if not isinstance(mail, dict):
+            return
+        providers = mail.get("providers")
+        if not isinstance(providers, list):
+            return
+        for provider in providers:
+            if not isinstance(provider, dict) or provider.get("type") != "outlook_token":
+                continue
+            credentials = mail_provider.parse_outlook_credentials(str(provider.get("mailboxes") or ""))
+            provider["mailboxes"] = ""
+            provider["mailboxes_count"] = len(credentials)
+            provider["mailboxes_preview"] = [self._mask_email(c["email"]) for c in credentials]
+            provider["mailboxes_stats"] = mail_provider.outlook_token_pool_stats(credentials)
 
     def _inject_proxy_to_mail(self) -> None:
         proxy = str(self._config.get("proxy") or "").strip()
         if proxy and isinstance(self._config.get("mail"), dict):
             self._config["mail"]["proxy"] = proxy
 
+    def _merge_outlook_pools(self, updates: dict) -> None:
+        """对 outlook_token provider：把前端新导入的 mailboxes 与已存池按邮箱合并去重。
+
+        前端 mailboxes 是只写导入框，留空表示不改动；填入的新行追加/覆盖已存凭据。
+        按数组下标与已存的同类型 provider 对齐。
+        """
+        mail = updates.get("mail")
+        if not isinstance(mail, dict) or not isinstance(mail.get("providers"), list):
+            return
+        old_mail = self._config.get("mail") if isinstance(self._config.get("mail"), dict) else {}
+        old_providers = old_mail.get("providers") if isinstance(old_mail.get("providers"), list) else []
+        for index, provider in enumerate(mail["providers"]):
+            if not isinstance(provider, dict) or provider.get("type") != "outlook_token":
+                continue
+            old = old_providers[index] if index < len(old_providers) and isinstance(old_providers[index], dict) else {}
+            old_text = str(old.get("mailboxes") or "") if old.get("type") == "outlook_token" else ""
+            new_text = str(provider.get("mailboxes") or "")
+            provider["mailboxes"] = _merge_outlook_pool(old_text, new_text) if (old_text or new_text) else ""
+            for key in ("mailboxes_count", "mailboxes_preview", "mailboxes_stats"):
+                provider.pop(key, None)
+
     def update(self, updates: dict) -> dict:
         with self._lock:
+            self._merge_outlook_pools(updates)
             self._config = _normalize({**self._config, **updates})
             self._inject_proxy_to_mail()
             openai_register.config.update({k: self._config[k] for k in ("mail", "proxy", "total", "threads")})
@@ -115,6 +183,16 @@ class RegisterService:
                 openai_register.stats.update({"done": 0, "success": 0, "fail": 0, "start_time": 0.0})
             self._save()
             return self.get()
+
+    def reset_outlook_pool(self, scope: str = "all") -> dict:
+        scope = "failed" if str(scope) == "failed" else "all"
+        cleared = mail_provider.reset_outlook_token_pool_state(scope)
+        with self._lock:
+            self._append_log(
+                f"已重置 Outlook 邮箱池状态（范围={'仅失败/占用' if scope == 'failed' else '全部'}），清除 {cleared} 条记录",
+                "yellow",
+            )
+        return self.get()
 
     def _append_log(self, text: str, color: str = "") -> None:
         with self._lock:

--- a/services/register_service.py
+++ b/services/register_service.py
@@ -138,6 +138,26 @@ class RegisterService:
             for key in ("mailboxes_count", "mailboxes_preview", "mailboxes_stats"):
                 provider.pop(key, None)
 
+    def _prune_unused_outlook_pools(self) -> int:
+        mail = self._config.get("mail")
+        if not isinstance(mail, dict):
+            return 0
+        providers = mail.get("providers")
+        if not isinstance(providers, list):
+            return 0
+        total_removed = 0
+        for provider in providers:
+            if not isinstance(provider, dict) or provider.get("type") != "outlook_token":
+                continue
+            credentials = mail_provider.parse_outlook_credentials(str(provider.get("mailboxes") or ""))
+            kept, removed = mail_provider.prune_outlook_unused_credentials(credentials)
+            if removed:
+                provider["mailboxes"] = _serialize_outlook_pool(kept)
+                total_removed += removed
+            for key in ("mailboxes_count", "mailboxes_preview", "mailboxes_stats"):
+                provider.pop(key, None)
+        return total_removed
+
     def update(self, updates: dict) -> dict:
         with self._lock:
             self._merge_outlook_pools(updates)
@@ -185,6 +205,14 @@ class RegisterService:
             return self.get()
 
     def reset_outlook_pool(self, scope: str = "all") -> dict:
+        scope = str(scope or "all").strip().lower()
+        if scope == "unused":
+            with self._lock:
+                removed = self._prune_unused_outlook_pools()
+                openai_register.config.update({k: self._config[k] for k in ("mail", "proxy", "total", "threads")})
+                self._save()
+                self._append_log(f"已清空 Outlook 邮箱池未使用邮箱，移除 {removed} 个", "yellow")
+            return self.get()
         scope = "failed" if str(scope) == "failed" else "all"
         cleared = mail_provider.reset_outlook_token_pool_state(scope)
         with self._lock:

--- a/web/src/app/register/components/register-card.tsx
+++ b/web/src/app/register/components/register-card.tsx
@@ -308,9 +308,12 @@ export function RegisterCard() {
                           {preview.length ? (
                             <p className="text-xs text-stone-400">已保存邮箱（脱敏）：{preview.slice(0, 8).join("、")}{preview.length > 8 ? ` 等 ${preview.length} 个` : ""}</p>
                           ) : null}
-                          <div className="flex items-center gap-2">
+                          <div className="flex flex-wrap items-center gap-2">
                             <Button type="button" variant="outline" className="h-8 rounded-lg border-stone-200 bg-white px-3 text-xs text-stone-700" onClick={() => void resetOutlookPool("failed")} disabled={config.enabled}>
                               清除失败/占用状态
+                            </Button>
+                            <Button type="button" variant="outline" className="h-8 rounded-lg border-amber-200 bg-white px-3 text-xs text-amber-700 hover:bg-amber-50" onClick={() => { if (window.confirm("确定要从 Outlook 邮箱池中删除所有未使用邮箱吗？此操作会移除这些已保存凭据。")) void resetOutlookPool("unused"); }} disabled={config.enabled}>
+                              清空未使用
                             </Button>
                             <Button type="button" variant="outline" className="h-8 rounded-lg border-rose-200 bg-white px-3 text-xs text-rose-600 hover:bg-rose-50" onClick={() => { if (window.confirm("确定要重置整个 Outlook 邮箱池状态吗？所有邮箱会被标记为可重新使用。")) void resetOutlookPool("all"); }} disabled={config.enabled}>
                               重置全部状态

--- a/web/src/app/register/components/register-card.tsx
+++ b/web/src/app/register/components/register-card.tsx
@@ -29,6 +29,7 @@ export function RegisterCard() {
   const save = useSettingsStore((state) => state.saveRegister);
   const toggle = useSettingsStore((state) => state.toggleRegister);
   const reset = useSettingsStore((state) => state.resetRegister);
+  const resetOutlookPool = useSettingsStore((state) => state.resetOutlookPool);
 
   if (isLoading) {
     return (
@@ -56,6 +57,7 @@ export function RegisterCard() {
       ...(type === "gptmail" ? { api_key: "", default_domain: "" } : {}),
       ...(type === "yyds_mail" ? { api_base: "https://maliapi.215.im/v1", api_key: "", domain: [], subdomain: "", wildcard: false } : {}),
       ...(type === "ddg_mail" ? { ddg_token: "", cf_inbox_jwt: "", cf_domain: [], admin_password: "" } : {}),
+      ...(type === "outlook_token" ? { mailboxes: "", mode: "graph", imap_host: "outlook.office365.com", message_limit: 10 } : {}),
     });
   };
 
@@ -178,6 +180,7 @@ export function RegisterCard() {
                             <SelectItem value="gptmail">gptmail(未测试)</SelectItem>
                             <SelectItem value="yyds_mail">yyds_mail</SelectItem>
                             <SelectItem value="ddg_mail">ddg_mail (DDG邮箱+CF中转)</SelectItem>
+                            <SelectItem value="outlook_token">outlook_token (Outlook/Hotmail 邮箱池)</SelectItem>
                           </SelectContent>
                         </Select>
                       </div>
@@ -258,7 +261,65 @@ export function RegisterCard() {
                           </label>
                         </>
                       ) : null}
+                      {type === "outlook_token" ? (
+                        <>
+                          <div className="space-y-2">
+                            <label className="text-sm text-stone-700">读取方式</label>
+                            <Select value={String(provider.mode || "graph")} onValueChange={(value) => updateProvider(index, { mode: value })} disabled={config.enabled}>
+                              <SelectTrigger className="h-10 rounded-xl border-stone-200 bg-white">
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                <SelectItem value="graph">Graph API</SelectItem>
+                                <SelectItem value="imap">IMAP (XOAUTH2)</SelectItem>
+                                <SelectItem value="auto">自动 (Graph→IMAP)</SelectItem>
+                              </SelectContent>
+                            </Select>
+                          </div>
+                          {String(provider.mode || "graph") !== "graph" ? (
+                            <div className="space-y-2">
+                              <label className="text-sm text-stone-700">IMAP Host</label>
+                              <Input value={String(provider.imap_host || "outlook.office365.com")} onChange={(event) => updateProvider(index, { imap_host: event.target.value })} className="h-10 rounded-xl border-stone-200 bg-white" disabled={config.enabled} />
+                            </div>
+                          ) : null}
+                        </>
+                      ) : null}
                     </div>
+
+                    {type === "outlook_token" ? (() => {
+                      const stats = (provider.mailboxes_stats || {}) as Record<string, number>;
+                      const savedCount = Number(provider.mailboxes_count || 0);
+                      const preview = Array.isArray(provider.mailboxes_preview) ? (provider.mailboxes_preview as string[]) : [];
+                      const pendingCount = String(provider.mailboxes || "").split(/\r?\n/).filter((line) => line.includes("----") && line.split("----").length >= 4).length;
+                      return (
+                        <div className="space-y-2">
+                          <label className="flex items-center justify-between text-sm text-stone-700">
+                            <span>邮箱池导入 <span className="text-red-400">*</span></span>
+                            <span className="text-xs text-stone-400">已保存 {savedCount} 个{pendingCount ? ` · 待导入 ${pendingCount} 个` : ""}</span>
+                          </label>
+                          <Textarea value={String(provider.mailboxes || "")} onChange={(event) => updateProvider(index, { mailboxes: event.target.value })} placeholder={"每行一个邮箱，格式：\n邮箱----密码----client_id----refresh_token\n（出于安全，已保存的密码/refresh_token 不会回显；此处仅用于新增或覆盖）"} className="min-h-32 rounded-xl border-stone-200 bg-white font-mono text-xs" disabled={config.enabled} />
+                          <div className="flex flex-wrap items-center gap-1.5 text-xs">
+                            <span className="rounded-md bg-stone-100 px-2 py-1 text-stone-600">未使用 {stats.unused ?? 0}</span>
+                            <span className="rounded-md bg-blue-50 px-2 py-1 text-blue-600">占用中 {stats.in_use ?? 0}</span>
+                            <span className="rounded-md bg-emerald-50 px-2 py-1 text-emerald-700">已用 {stats.used ?? 0}</span>
+                            <span className="rounded-md bg-amber-50 px-2 py-1 text-amber-700">token失效 {stats.token_invalid ?? 0}</span>
+                            <span className="rounded-md bg-rose-50 px-2 py-1 text-rose-600">失败 {stats.failed ?? 0}</span>
+                          </div>
+                          {preview.length ? (
+                            <p className="text-xs text-stone-400">已保存邮箱（脱敏）：{preview.slice(0, 8).join("、")}{preview.length > 8 ? ` 等 ${preview.length} 个` : ""}</p>
+                          ) : null}
+                          <div className="flex items-center gap-2">
+                            <Button type="button" variant="outline" className="h-8 rounded-lg border-stone-200 bg-white px-3 text-xs text-stone-700" onClick={() => void resetOutlookPool("failed")} disabled={config.enabled}>
+                              清除失败/占用状态
+                            </Button>
+                            <Button type="button" variant="outline" className="h-8 rounded-lg border-rose-200 bg-white px-3 text-xs text-rose-600 hover:bg-rose-50" onClick={() => { if (window.confirm("确定要重置整个 Outlook 邮箱池状态吗？所有邮箱会被标记为可重新使用。")) void resetOutlookPool("all"); }} disabled={config.enabled}>
+                              重置全部状态
+                            </Button>
+                          </div>
+                          <p className="text-xs text-stone-500">每个邮箱仅成功注册一次（状态记录在 data/outlook_token_used.json）。失败的邮箱会被标记原因，可用上方按钮释放后重试。</p>
+                        </div>
+                      );
+                    })() : null}
 
                     {type === "cloudmail_gen" || type === "tempmail_lol" || type === "cloudflare_temp_email" || type === "moemail" || type === "inbucket" || type === "yyds_mail" || type === "ddg_mail" ? (
                       <div className="space-y-2">

--- a/web/src/app/settings/store.ts
+++ b/web/src/app/settings/store.ts
@@ -245,7 +245,7 @@ type SettingsStore = {
   saveRegister: () => Promise<void>;
   toggleRegister: () => Promise<void>;
   resetRegister: () => Promise<void>;
-  resetOutlookPool: (scope: "all" | "failed") => Promise<void>;
+  resetOutlookPool: (scope: "all" | "failed" | "unused") => Promise<void>;
 
   loadPools: (silent?: boolean) => Promise<void>;
   openAddDialog: () => void;
@@ -830,7 +830,7 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
     try {
       const data = await resetOutlookPoolApi(scope);
       set({ registerConfig: data.register });
-      toast.success(scope === "failed" ? "已清除失败/占用的邮箱状态" : "Outlook 邮箱池状态已全部重置");
+      toast.success(scope === "unused" ? "已清空未使用邮箱" : scope === "failed" ? "已清除失败/占用的邮箱状态" : "Outlook 邮箱池状态已全部重置");
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "重置邮箱池状态失败");
     } finally {

--- a/web/src/app/settings/store.ts
+++ b/web/src/app/settings/store.ts
@@ -12,6 +12,7 @@ import {
   fetchBackups,
   fetchRegisterConfig,
   resetRegister as resetRegisterApi,
+  resetOutlookPool as resetOutlookPoolApi,
   fetchSettingsConfig,
   runBackupNow,
   syncImageStorage,
@@ -244,6 +245,7 @@ type SettingsStore = {
   saveRegister: () => Promise<void>;
   toggleRegister: () => Promise<void>;
   resetRegister: () => Promise<void>;
+  resetOutlookPool: (scope: "all" | "failed") => Promise<void>;
 
   loadPools: (silent?: boolean) => Promise<void>;
   openAddDialog: () => void;
@@ -818,6 +820,19 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
       toast.success("注册统计已重置");
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "重置注册统计失败");
+    } finally {
+      set({ isSavingRegister: false });
+    }
+  },
+
+  resetOutlookPool: async (scope) => {
+    set({ isSavingRegister: true });
+    try {
+      const data = await resetOutlookPoolApi(scope);
+      set({ registerConfig: data.register });
+      toast.success(scope === "failed" ? "已清除失败/占用的邮箱状态" : "Outlook 邮箱池状态已全部重置");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "重置邮箱池状态失败");
     } finally {
       set({ isSavingRegister: false });
     }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -705,7 +705,7 @@ export async function resetRegister() {
   return httpRequest<{ register: RegisterConfig }>("/api/register/reset", { method: "POST" });
 }
 
-export async function resetOutlookPool(scope: "all" | "failed" = "all") {
+export async function resetOutlookPool(scope: "all" | "failed" | "unused" = "all") {
   return httpRequest<{ register: RegisterConfig }>("/api/register/outlook-pool/reset", {
     method: "POST",
     body: { scope },

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -262,6 +262,14 @@ export type UserKey = {
   last_used_at: string | null;
 };
 
+export type OutlookPoolStats = {
+  unused: number;
+  in_use: number;
+  used: number;
+  token_invalid: number;
+  failed: number;
+};
+
 export type RegisterConfig = {
   enabled: boolean;
   mail: {
@@ -695,6 +703,13 @@ export async function stopRegister() {
 
 export async function resetRegister() {
   return httpRequest<{ register: RegisterConfig }>("/api/register/reset", { method: "POST" });
+}
+
+export async function resetOutlookPool(scope: "all" | "failed" = "all") {
+  return httpRequest<{ register: RegisterConfig }>("/api/register/outlook-pool/reset", {
+    method: "POST",
+    body: { scope },
+  });
 }
 
 // ── CPA (CLIProxyAPI) ──────────────────────────────────────────────


### PR DESCRIPTION
本次 Outlook/Hotmail 邮箱注册兼容方案由 @lihuazou-gulie 实现，并已在实际部署环境完成测试。

主要改动：
- 新增 outlook_token 邮箱提供器，支持导入 email----password----client_id----refresh_token
- 支持使用 Outlook/Hotmail refresh_token 获取 access_token
- 支持通过 IMAP XOAUTH2 读取 Outlook 收件箱验证码
- 新增 Outlook 邮箱池状态管理：未使用、占用中、已使用、token失效、失败
- 前端注册配置页支持 Outlook 邮箱池导入、状态展示、Graph/IMAP 模式配置
- 修复真实 Outlook 邮箱注册时被 login_or_signup 路由到登录分支，导致 invalid_auth_step 的问题
- 增加 authorize 落点日志，方便排查注册流程
- 新增清空未使用邮箱功能，方便移除异常或不想继续使用的 Outlook 邮箱
- 新增 Outlook refresh_token 邮箱读取测试脚本

验证情况：
- 已验证 refresh_token 可以成功刷新 access_token
- 已验证 IMAP XOAUTH2 可以登录 Outlook 并读取收件箱
- 已验证 Outlook 注册流程可以进入正确 signup 分支
- 已完成前端构建和后端语法检查