### PR TITLE
fix(register): add configurable mail proxy & fix CloudMailGen stale token timeout

### DIFF
--- a/services/register/mail_provider.py
+++ b/services/register/mail_provider.py
@@ -329,7 +329,7 @@ def _extract_text_candidates(value: Any) -> list[str]:
 def _message_matches_email(data: dict[str, Any], email: str) -> bool:
     target = str(email or "").strip().lower()
     candidates: list[str] = []
-    for key in ("to", "mailTo", "receiver", "receivers", "address", "email", "envelope_to"):
+    for key in ("to", "toEmail", "mailTo", "receiver", "receivers", "address", "email", "envelope_to"):
         if key in data:
             candidates.extend(_extract_text_candidates(data.get(key)))
     return not target or not candidates or any(target in str(item).strip().lower() for item in candidates if str(item).strip())
@@ -578,6 +578,10 @@ class DDGMailProvider(BaseMailProvider):
         self.session.close()
 
 
+class _NonRetryableCloudMailGenError(RuntimeError):
+    pass
+
+
 class CloudMailGenProvider(BaseMailProvider):
     name = "cloudmail_gen"
 
@@ -591,6 +595,10 @@ class CloudMailGenProvider(BaseMailProvider):
         self.email_prefix = str(entry.get("email_prefix") or "").strip()
         self.session = _create_session(conf)
 
+    @staticmethod
+    def _is_retryable_status(status_code: int) -> bool:
+        return status_code == 429 or status_code >= 500
+
     def _request(
         self,
         method: str,
@@ -600,22 +608,36 @@ class CloudMailGenProvider(BaseMailProvider):
         payload: dict | None = None,
         expected: tuple[int, ...] = (200,),
     ):
-        resp = self.session.request(
-            method.upper(),
-            f"{self.api_base}{path}",
-            headers={
-                "Content-Type": "application/json",
-                "User-Agent": self.conf["user_agent"],
-                **(headers or {}),
-            },
-            params=params,
-            json=payload,
-            timeout=self.conf["request_timeout"],
-            verify=False,
-        )
-        if resp.status_code not in expected:
-            raise RuntimeError(f"CloudMailGen 请求失败: {method} {path}, HTTP {resp.status_code}, body={resp.text[:300]}")
-        return {} if resp.status_code == 204 else resp.json()
+        last_error = ""
+        attempts = 3
+        for attempt in range(attempts):
+            try:
+                resp = self.session.request(
+                    method.upper(),
+                    f"{self.api_base}{path}",
+                    headers={
+                        "Content-Type": "application/json",
+                        "User-Agent": self.conf["user_agent"],
+                        **(headers or {}),
+                    },
+                    params=params,
+                    json=payload,
+                    timeout=self.conf["request_timeout"],
+                    verify=False,
+                )
+                if resp.status_code in expected:
+                    return {} if resp.status_code == 204 else resp.json()
+                message = f"CloudMailGen 请求失败: {method} {path}, HTTP {resp.status_code}, body={resp.text[:300]}"
+                if not self._is_retryable_status(int(resp.status_code)):
+                    raise _NonRetryableCloudMailGenError(message)
+                last_error = message
+            except _NonRetryableCloudMailGenError as error:
+                raise RuntimeError(str(error)) from error
+            except Exception as error:
+                last_error = f"CloudMailGen 请求异常: {method} {path}, error={error}"
+            if attempt < attempts - 1:
+                time.sleep(0.5 * (attempt + 1))
+        raise RuntimeError(last_error or f"CloudMailGen 请求失败: {method} {path}")
 
     def _cache_key(self) -> str:
         return f"{self.api_base}|{self.admin_email}"
@@ -681,13 +703,13 @@ class CloudMailGenProvider(BaseMailProvider):
         return {
             "provider": self.name,
             "mailbox": address,
-            "message_id": str(item.get("id") or item.get("_id") or item.get("messageId") or ""),
+            "message_id": str(item.get("id") or item.get("_id") or item.get("messageId") or item.get("emailId") or ""),
             "subject": str(item.get("subject") or ""),
-            "sender": str(item.get("from") or item.get("sender") or ""),
+            "sender": str(item.get("from") or item.get("sender") or item.get("sendEmail") or ""),
             "text_content": text_content,
             "html_content": html_content,
             "received_at": _parse_received_at(
-                item.get("createdAt") or item.get("created_at") or item.get("receivedAt") or item.get("date") or item.get("timestamp")
+                item.get("createdAt") or item.get("created_at") or item.get("createTime") or item.get("receivedAt") or item.get("date") or item.get("timestamp")
             ),
             "to": item.get("to") or item.get("toEmail") or item.get("mailTo"),
             "raw": item,

--- a/services/register/mail_provider.py
+++ b/services/register/mail_provider.py
@@ -595,6 +595,10 @@ class CloudMailGenProvider(BaseMailProvider):
         self.email_prefix = str(entry.get("email_prefix") or "").strip()
         self.session = _create_session(conf)
 
+    def _clear_token_cache(self) -> None:
+        with cloudmail_token_lock:
+            cloudmail_token_cache.pop(self._cache_key(), None)
+
     @staticmethod
     def _is_retryable_status(status_code: int) -> bool:
         return status_code == 429 or status_code >= 500
@@ -642,6 +646,21 @@ class CloudMailGenProvider(BaseMailProvider):
     def _cache_key(self) -> str:
         return f"{self.api_base}|{self.admin_email}"
 
+    @staticmethod
+    def _is_success_payload(data: Any) -> bool:
+        return isinstance(data, dict) and data.get("code") == 200
+
+    def _fetch_email_list(self, token: str, address: str) -> dict:
+        data = self._request(
+            "POST",
+            "/api/public/emailList",
+            headers={"Authorization": token},
+            payload={"toEmail": address, "size": 20, "timeSort": "desc"},
+        )
+        if not isinstance(data, dict):
+            raise RuntimeError(f"CloudMailGen emailList 返回异常: {data}")
+        return data
+
     def _get_token(self) -> str:
         if not self.admin_email or not self.admin_password:
             raise RuntimeError("CloudMailGen 缺少 admin_email 或 admin_password")
@@ -688,13 +707,14 @@ class CloudMailGenProvider(BaseMailProvider):
         if not address:
             raise RuntimeError("CloudMailGen 缺少 address")
         token = self._get_token()
-        data = self._request(
-            "POST",
-            "/api/public/emailList",
-            headers={"Authorization": token},
-            payload={"toEmail": address, "size": 20, "timeSort": "desc"},
-        )
-        items = (data.get("data") or []) if isinstance(data, dict) and data.get("code") == 200 else []
+        data = self._fetch_email_list(token, address)
+        if not self._is_success_payload(data):
+            self._clear_token_cache()
+            token = self._get_token()
+            data = self._fetch_email_list(token, address)
+        if not self._is_success_payload(data):
+            raise RuntimeError(f"CloudMailGen emailList 返回异常: {data}")
+        items = data.get("data") or []
         messages = [item for item in items if isinstance(item, dict) and _message_matches_email(item, address)]
         if not messages:
             return None

--- a/services/register/openai_register.py
+++ b/services/register/openai_register.py
@@ -26,6 +26,7 @@ config = {
         "request_timeout": 30,
         "wait_timeout": 30,
         "wait_interval": 2,
+        "api_use_register_proxy": True,
         "providers": [],
     },
     "proxy": "",
@@ -210,8 +211,24 @@ def _is_cloudflare_challenge(resp) -> bool:
     )
 
 
-def _mail_config() -> dict:
-    return {**config["mail"], "proxy": config["proxy"]}
+def _truthy(value: object, fallback: bool = True) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return fallback
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "on"}:
+        return True
+    if text in {"0", "false", "no", "off"}:
+        return False
+    return fallback
+
+
+def _mail_config(register_proxy: str = "") -> dict:
+    mail = config["mail"] if isinstance(config.get("mail"), dict) else {}
+    use_register_proxy = _truthy(mail.get("api_use_register_proxy"), True)
+    proxy = str(register_proxy or "").strip() if use_register_proxy else ""
+    return {**mail, "api_use_register_proxy": use_register_proxy, "proxy": proxy}
 
 
 def _authorize_landed_page(resp) -> str:
@@ -235,12 +252,12 @@ def _authorize_landed_page(resp) -> str:
     return ""
 
 
-def create_mailbox(username: str | None = None) -> dict:
-    return mail_provider.create_mailbox(_mail_config(), username)
+def create_mailbox(username: str | None = None, register_proxy: str = "") -> dict:
+    return mail_provider.create_mailbox(_mail_config(register_proxy), username)
 
 
-def wait_for_code(mailbox: dict) -> str | None:
-    return mail_provider.wait_for_code(_mail_config(), mailbox)
+def wait_for_code(mailbox: dict, register_proxy: str = "") -> str | None:
+    return mail_provider.wait_for_code(_mail_config(register_proxy), mailbox)
 
 
 from utils.sentinel import SentinelTokenGenerator, build_sentinel_token as _build_sentinel_token_tuple  # noqa: F401
@@ -569,7 +586,7 @@ class PlatformRegistrar:
 
     def register(self, index: int) -> dict:
         step(index, "开始创建邮箱")
-        mailbox = create_mailbox()
+        mailbox = create_mailbox(register_proxy=self.proxy)
         email = str(mailbox.get("address") or "").strip()
         if not email:
             mail_provider.release_mailbox(mailbox)
@@ -583,7 +600,7 @@ class PlatformRegistrar:
             self._register_user(email, password, index)
             self._send_otp(index)
             step(index, "开始等待注册验证码")
-            code = wait_for_code(mailbox)
+            code = wait_for_code(mailbox, register_proxy=self.proxy)
             if not code:
                 raise RuntimeError("等待注册验证码超时")
             step(index, f"收到注册验证码: {code}")

--- a/services/register_service.py
+++ b/services/register_service.py
@@ -40,6 +40,19 @@ def _default_config() -> dict:
     return {**openai_register.config, "mode": "total", "target_quota": 100, "target_available": 10, "check_interval": 5, "enabled": False, "stats": {"success": 0, "fail": 0, "done": 0, "running": 0, "threads": openai_register.config["threads"], "elapsed_seconds": 0, "avg_seconds": 0, "success_rate": 0, "current_quota": 0, "current_available": 0}}
 
 
+def _safe_bool(value: object, fallback: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return fallback
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "on"}:
+        return True
+    if text in {"0", "false", "no", "off"}:
+        return False
+    return fallback
+
+
 def _normalize(raw: dict) -> dict:
     cfg = _default_config()
     cfg.update({k: v for k, v in raw.items() if k not in {"stats", "logs"}})
@@ -50,8 +63,11 @@ def _normalize(raw: dict) -> dict:
     cfg["target_available"] = max(1, int(cfg.get("target_available") or 1))
     cfg["check_interval"] = max(1, int(cfg.get("check_interval") or 5))
     cfg["proxy"] = str(cfg.get("proxy") or "").strip()
-    if isinstance(cfg.get("mail"), dict):
-        cfg["mail"].pop("proxy", None)
+    default_mail = _default_config()["mail"] if isinstance(_default_config().get("mail"), dict) else {}
+    mail = cfg.get("mail") if isinstance(cfg.get("mail"), dict) else {}
+    cfg["mail"] = {**default_mail, **mail}
+    cfg["mail"]["api_use_register_proxy"] = _safe_bool(cfg["mail"].get("api_use_register_proxy"), True)
+    cfg["mail"].pop("proxy", None)
     cfg["enabled"] = bool(cfg.get("enabled"))
     stats = {**_default_config()["stats"], **(raw.get("stats") if isinstance(raw.get("stats"), dict) else {}),
              "threads": cfg["threads"]}

--- a/test/test_register_mail_proxy.py
+++ b/test/test_register_mail_proxy.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import unittest
+import copy
+from datetime import datetime
+from unittest.mock import patch
+
+from services.register import mail_provider, openai_register
+
+
+class FakeSession:
+    def __init__(self, responses=None, **kwargs):
+        self.kwargs = kwargs
+        self.responses = list(responses or [])
+        self.closed = False
+        self.calls = []
+
+    def request(self, method, url, **kwargs):
+        self.calls.append({"method": method, "url": url, **kwargs})
+        item = self.responses.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    def close(self):
+        self.closed = True
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code=200, text=""):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = text or str(payload)
+
+    def json(self):
+        return self._payload
+
+
+def cloudmail_entry() -> dict:
+    return {
+        "enable": True,
+        "type": "cloudmail_gen",
+        "api_base": "https://mail.example",
+        "admin_email": "admin@example.com",
+        "admin_password": "secret",
+        "domain": ["example.com"],
+    }
+
+
+class RegisterMailProxyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.original_config = {
+            "mail": copy.deepcopy(openai_register.config.get("mail")),
+            "proxy": openai_register.config.get("proxy"),
+        }
+        mail_provider.cloudmail_token_cache.clear()
+
+    def tearDown(self) -> None:
+        openai_register.config["mail"] = self.original_config["mail"]
+        openai_register.config["proxy"] = self.original_config["proxy"]
+        mail_provider.cloudmail_token_cache.clear()
+
+    def test_mail_api_uses_register_proxy_when_enabled(self) -> None:
+        openai_register.config["proxy"] = "http://register.example:8080"
+        openai_register.config["mail"] = {
+            "api_use_register_proxy": True,
+            "providers": [cloudmail_entry()],
+        }
+
+        self.assertEqual(openai_register._mail_config("http://worker.example:9000")["proxy"], "http://worker.example:9000")
+
+    def test_mail_api_uses_direct_connection_when_disabled(self) -> None:
+        openai_register.config["proxy"] = "http://register.example:8080"
+        openai_register.config["mail"] = {
+            "api_use_register_proxy": False,
+            "providers": [cloudmail_entry()],
+        }
+
+        self.assertEqual(openai_register._mail_config("http://worker.example:9000")["proxy"], "")
+
+    def test_provider_session_receives_no_proxy_when_disabled(self) -> None:
+        openai_register.config["mail"] = {
+            "api_use_register_proxy": False,
+            "providers": [cloudmail_entry()],
+        }
+        created: list[FakeSession] = []
+
+        def session_factory(**kwargs):
+            session = FakeSession(**kwargs)
+            created.append(session)
+            return session
+
+        with patch.object(mail_provider.requests, "Session", side_effect=session_factory):
+            mailbox = openai_register.create_mailbox(register_proxy="http://worker.example:9000")
+
+        self.assertEqual(mailbox["provider"], "cloudmail_gen")
+        self.assertEqual(len(created), 1)
+        self.assertNotIn("proxy", created[0].kwargs)
+
+    def test_cloudmail_gen_parses_current_field_names_and_retries_transient_errors(self) -> None:
+        responses = [
+            RuntimeError("temporary tls failure"),
+            RuntimeError("temporary empty response"),
+            FakeResponse({"code": 200, "data": {"token": "mail-token"}}),
+            FakeResponse(
+                {
+                    "code": 200,
+                    "data": [
+                        {
+                            "emailId": "mail-1",
+                            "toEmail": "user@example.com",
+                            "sendEmail": "noreply@example.com",
+                            "subject": "OpenAI verification",
+                            "text": "Verification code: 123456",
+                            "createTime": "2026-06-15T01:02:03Z",
+                        }
+                    ],
+                }
+            ),
+        ]
+        session = FakeSession(responses=responses)
+
+        with patch.object(mail_provider, "_create_session", return_value=session), patch.object(mail_provider.time, "sleep", return_value=None):
+            provider = mail_provider.CloudMailGenProvider(cloudmail_entry(), mail_provider._config({"proxy": ""}))
+            message = provider.fetch_latest_message({"address": "user@example.com"})
+
+        self.assertIsNotNone(message)
+        assert message is not None
+        self.assertEqual(message["message_id"], "mail-1")
+        self.assertEqual(message["sender"], "noreply@example.com")
+        self.assertEqual(message["text_content"], "Verification code: 123456")
+        self.assertIsInstance(message["received_at"], datetime)
+        self.assertEqual(len(session.calls), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_register_mail_proxy.py
+++ b/test/test_register_mail_proxy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import unittest
 import copy
+import time
 from datetime import datetime
 from unittest.mock import patch
 
@@ -131,6 +132,41 @@ class RegisterMailProxyTests(unittest.TestCase):
         self.assertEqual(message["text_content"], "Verification code: 123456")
         self.assertIsInstance(message["received_at"], datetime)
         self.assertEqual(len(session.calls), 4)
+
+    def test_cloudmail_gen_refreshes_cached_token_when_email_list_rejects_it(self) -> None:
+        entry = cloudmail_entry()
+        cache_key = f"{entry['api_base']}|{entry['admin_email']}"
+        mail_provider.cloudmail_token_cache[cache_key] = ("stale-token", time.time() + 3600)
+        responses = [
+            FakeResponse({"code": 401, "message": "invalid token"}),
+            FakeResponse({"code": 200, "data": {"token": "fresh-token"}}),
+            FakeResponse(
+                {
+                    "code": 200,
+                    "data": [
+                        {
+                            "emailId": "mail-2",
+                            "toEmail": "user@example.com",
+                            "subject": "OpenAI verification",
+                            "text": "Verification code: 654321",
+                        }
+                    ],
+                }
+            ),
+        ]
+        session = FakeSession(responses=responses)
+
+        with patch.object(mail_provider, "_create_session", return_value=session), patch.object(mail_provider.time, "sleep", return_value=None):
+            provider = mail_provider.CloudMailGenProvider(entry, mail_provider._config({"proxy": ""}))
+            message = provider.fetch_latest_message({"address": "user@example.com"})
+
+        self.assertIsNotNone(message)
+        assert message is not None
+        self.assertEqual(message["message_id"], "mail-2")
+        self.assertEqual(mail_provider._extract_code(message), "654321")
+        self.assertEqual(len(session.calls), 3)
+        self.assertEqual(session.calls[0]["headers"]["Authorization"], "stale-token")
+        self.assertEqual(session.calls[2]["headers"]["Authorization"], "fresh-token")
 
 
 if __name__ == "__main__":

--- a/web/src/app/register/components/register-card.tsx
+++ b/web/src/app/register/components/register-card.tsx
@@ -23,6 +23,7 @@ export function RegisterCard() {
   const setTargetAvailable = useSettingsStore((state) => state.setRegisterTargetAvailable);
   const setCheckInterval = useSettingsStore((state) => state.setRegisterCheckInterval);
   const setMailField = useSettingsStore((state) => state.setRegisterMailField);
+  const setMailApiUseRegisterProxy = useSettingsStore((state) => state.setRegisterMailApiUseRegisterProxy);
   const addProvider = useSettingsStore((state) => state.addRegisterProvider);
   const updateProvider = useSettingsStore((state) => state.updateRegisterProvider);
   const deleteProvider = useSettingsStore((state) => state.deleteRegisterProvider);
@@ -150,6 +151,14 @@ export function RegisterCard() {
                 <Input value={String(config.mail.wait_interval || "")} onChange={(event) => setMailField("wait_interval", event.target.value)} className="h-10 rounded-xl border-stone-200 bg-white" disabled={config.enabled} />
               </div>
             </div>
+
+            <label className="flex items-start gap-3 rounded-xl border border-stone-200 bg-white px-3 py-2 text-sm text-stone-700">
+              <Checkbox checked={config.mail.api_use_register_proxy !== false} onCheckedChange={(checked) => setMailApiUseRegisterProxy(Boolean(checked))} disabled={config.enabled} />
+              <span className="space-y-1">
+                <span className="block font-medium text-stone-800">邮箱服务后台 API 使用注册代理</span>
+                <span className="block text-xs leading-5 text-stone-500">关闭后邮箱平台 API 直连，注册 OpenAI/Auth0 请求仍使用注册代理。</span>
+              </span>
+            </label>
 
             <div className="space-y-3">
               {providers.map((provider, index) => {

--- a/web/src/app/settings/store.ts
+++ b/web/src/app/settings/store.ts
@@ -117,7 +117,7 @@ function normalizeProxyRuntime(value: unknown): ProxyRuntimeSettings {
 
 function normalizeThirdPartyApps(value: unknown): ThirdPartyAppsSettings {
   const source = typeof value === "object" && value !== null ? value as Partial<ThirdPartyAppsSettings> : {};
-  const canvas = typeof source.infinite_canvas === "object" && source.infinite_canvas
+  const canvas: Partial<ThirdPartyAppsSettings["infinite_canvas"]> = typeof source.infinite_canvas === "object" && source.infinite_canvas
     ? source.infinite_canvas
     : {};
   return {
@@ -334,6 +334,7 @@ type SettingsStore = {
   setRegisterTargetAvailable: (value: string) => void;
   setRegisterCheckInterval: (value: string) => void;
   setRegisterMailField: (key: "request_timeout" | "wait_timeout" | "wait_interval", value: string) => void;
+  setRegisterMailApiUseRegisterProxy: (value: boolean) => void;
   addRegisterProvider: () => void;
   updateRegisterProvider: (index: number, updates: Record<string, unknown>) => void;
   deleteRegisterProvider: (index: number) => void;
@@ -927,6 +928,15 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
       registerConfig: {
         ...state.registerConfig,
         mail: { ...state.registerConfig.mail, [key]: Number(value) || 0 },
+      },
+    } : {});
+  },
+
+  setRegisterMailApiUseRegisterProxy: (value) => {
+    set((state) => state.registerConfig ? {
+      registerConfig: {
+        ...state.registerConfig,
+        mail: { ...state.registerConfig.mail, api_use_register_proxy: value },
       },
     } : {});
   },

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -331,6 +331,7 @@ export type RegisterConfig = {
     request_timeout: number;
     wait_timeout: number;
     wait_interval: number;
+    api_use_register_proxy: boolean;
     providers: Array<Record<string, unknown>>;
   };
   proxy: string;


### PR DESCRIPTION
## Summary
- Add a `mail.api_use_register_proxy` setting for registration mail providers. It defaults to `true`, so existing behavior is preserved.
- When disabled, mail provider backend API calls use a direct connection while OpenAI/Auth0 registration requests still use the registration proxy.
- Harden CloudMailGen compatibility for current response fields: `toEmail`, `emailId`, `createTime`, and `sendEmail`.
- Add short retries for transient CloudMailGen request failures, `429`, and `5xx` responses.
- Refresh stale CloudMailGen cached tokens: if `emailList` returns a business-level failure, clear the cached token, call `genToken` again, retry once, and raise a clear provider error if it still fails.
<img width="1053" height="308" alt="1781481389660_d" src="https://github.com/user-attachments/assets/b2e9071e-38e5-4a73-bf14-013182beb1dc" />

## Why
Some deployments use registration proxies that are valid for OpenAI/Auth0 but unreliable for mail provider backend APIs. This makes that coupling explicit and configurable without changing the default behavior.

The CloudMailGen timeout was not directly caused by low memory. The failure pattern is more consistent with long-running process state: CloudMailGen tokens are cached in memory, and a stale token can make `emailList` return HTTP 200 with a business error payload. The old code treated that response as an empty inbox, so registration kept polling until the verification-code wait timeout even though the email had already arrived. Restarting the service temporarily fixed it because the in-memory token cache was cleared.

This change makes that state failure explicit: invalidate the stale token, get a fresh token, retry `emailList`, and fail loudly if the provider still rejects the request.

## Tests
- `python -m py_compile services/register/mail_provider.py services/register/openai_register.py services/register_service.py api/register.py`
- `python -m unittest test.test_register_mail_proxy`
- `cd web && npx tsc --noEmit && npm run build`

The regression tests cover the stale-token path: cached token fails on the first `emailList` call, `genToken` returns a fresh token, and the second `emailList` call returns the verification email.