### PR TITLE
fix: add trailing slashes to all routes to match Next.js trailingSlash config

### DIFF
--- a/web/src/app/accounts/components/account-import-dialog.tsx
+++ b/web/src/app/accounts/components/account-import-dialog.tsx
@@ -725,7 +725,7 @@ export function AccountImportDialog({ disabled, onImported }: AccountImportDialo
           onClick={() => {
             setOpen(false);
             resetState();
-            router.push("/settings");
+            router.push("/settings/");
           }}
         />
         <MethodCard
@@ -735,7 +735,7 @@ export function AccountImportDialog({ disabled, onImported }: AccountImportDialo
           onClick={() => {
             setOpen(false);
             resetState();
-            router.push("/settings");
+            router.push("/settings/");
           }}
         />
       </div>

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -17,7 +17,7 @@ export default function HomePage() {
       if (!active) {
         return;
       }
-      router.replace(session ? getDefaultRouteForRole(session.role) : "/login");
+      router.replace(session ? getDefaultRouteForRole(session.role) : "/login/");
     };
 
     void redirect();

--- a/web/src/components/top-nav.tsx
+++ b/web/src/components/top-nav.tsx
@@ -16,16 +16,16 @@ import { cn } from "@/lib/utils";
 import { clearStoredAuthSession, type StoredAuthSession } from "@/store/auth";
 
 const adminNavItems = [
-  { href: "/image", label: "生图" },
-  { href: "/accounts", label: "号池管理" },
-  { href: "/register", label: "注册机" },
-  { href: "/image-manager", label: "图片管理" },
-  { href: "/logs", label: "日志管理" },
-  { href: "/debug", label: "调试" },
-  { href: "/settings", label: "设置" },
+  { href: "/image/", label: "生图" },
+  { href: "/accounts/", label: "号池管理" },
+  { href: "/register/", label: "注册机" },
+  { href: "/image-manager/", label: "图片管理" },
+  { href: "/logs/", label: "日志管理" },
+  { href: "/debug/", label: "调试" },
+  { href: "/settings/", label: "设置" },
 ];
 
-const userNavItems = [{ href: "/image", label: "画图" }];
+const userNavItems = [{ href: "/image/", label: "画图" }];
 
 function buildThirdPartyHref(appUrl: string, baseUrl: string, apiKey: string) {
   const url = appUrl.trim();
@@ -50,7 +50,7 @@ export function TopNav() {
     let active = true;
 
     const load = async () => {
-      if (pathname === "/login") {
+      if (pathname === "/login/") {
         if (!active) {
           return;
         }
@@ -101,10 +101,10 @@ export function TopNav() {
 
   const handleLogout = async () => {
     await clearStoredAuthSession();
-    router.replace("/login");
+    router.replace("/login/");
   };
 
-  if (pathname === "/login" || session === undefined || !session) {
+  if (pathname === "/login/" || session === undefined || !session) {
     return null;
   }
 
@@ -182,7 +182,7 @@ export function TopNav() {
               </SheetContent>
             </Sheet>
             <Link
-              href="/image"
+              href="/image/"
               className="shrink-0 py-1 text-[15px] font-bold tracking-tight text-stone-950 transition hover:text-stone-700 dark:text-stone-50 dark:hover:text-white"
             >
               chatgpt2api

--- a/web/src/lib/request.ts
+++ b/web/src/lib/request.ts
@@ -52,9 +52,9 @@ request.interceptors.response.use(
         const shouldRedirect = (error.config as RequestConfig | undefined)?.redirectOnUnauthorized !== false;
         if (status === 401 && shouldRedirect && typeof window !== "undefined") {
             // Avoid redirect loop — only redirect if not already on /login
-            if (!window.location.pathname.startsWith("/login")) {
+            if (!window.location.pathname.startsWith("/login/")) {
                 await clearStoredAuthSession();
-                window.location.replace("/login");
+                window.location.replace("/login/");
                 // Return a never-resolving promise to prevent further error handling
                 // while the browser navigates away
                 return new Promise(() => {});

--- a/web/src/lib/use-auth-guard.ts
+++ b/web/src/lib/use-auth-guard.ts
@@ -34,7 +34,7 @@ export function useAuthGuard(allowedRoles?: AuthRole[]): UseAuthGuardResult {
       if (!storedSession) {
         setSession(null);
         setIsCheckingAuth(false);
-        router.replace("/login");
+        router.replace("/login/");
         return;
       }
 

--- a/web/src/store/auth.ts
+++ b/web/src/store/auth.ts
@@ -40,7 +40,7 @@ function normalizeSession(value: unknown, fallbackKey = ""): StoredAuthSession |
 }
 
 export function getDefaultRouteForRole(role: AuthRole) {
-  return role === "admin" ? "/accounts" : "/image";
+  return role === "admin" ? "/accounts/" : "/image/";
 }
 
 export async function getStoredAuthKey() {


### PR DESCRIPTION
## Summary

Fixes routing issues caused by mismatch between Next.js `trailingSlash: true` config and route paths in code.

## Problem

The `next.config.ts` has `trailingSlash: true` enabled, which means Next.js generates all routes with trailing slashes (`/accounts/`, `/login/`, etc.). However, the code was referencing routes without trailing slashes (`/accounts`, `/login`).

This mismatch caused:
- 🐛 404 errors during page navigation
- 🐛 Broken pathname comparisons (e.g., `pathname === "/login"` always returns false)
- 🐛 Incorrect navigation menu highlighting
- 🐛 Failed redirects in auth guards and HTTP interceptors

## Changes

- ✅ Added trailing slashes to all navigation menu `href` attributes
- ✅ Updated all `router.push()` and `router.replace()` calls
- ✅ Fixed pathname comparison logic in auth guards
- ✅ Updated redirect paths in HTTP 401 interceptor
- ✅ Fixed default route generation for different user roles

## Files Changed

- `web/src/app/accounts/components/account-import-dialog.tsx`
- `web/src/app/page.tsx`
- `web/src/components/top-nav.tsx`
- `web/src/lib/request.ts`
- `web/src/lib/use-auth-guard.ts`
- `web/src/store/auth.ts`

## Test Plan

- [x] Navigation between pages works without 404 errors
- [x] Login redirect works correctly
- [x] 401 auto-redirect to login page works
- [x] Active navigation item highlighting works
- [x] User role-based default routes work (admin → `/accounts/`, user → `/image/`)
