### PR TITLE
Fix CloudMail registration flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ dist/
 wheels/
 *.egg-info
 web_dist
+node_modules/
+web/node_modules/
 # Virtual environments
 .venv
 .idea

--- a/api/register.py
+++ b/api/register.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 
-from fastapi import APIRouter, Header
+from fastapi import APIRouter, Body, Header
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
@@ -40,8 +40,13 @@ def create_router() -> APIRouter:
         return {"register": register_service.update(body.model_dump(exclude_none=True))}
 
     @router.post("/api/register/start")
-    async def start_register(authorization: str | None = Header(default=None)):
+    async def start_register(
+        body: RegisterConfigRequest | None = Body(default=None),
+        authorization: str | None = Header(default=None),
+    ):
         require_admin(authorization)
+        if body is not None:
+            register_service.update(body.model_dump(exclude_none=True))
         return {"register": register_service.start()}
 
     @router.post("/api/register/stop")

--- a/api/register.py
+++ b/api/register.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 
-from fastapi import APIRouter, Body, Header
+from fastapi import APIRouter, Body, Header, HTTPException
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
@@ -20,10 +20,16 @@ class RegisterConfigRequest(BaseModel):
     target_quota: int | None = None
     target_available: int | None = None
     check_interval: int | None = None
+    otp_resend: str | None = None
+    otp_resend_delay: int | None = None
 
 
 class OutlookPoolResetRequest(BaseModel):
     scope: str | None = None
+
+
+class RegisterPresetRequest(RegisterConfigRequest):
+    pass
 
 
 def create_router() -> APIRouter:
@@ -63,6 +69,27 @@ def create_router() -> APIRouter:
     async def reset_outlook_pool(body: OutlookPoolResetRequest, authorization: str | None = Header(default=None)):
         require_admin(authorization)
         return {"register": register_service.reset_outlook_pool(body.scope or "all")}
+
+    @router.get("/api/register/presets")
+    async def list_register_presets(authorization: str | None = Header(default=None)):
+        require_admin(authorization)
+        return register_service.list_presets()
+
+    @router.post("/api/register/presets/{name}")
+    async def save_register_preset(name: str, body: RegisterPresetRequest, authorization: str | None = Header(default=None)):
+        require_admin(authorization)
+        try:
+            return register_service.save_preset(name, body.model_dump(exclude_none=True))
+        except ValueError as error:
+            raise HTTPException(status_code=400, detail=str(error)) from error
+
+    @router.post("/api/register/presets/{name}/apply")
+    async def apply_register_preset(name: str, authorization: str | None = Header(default=None)):
+        require_admin(authorization)
+        try:
+            return {"register": register_service.apply_preset(name)}
+        except ValueError as error:
+            raise HTTPException(status_code=404, detail=str(error)) from error
 
     @router.get("/api/register/events")
     async def register_events(token: str = ""):

--- a/docs/cloudmail-registration-status.md
+++ b/docs/cloudmail-registration-status.md
@@ -1,0 +1,89 @@
+# CloudMail Registration Status
+
+## Current Result
+
+CloudMail-based OpenAI registration is now working in both deployment modes that were tested:
+
+- VPS mode: the running `chatgpt2api-warp` container uses CloudMail and completed a real `total=5, threads=1` registration batch.
+- Local mode: the local API service completed a real registration using the local OpenAI proxy while leaving CloudMail direct.
+
+The latest VPS batch finished with:
+
+- Total: 5
+- Threads: 1
+- Success: 5
+- Fail: 0
+- Success rate: 100%
+- Average time: 18.8 seconds/account
+- Active VPS register config: `total=5`, `threads=1`, `proxy=""`
+
+## Root Cause
+
+The previous `cloudmail_gen` provider only generated an email address string. It did not create/register that address in CloudMail before OpenAI sent the OTP.
+
+For already-existing CloudMail addresses this could work, which made manual tests look healthy. Fresh random addresses used by batch registration often had no CloudMail account state, so CloudMail returned raw count `0` and the registration timed out while waiting for the OTP.
+
+## Implemented Fixes
+
+- `cloudmail_gen` now logs in to CloudMail via `/api/login` and calls `/api/account/add` before returning a generated mailbox.
+- Duplicate CloudMail addresses (`code=501`, already registered) are treated as usable instead of fatal.
+- CloudMail recipient matching now checks recipient fields such as `toEmail`, `toName`, and `emailId`, and does not treat sender fields as recipients.
+- CloudMail wait timeouts include diagnostic counts and recent message metadata.
+- OpenAI registration flow records useful debug snippets for `user/register`, `email-otp/send`, and `email-otp/resend`.
+- `/api/register/start` accepts an optional config body and applies it before launching, so UI/API starts use the latest `total`, `threads`, proxy, and mail settings.
+- The frontend now sends the current register config when starting registration.
+- The OpenAI register proxy no longer automatically forces CloudMail traffic through the same proxy. CloudMail is direct by default unless `mail.proxy` or provider-level `proxy` is explicitly set.
+
+## Local And VPS Config
+
+Sensitive runtime config is stored only under ignored `data/` paths and is not committed.
+
+Local files created:
+
+- `data/register.json`: active local config
+- `data/register.local.json`: local preset with `proxy=http://127.0.0.1:10808`
+- `data/register.vps.json`: VPS preset with `proxy=""`
+
+VPS files created inside the container:
+
+- `/app/data/register.json`: active VPS config
+- `/app/data/register.local.json`: local preset copy
+- `/app/data/register.vps.json`: VPS preset copy
+
+## Verification Commands
+
+Relevant checks run successfully:
+
+```bash
+uv run python -m unittest test.test_register_proxy_runtime
+uv run python -m py_compile api/register.py services/register/mail_provider.py services/register/openai_register.py scripts/test_cloudmail.py scripts/test_openai_delivery.py
+```
+
+VPS production-style verification:
+
+```bash
+POST /api/register/start
+body: {"total":5,"threads":1,"mode":"total"}
+```
+
+Observed VPS result:
+
+```json
+{"enabled":false,"total":5,"threads":1,"proxy":"","success":5,"fail":0,"done":5,"success_rate":100.0,"avg_seconds":18.8,"current_available":10,"current_quota":244}
+```
+
+## Diagnostic Scripts
+
+Two helper scripts were added:
+
+- `scripts/test_cloudmail.py`: checks CloudMail token generation, recent messages, recipient matching, and raw inbox visibility.
+- `scripts/test_openai_delivery.py`: runs a one-shot OpenAI delivery or registration probe using the production registration flow.
+
+Both scripts can read `data/register.json`, or accept CloudMail parameters via CLI flags for temporary environments.
+
+## Operational Notes
+
+- Keep batch sizes modest while observing domain and IP reputation. The verified baseline is `total=5, threads=1`.
+- For local runs, set the OpenAI register proxy to the local browser/system proxy if direct auth requests return `unsupported_country_region_territory`.
+- Do not commit files under `data/`; they contain runtime credentials, account state, and generated accounts.
+- If CloudMail OTP timeouts return `cloudmail_raw=0`, first verify that `/api/account/add` is still succeeding for fresh addresses.

--- a/scripts/test_cloudmail.py
+++ b/scripts/test_cloudmail.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""CloudMail receiving diagnostics.
+
+This script talks directly to CloudMail public APIs:
+  - /api/public/genToken
+  - /api/public/emailList
+
+Use it to separate two very different failure modes:
+  1. raw emailList returns 0 items: the message did not reach CloudMail.
+  2. raw emailList has items, filtered count is 0: our recipient matching is wrong.
+
+Credentials are read from data/register.json's first cloudmail_gen provider unless
+overridden on the command line.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import string
+import time
+from pathlib import Path
+from typing import Any
+
+from curl_cffi import requests  # noqa: E402
+
+
+REGISTER_JSON = Path(__file__).resolve().parents[1] / "data" / "register.json"
+
+
+def _load_cloudmail_entry() -> dict[str, Any]:
+    try:
+        config = json.loads(REGISTER_JSON.read_text(encoding="utf-8"))
+    except Exception as error:
+        print(f"[warn] Cannot read {REGISTER_JSON}: {error}")
+        return {}
+    providers = (config.get("mail") or {}).get("providers") or []
+    for item in providers:
+        if isinstance(item, dict) and item.get("type") == "cloudmail_gen":
+            return item
+    print("[warn] No cloudmail_gen provider found in data/register.json")
+    return {}
+
+
+def _session(proxy: str):
+    kwargs: dict[str, Any] = {"impersonate": "chrome", "verify": False}
+    if proxy:
+        kwargs["proxy"] = proxy
+    return requests.Session(**kwargs)
+
+
+def _gen_token(session, api_base: str, admin_email: str, admin_password: str) -> str:
+    resp = session.post(
+        f"{api_base}/api/public/genToken",
+        json={"email": admin_email, "password": admin_password},
+        headers={"Content-Type": "application/json"},
+        timeout=30,
+    )
+    data = resp.json() if resp.text else {}
+    if not (isinstance(data, dict) and data.get("code") == 200):
+        raise RuntimeError(f"genToken failed: HTTP {resp.status_code}, body={resp.text[:300]}")
+    token = str((data.get("data") or {}).get("token") or "").strip()
+    if not token:
+        raise RuntimeError(f"genToken response missing token: {data}")
+    return token
+
+
+def _email_list(session, api_base: str, token: str, address: str = "", size: int = 20) -> list[dict[str, Any]]:
+    payload: dict[str, Any] = {"size": size, "timeSort": "desc"}
+    if address:
+        payload["toEmail"] = address
+    resp = session.post(
+        f"{api_base}/api/public/emailList",
+        json=payload,
+        headers={"Content-Type": "application/json", "Authorization": token},
+        timeout=30,
+    )
+    data = resp.json() if resp.text else {}
+    if not (isinstance(data, dict) and data.get("code") == 200):
+        raise RuntimeError(f"emailList failed: HTTP {resp.status_code}, body={resp.text[:300]}")
+    items = data.get("data") or []
+    return [item for item in items if isinstance(item, dict)]
+
+
+def _field(item: dict[str, Any], *names: str) -> str:
+    for name in names:
+        value = item.get(name)
+        if value is not None:
+            return str(value)
+    return ""
+
+
+def _extract_text_candidates(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, dict):
+        out: list[str] = []
+        for key in ("address", "email", "name", "value"):
+            if value.get(key):
+                out.extend(_extract_text_candidates(value.get(key)))
+        return out
+    if isinstance(value, list):
+        out: list[str] = []
+        for item in value:
+            out.extend(_extract_text_candidates(item))
+        return out
+    return []
+
+
+def _message_matches_email(data: dict[str, Any], email: str) -> bool:
+    target = str(email or "").strip().lower()
+    candidates: list[str] = []
+    for key in ("to", "toEmail", "toName", "mailTo", "receiver", "receivers", "address", "email", "envelope_to"):
+        if key in data:
+            candidates.extend(_extract_text_candidates(data.get(key)))
+    return not target or not candidates or any(target in str(item).strip().lower() for item in candidates if str(item).strip())
+
+
+def _print_item(index: int, item: dict[str, Any], address: str = "") -> None:
+    to_email = _field(item, "toEmail", "to", "mailTo", "recipient")
+    sender = _field(item, "sendEmail", "from", "sender", "source")
+    subject = _field(item, "subject")
+    created = _field(item, "createTime", "createdAt", "created_at", "receivedAt", "date", "timestamp")
+    email_id = _field(item, "emailId", "id", "_id", "messageId")
+    verdict = ""
+    if address:
+        verdict = " match" if _message_matches_email(item, address) else " filtered"
+    print(f"  {index}. id={email_id} to={to_email} from={sender} subject={subject[:90]}{verdict}")
+    if created:
+        print(f"     time={created}")
+
+
+def _summarize(items: list[dict[str, Any]], address: str) -> None:
+    print(f"[info] raw emailList count: {len(items)}")
+    if not items:
+        print("[result] Raw count is 0. The message did not reach CloudMail for this address.")
+        print("[hint] Focus on OpenAI delivery, domain routing/catch-all, sender reputation, or request fingerprint.")
+        return
+
+    matched = [item for item in items if _message_matches_email(item, address)]
+    print(f"[info] matched by _message_matches_email: {len(matched)}")
+    for index, item in enumerate(items[:8], start=1):
+        _print_item(index, item, address)
+    if not matched:
+        print("[result] Raw messages exist but our filter rejected them. Fix recipient matching.")
+    else:
+        print("[result] CloudMail receiving and current recipient matching both work.")
+
+
+def _random_address(domain: str, prefix: str = "") -> str:
+    local = "".join(random.choices(string.ascii_lowercase + string.digits, k=10))
+    if prefix:
+        local = f"{prefix}_{local}"
+    return f"{local}@{domain}"
+
+
+def _domain_from_entry(entry: dict[str, Any], fallback: str) -> str:
+    domains = entry.get("domain") if isinstance(entry.get("domain"), list) else []
+    domains = [str(item).strip() for item in domains if str(item).strip()]
+    return fallback or (domains[0] if domains else "mail.fxo.me")
+
+
+def _global_search(items: list[dict[str, Any]], terms: list[str]) -> list[dict[str, Any]]:
+    lowered_terms = [term.strip().lower() for term in terms if term.strip()]
+    if not lowered_terms:
+        return items
+    result: list[dict[str, Any]] = []
+    fields = ("sendEmail", "sendName", "subject", "toEmail", "toName", "text", "content", "html", "raw")
+    for item in items:
+        haystack = " ".join(str(item.get(field) or "") for field in fields).lower()
+        if any(term in haystack for term in lowered_terms):
+            result.append(item)
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="CloudMail receive diagnostics")
+    parser.add_argument("--address", default="", help="Recipient address to query")
+    parser.add_argument("--probe", action="store_true", help="Generate an address and wait for a manual test email")
+    parser.add_argument("--global-search", action="store_true", help="Search recent global CloudMail messages")
+    parser.add_argument("--terms", default="openai,verification,verify,otp", help="Comma-separated terms for --global-search")
+    parser.add_argument("--api-base", default="", help="Override CloudMail base URL")
+    parser.add_argument("--admin-email", default="", help="Override CloudMail admin email")
+    parser.add_argument("--admin-password", default="", help="Override CloudMail admin password")
+    parser.add_argument("--domain", default="", help="Domain to use with --probe")
+    parser.add_argument("--prefix", default="", help="Local-part prefix to use with --probe")
+    parser.add_argument("--proxy", default="", help="Proxy URL, for example http://127.0.0.1:7890")
+    parser.add_argument("--timeout", type=int, default=120, help="Polling timeout for --probe/--address")
+    parser.add_argument("--interval", type=float, default=5.0, help="Polling interval in seconds")
+    parser.add_argument("--size", type=int, default=100, help="emailList page size")
+    parser.add_argument("--once", action="store_true", help="Query once instead of polling for --address")
+    args = parser.parse_args()
+
+    entry = _load_cloudmail_entry()
+    api_base = (args.api_base or entry.get("api_base") or "").rstrip("/")
+    admin_email = args.admin_email or entry.get("admin_email") or ""
+    admin_password = args.admin_password or entry.get("admin_password") or ""
+    proxy = args.proxy or str(entry.get("proxy") or "")
+
+    if not api_base or not admin_email or not admin_password:
+        print("[error] Missing api_base/admin_email/admin_password. Pass flags or configure data/register.json.")
+        return 2
+
+    session = _session(proxy)
+    try:
+        token = _gen_token(session, api_base, admin_email, admin_password)
+    except Exception as error:
+        print(f"[error] {error}")
+        return 1
+    print(f"[info] genToken ok: {token[:8]}...")
+
+    if args.global_search:
+        try:
+            items = _email_list(session, api_base, token, size=max(1, args.size))
+        except Exception as error:
+            print(f"[error] {error}")
+            return 1
+        terms = [term for term in args.terms.split(",")]
+        matches = _global_search(items, terms)
+        print(f"[info] global recent count: {len(items)}")
+        print(f"[info] global matches for {terms}: {len(matches)}")
+        for index, item in enumerate(matches[:20], start=1):
+            _print_item(index, item)
+        return 0
+
+    address = args.address.strip()
+    if args.probe:
+        domain = _domain_from_entry(entry, args.domain.strip())
+        address = _random_address(domain, args.prefix.strip())
+        print(f"[info] probe address: {address}")
+        print("[action] Send any test email to this address now. Polling CloudMail...")
+
+    if not address:
+        print("[error] Use --address, --probe, or --global-search.")
+        return 2
+
+    deadline = time.time() + max(1, args.timeout)
+    while True:
+        try:
+            items = _email_list(session, api_base, token, address=address, size=max(1, args.size))
+        except Exception as error:
+            print(f"[error] {error}")
+            return 1
+        if items or args.once:
+            _summarize(items, address)
+            return 0 if items else 1
+        remaining = int(deadline - time.time())
+        if remaining <= 0:
+            _summarize([], address)
+            return 1
+        print(f"[info] no messages yet for {address}; {remaining}s remaining")
+        time.sleep(max(0.2, args.interval))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_openai_delivery.py
+++ b/scripts/test_openai_delivery.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""One-shot OpenAI signup delivery probe.
+
+It reuses the production registration flow, but lets us switch the OAuth entry
+between the current Platform client and ChatGPT web's NextAuth/OpenAI client.
+The goal is to verify whether CloudMail delivery depends on the OAuth client.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from services.register import openai_register  # noqa: E402
+from services.register.mail_provider import create_mailbox, release_mailbox, wait_for_code  # noqa: E402
+
+
+REGISTER_JSON = Path(__file__).resolve().parents[1] / "data" / "register.json"
+
+CHATGPT_CLIENT_ID = "app_X8zY6vW2pQ9tR3dE7nK1jL5gH"
+CHATGPT_REDIRECT_URI = "https://chatgpt.com/api/auth/callback/openai"
+
+
+def _load_config(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if "mail" not in data:
+        raise RuntimeError(f"{path} does not contain mail config")
+    return data
+
+
+def _config_from_args(args: argparse.Namespace) -> dict:
+    domains = [item.strip() for item in str(args.domain or "").split(",") if item.strip()]
+    if not (args.api_base and args.admin_email and args.admin_password and domains):
+        missing = [
+            name
+            for name, value in (
+                ("--api-base", args.api_base),
+                ("--admin-email", args.admin_email),
+                ("--admin-password", args.admin_password),
+                ("--domain", domains),
+            )
+            if not value
+        ]
+        raise RuntimeError(f"missing CloudMail flags: {', '.join(missing)}")
+    return {
+        "mail": {
+            "request_timeout": 30,
+            "wait_timeout": args.wait_timeout or 120,
+            "wait_interval": 3,
+            "providers": [
+                {
+                    "enable": True,
+                    "type": "cloudmail_gen",
+                    "api_base": args.api_base.rstrip("/"),
+                    "admin_email": args.admin_email,
+                    "admin_password": args.admin_password,
+                    "domain": domains,
+                    "subdomain": [],
+                    "email_prefix": args.email_prefix or "",
+                }
+            ],
+        },
+        "proxy": args.proxy or "",
+    }
+
+
+def _use_chatgpt_entry() -> None:
+    openai_register.platform_base = "https://chatgpt.com"
+    openai_register.platform_oauth_client_id = CHATGPT_CLIENT_ID
+    openai_register.platform_oauth_redirect_uri = CHATGPT_REDIRECT_URI
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Probe OpenAI signup delivery to CloudMail")
+    parser.add_argument("--entry", choices=("platform", "chatgpt"), default="platform")
+    parser.add_argument("--proxy", default=None)
+    parser.add_argument("--mail-proxy", default=None)
+    parser.add_argument("--email-prefix", default=None)
+    parser.add_argument("--username", default=None, help="Force CloudMail local-part for the generated mailbox")
+    parser.add_argument("--wait-timeout", type=int, default=None)
+    parser.add_argument("--passwordless-probe", action="store_true")
+    parser.add_argument("--register-json", default=str(REGISTER_JSON), help="Path to register.json")
+    parser.add_argument("--api-base", default="", help="CloudMail base URL; allows running without register.json")
+    parser.add_argument("--admin-email", default="", help="CloudMail admin email; allows running without register.json")
+    parser.add_argument("--admin-password", default="", help="CloudMail admin password; allows running without register.json")
+    parser.add_argument("--domain", default="", help="Comma-separated CloudMail domains; allows running without register.json")
+    args = parser.parse_args()
+
+    if args.api_base or args.admin_email or args.admin_password or args.domain:
+        cfg = _config_from_args(args)
+    else:
+        cfg = _load_config(Path(args.register_json))
+    mail = cfg["mail"]
+    selected_proxy = cfg.get("proxy", "") if args.proxy is None else args.proxy
+    if args.email_prefix is not None:
+        for provider in mail.get("providers") or []:
+            if isinstance(provider, dict) and provider.get("type") == "cloudmail_gen":
+                provider["email_prefix"] = args.email_prefix
+    if args.wait_timeout is not None:
+        mail["wait_timeout"] = args.wait_timeout
+
+    mail_config = dict(mail)
+    if args.mail_proxy is not None:
+        mail_config["proxy"] = args.mail_proxy
+    openai_register.config.update(
+        {
+            "mail": mail_config,
+            "proxy": selected_proxy,
+            "total": 1,
+            "threads": 1,
+        }
+    )
+    if args.entry == "chatgpt":
+        _use_chatgpt_entry()
+
+    print(f"[info] entry={args.entry}")
+    print(f"[info] client_id={openai_register.platform_oauth_client_id}")
+    print(f"[info] redirect_uri={openai_register.platform_oauth_redirect_uri}")
+    registrar = openai_register.PlatformRegistrar(openai_register.config.get("proxy", ""))
+    try:
+        if args.passwordless_probe:
+            mailbox = create_mailbox(openai_register.config["mail"], args.username or None)
+            email = str(mailbox.get("address") or "").strip()
+            print(f"[info] mailbox={email}")
+            try:
+                registrar._platform_authorize(email, 1)
+                registrar._send_otp(1)
+                code = wait_for_code(openai_register.config["mail"], mailbox)
+                if not code:
+                    raise RuntimeError(
+                        "wait_otp_timeout"
+                        f" (cloudmail_raw={mailbox.get('_cloudmail_last_raw_count', 'unknown')},"
+                        f" matched={mailbox.get('_cloudmail_last_matched_count', 'unknown')})"
+                    )
+                print(f"[result] received_code={code}")
+                return 0
+            except Exception:
+                release_mailbox(mailbox)
+                raise
+        if args.username:
+            original_create_mailbox = openai_register.create_mailbox
+
+            def create_fixed_mailbox():
+                return original_create_mailbox(args.username)
+
+            openai_register.create_mailbox = create_fixed_mailbox
+        result = registrar.register(1)
+        print("[result] success")
+        print(json.dumps({k: result.get(k) for k in ("email", "source_type", "created_at")}, ensure_ascii=False))
+        return 0
+    except Exception as error:
+        print(f"[result] failed: {error}")
+        return 1
+    finally:
+        registrar.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/register/mail_provider.py
+++ b/services/register/mail_provider.py
@@ -217,6 +217,8 @@ def _config(mail_config: dict) -> dict:
         "request_timeout": float(mail_config.get("request_timeout") or 30),
         "wait_timeout": float(mail_config.get("wait_timeout") or 30),
         "wait_interval": float(mail_config.get("wait_interval") or 2),
+        "fast_wait_seconds": float(mail_config.get("fast_wait_seconds") or 10),
+        "fast_wait_interval": float(mail_config.get("fast_wait_interval") or 0.8),
         "user_agent": str(mail_config.get("user_agent") or "Mozilla/5.0"),
         "proxy": str(mail_config.get("proxy") or "").strip(),
     }
@@ -376,14 +378,17 @@ class BaseMailProvider:
         self.provider_ref = provider_ref
 
     def wait_for(self, mailbox: dict[str, Any], on_message: Callable[[dict[str, Any]], ResultT | None]) -> ResultT | None:
-        deadline = time.monotonic() + self.conf["wait_timeout"]
+        started = time.monotonic()
+        deadline = started + self.conf["wait_timeout"]
         while time.monotonic() < deadline:
             message = self.fetch_latest_message(mailbox)
             if message:
                 result = on_message(message)
                 if result is not None:
                     return result
-            time.sleep(max(0.2, self.conf["wait_interval"]))
+            elapsed = time.monotonic() - started
+            interval = self.conf["fast_wait_interval"] if elapsed < self.conf["fast_wait_seconds"] else self.conf["wait_interval"]
+            time.sleep(max(0.2, interval))
         return None
 
     def wait_for_code(self, mailbox: dict[str, Any]) -> str | None:
@@ -685,10 +690,11 @@ class CloudMailGenProvider(BaseMailProvider):
         message = str(data.get("message") or "")
         if code == 200:
             account = data.get("data")
-            return account if isinstance(account, dict) else {}
+            result = account if isinstance(account, dict) else {}
+            return {**result, "_cloudmail_account_add_status": "created", "_cloudmail_account_add_message": message or "created"}
         if code == 501 and "already" in message.lower():
-            return {"already_registered": True}
-        raise RuntimeError(f"CloudMailGen account/add returned invalid response: {data}")
+            return {"already_registered": True, "_cloudmail_account_add_status": "already_registered", "_cloudmail_account_add_message": message}
+        raise RuntimeError(f"CloudMailGen account/add failed: code={code}, message={message}, response={data}")
 
     def _resolve_address(self, username: str | None = None) -> str:
         domain = _next_domain(self.domain)
@@ -711,6 +717,8 @@ class CloudMailGenProvider(BaseMailProvider):
             account = self._ensure_account(address)
             mailbox["account_id"] = str(account.get("accountId") or account.get("id") or "")
             mailbox["_cloudmail_account_added"] = not bool(account.get("already_registered"))
+            mailbox["_cloudmail_account_add_status"] = str(account.get("_cloudmail_account_add_status") or "")
+            mailbox["_cloudmail_account_add_message"] = str(account.get("_cloudmail_account_add_message") or "")
         return mailbox
 
     def fetch_latest_message(self, mailbox: dict[str, Any]) -> dict[str, Any] | None:
@@ -1410,7 +1418,8 @@ class OutlookTokenProvider(BaseMailProvider):
             mailbox["_seen_code_message_refs"] = seen_value
         seen_refs = {str(item) for item in seen_value}
 
-        deadline = time.monotonic() + self.conf["wait_timeout"]
+        started = time.monotonic()
+        deadline = started + self.conf["wait_timeout"]
         while time.monotonic() < deadline:
             for message in self.fetch_recent_messages(mailbox):
                 ref = _message_tracking_ref(message)
@@ -1421,7 +1430,9 @@ class OutlookTokenProvider(BaseMailProvider):
                     seen_value.append(ref)
                     return code
                 seen_refs.add(ref)
-            time.sleep(max(0.2, self.conf["wait_interval"]))
+            elapsed = time.monotonic() - started
+            interval = self.conf["fast_wait_interval"] if elapsed < self.conf["fast_wait_seconds"] else self.conf["wait_interval"]
+            time.sleep(max(0.2, interval))
         return None
 
 

--- a/services/register/mail_provider.py
+++ b/services/register/mail_provider.py
@@ -329,7 +329,10 @@ def _extract_text_candidates(value: Any) -> list[str]:
 def _message_matches_email(data: dict[str, Any], email: str) -> bool:
     target = str(email or "").strip().lower()
     candidates: list[str] = []
-    for key in ("to", "mailTo", "receiver", "receivers", "address", "email", "envelope_to"):
+    # 仅匹配“收件人”字段。注意 sendEmail/sendName 是 CloudMail 的“发件人”字段（OpenAI 地址），
+    # 绝不能放进来：否则 candidates 非空却全是发件方，永远匹配不到我们自己的收件地址，
+    # 导致所有邮件被静默丢弃（表现为“一直收不到验证码”）。
+    for key in ("to", "toEmail", "toName", "mailTo", "receiver", "receivers", "address", "email", "envelope_to"):
         if key in data:
             candidates.extend(_extract_text_candidates(data.get(key)))
     return not target or not candidates or any(target in str(item).strip().lower() for item in candidates if str(item).strip())
@@ -589,6 +592,8 @@ class CloudMailGenProvider(BaseMailProvider):
         self.domain = _normalize_string_list(entry.get("domain"))
         self.subdomain = _normalize_string_list(entry.get("subdomain"))
         self.email_prefix = str(entry.get("email_prefix") or "").strip()
+        self.auto_add_account = entry.get("auto_add_account", True) is not False
+        self.account_add_token = str(entry.get("account_add_token") or entry.get("add_token") or "").strip()
         self.session = _create_session(conf)
 
     def _request(
@@ -643,6 +648,48 @@ class CloudMailGenProvider(BaseMailProvider):
             cloudmail_token_cache[cache_key] = (token, now + 24 * 3600)
         return token
 
+    def _get_admin_token(self) -> str:
+        if not self.admin_email or not self.admin_password:
+            raise RuntimeError("CloudMailGen missing admin_email or admin_password")
+        cache_key = f"{self._cache_key()}|admin"
+        now = time.time()
+        with cloudmail_token_lock:
+            cached = cloudmail_token_cache.get(cache_key)
+            if cached and now < cached[1] - 300:
+                return cached[0]
+        data = self._request(
+            "POST",
+            "/api/login",
+            payload={"email": self.admin_email, "password": self.admin_password},
+        )
+        token = ""
+        if isinstance(data, dict) and data.get("code") == 200:
+            token = str((data.get("data") or {}).get("token") or "").strip()
+        if not token:
+            raise RuntimeError(f"CloudMailGen login returned invalid response: {data}")
+        with cloudmail_token_lock:
+            cloudmail_token_cache[cache_key] = (token, now + 24 * 3600)
+        return token
+
+    def _ensure_account(self, address: str) -> dict[str, Any]:
+        token = self._get_admin_token()
+        data = self._request(
+            "POST",
+            "/api/account/add",
+            headers={"Authorization": token},
+            payload={"email": address, "token": self.account_add_token},
+        )
+        if not isinstance(data, dict):
+            raise RuntimeError(f"CloudMailGen account/add returned invalid response: {data}")
+        code = data.get("code")
+        message = str(data.get("message") or "")
+        if code == 200:
+            account = data.get("data")
+            return account if isinstance(account, dict) else {}
+        if code == 501 and "already" in message.lower():
+            return {"already_registered": True}
+        raise RuntimeError(f"CloudMailGen account/add returned invalid response: {data}")
+
     def _resolve_address(self, username: str | None = None) -> str:
         domain = _next_domain(self.domain)
         if self.subdomain:
@@ -659,7 +706,12 @@ class CloudMailGenProvider(BaseMailProvider):
         if not self.domain:
             raise RuntimeError("CloudMailGen 需要至少配置一个 domain")
         address = self._resolve_address(username)
-        return {"provider": self.name, "provider_ref": self.provider_ref, "address": address}
+        mailbox = {"provider": self.name, "provider_ref": self.provider_ref, "address": address}
+        if self.auto_add_account:
+            account = self._ensure_account(address)
+            mailbox["account_id"] = str(account.get("accountId") or account.get("id") or "")
+            mailbox["_cloudmail_account_added"] = not bool(account.get("already_registered"))
+        return mailbox
 
     def fetch_latest_message(self, mailbox: dict[str, Any]) -> dict[str, Any] | None:
         address = str(mailbox.get("address") or "").strip()
@@ -674,6 +726,14 @@ class CloudMailGenProvider(BaseMailProvider):
         )
         items = (data.get("data") or []) if isinstance(data, dict) and data.get("code") == 200 else []
         messages = [item for item in items if isinstance(item, dict) and _message_matches_email(item, address)]
+        mailbox["_cloudmail_last_raw_count"] = len([item for item in items if isinstance(item, dict)])
+        mailbox["_cloudmail_last_matched_count"] = len(messages)
+        mailbox["_cloudmail_last_checked_at"] = datetime.now(timezone.utc).isoformat()
+        if items:
+            first = next((item for item in items if isinstance(item, dict)), {})
+            mailbox["_cloudmail_last_to"] = str(first.get("toEmail") or first.get("to") or first.get("mailTo") or "")
+            mailbox["_cloudmail_last_from"] = str(first.get("sendEmail") or first.get("from") or first.get("sender") or "")
+            mailbox["_cloudmail_last_subject"] = str(first.get("subject") or "")[:120]
         if not messages:
             return None
         item = messages[0]
@@ -681,7 +741,7 @@ class CloudMailGenProvider(BaseMailProvider):
         return {
             "provider": self.name,
             "mailbox": address,
-            "message_id": str(item.get("id") or item.get("_id") or item.get("messageId") or ""),
+            "message_id": str(item.get("id") or item.get("_id") or item.get("messageId") or item.get("emailId") or ""),
             "subject": str(item.get("subject") or ""),
             "sender": str(item.get("from") or item.get("sender") or ""),
             "text_content": text_content,
@@ -1399,7 +1459,10 @@ def _next_entry(mail_config: dict) -> dict:
 def _create_provider(mail_config: dict, provider: str = "", provider_ref: str = "") -> BaseMailProvider:
     entry = next((dict(item) for item in _entries(mail_config) if provider_ref and item["provider_ref"] == provider_ref), None)
     entry = entry or next((dict(item) for item in _enabled_entries(mail_config) if provider and item["type"] == provider), None) or _next_entry(mail_config)
-    conf = _config(mail_config)
+    conf_source = dict(mail_config)
+    if str(entry.get("proxy") or "").strip():
+        conf_source["proxy"] = str(entry.get("proxy") or "").strip()
+    conf = _config(conf_source)
     if entry["type"] == "cloudmail_gen":
         return CloudMailGenProvider(entry, conf)
     if entry["type"] == "cloudflare_temp_email":

--- a/services/register/openai_register.py
+++ b/services/register/openai_register.py
@@ -26,16 +26,20 @@ config = {
         "request_timeout": 30,
         "wait_timeout": 30,
         "wait_interval": 2,
+        "fast_wait_seconds": 10,
+        "fast_wait_interval": 0.8,
         "providers": [],
     },
     "proxy": "",
     "total": 10,
     "threads": 3,
+    "otp_resend": "after_delay",
+    "otp_resend_delay": 5,
 }
 register_config_file = base_dir.parents[1] / "data" / "register.json"
 try:
     saved_config = json.loads(register_config_file.read_text(encoding="utf-8"))
-    config.update({key: saved_config[key] for key in ("mail", "proxy", "total", "threads") if key in saved_config})
+    config.update({key: saved_config[key] for key in ("mail", "proxy", "total", "threads", "otp_resend", "otp_resend_delay") if key in saved_config})
 except Exception:
     pass
 
@@ -55,8 +59,119 @@ sec_ch_ua_full_version_list = '"Chromium";v="145.0.0.0", "Not:A-Brand";v="99.0.0
 default_timeout = 30
 print_lock = threading.Lock()
 stats_lock = threading.Lock()
-stats = {"done": 0, "success": 0, "fail": 0, "start_time": 0.0}
+REGISTER_STAGE_NAMES = (
+    "create_mailbox_ms",
+    "authorize_ms",
+    "register_user_ms",
+    "send_otp_ms",
+    "wait_otp_ms",
+    "validate_otp_ms",
+    "create_account_ms",
+    "exchange_token_ms",
+    "refresh_account_ms",
+)
+
+
+def _new_stats(start_time: float = 0.0) -> dict:
+    return {
+        "done": 0,
+        "success": 0,
+        "fail": 0,
+        "start_time": start_time,
+        "stage_totals_ms": {},
+        "stage_counts": {},
+        "last_errors_by_stage": {},
+        "mailbox_provider_success": {},
+        "otp_wait_total_seconds": 0.0,
+        "otp_wait_count": 0,
+    }
+
+
+stats = _new_stats()
 register_log_sink = None
+
+
+class RegisterStageError(RuntimeError):
+    def __init__(self, stage: str, error: Exception):
+        self.stage = stage
+        self.original = error
+        super().__init__(str(error))
+
+
+def reset_stats(start_time: float = 0.0) -> None:
+    with stats_lock:
+        stats.clear()
+        stats.update(_new_stats(start_time))
+
+
+def _round_ms(value: float) -> float:
+    return round(float(value), 1)
+
+
+def _merge_stage_ms(target: dict, stage_ms: dict[str, float]) -> None:
+    totals = target.setdefault("stage_totals_ms", {})
+    counts = target.setdefault("stage_counts", {})
+    for key, value in stage_ms.items():
+        if key not in REGISTER_STAGE_NAMES:
+            continue
+        totals[key] = float(totals.get(key) or 0.0) + float(value or 0.0)
+        counts[key] = int(counts.get(key) or 0) + 1
+
+
+def _failure_stage(error: Exception) -> str:
+    if isinstance(error, RegisterStageError):
+        return error.stage
+    return "openai_register"
+
+
+def record_register_success(metrics: dict[str, Any]) -> None:
+    with stats_lock:
+        _merge_stage_ms(stats, metrics.get("stage_ms") if isinstance(metrics.get("stage_ms"), dict) else {})
+        provider = str(metrics.get("mailbox_provider") or "").strip()
+        if provider:
+            providers = stats.setdefault("mailbox_provider_success", {})
+            providers[provider] = int(providers.get(provider) or 0) + 1
+        otp_wait = metrics.get("otp_wait_seconds")
+        if isinstance(otp_wait, (int, float)):
+            stats["otp_wait_total_seconds"] = float(stats.get("otp_wait_total_seconds") or 0.0) + float(otp_wait)
+            stats["otp_wait_count"] = int(stats.get("otp_wait_count") or 0) + 1
+
+
+def record_register_stage_metrics(stage_ms: dict[str, float]) -> None:
+    with stats_lock:
+        _merge_stage_ms(stats, stage_ms)
+
+
+def record_register_failure(error: Exception) -> None:
+    stage = _failure_stage(error)
+    with stats_lock:
+        errors = stats.setdefault("last_errors_by_stage", {})
+        errors[stage] = str(error)[-500:]
+
+
+def record_refresh_metrics(duration_ms: float, error: Exception | str | None = None) -> None:
+    with stats_lock:
+        _merge_stage_ms(stats, {"refresh_account_ms": duration_ms})
+        if error:
+            errors = stats.setdefault("last_errors_by_stage", {})
+            errors["account_refresh"] = str(error)[-500:]
+
+
+def snapshot_extra_stats() -> dict:
+    with stats_lock:
+        totals = dict(stats.get("stage_totals_ms") or {})
+        counts = dict(stats.get("stage_counts") or {})
+        otp_count = int(stats.get("otp_wait_count") or 0)
+        return {
+            "avg_stage_ms": {
+                key: _round_ms(float(totals.get(key) or 0.0) / int(counts.get(key) or 1))
+                for key in REGISTER_STAGE_NAMES
+                if int(counts.get(key) or 0) > 0
+            },
+            "last_errors_by_stage": dict(stats.get("last_errors_by_stage") or {}),
+            "mailbox_provider_success": dict(stats.get("mailbox_provider_success") or {}),
+            "otp_wait_avg_seconds": round(float(stats.get("otp_wait_total_seconds") or 0.0) / otp_count, 1) if otp_count else 0,
+        }
 
 common_headers = {
     "accept": "application/json",
@@ -393,9 +508,23 @@ class PlatformRegistrar:
         self.code_verifier = ""
         self.platform_auth_code = ""
         self.otp_send_url = ""
+        self.stage_ms: dict[str, float] = {}
+        self.otp_wait_seconds = 0.0
+        self.mailbox_provider = ""
 
     def close(self) -> None:
         self.session.close()
+
+    def _time_stage(self, metric: str, failure_stage: str, func, *args, **kwargs):
+        started = time.monotonic()
+        try:
+            return func(*args, **kwargs)
+        except RegisterStageError:
+            raise
+        except Exception as error:
+            raise RegisterStageError(failure_stage, error) from error
+        finally:
+            self.stage_ms[metric] = _round_ms((time.monotonic() - started) * 1000)
 
     def _navigate_headers(self, referer: str = "") -> dict[str, str]:
         headers = dict(navigate_headers)
@@ -684,6 +813,150 @@ class PlatformRegistrar:
         }
 
 
+def _platform_resend_otp(self: PlatformRegistrar, index: int) -> None:
+    try:
+        resent = self._resend_otp_request(index)
+        step(index, f"resend_otp response: {_response_debug_detail(resent, limit=200)}")
+    except Exception as error:
+        step(index, f"resend_otp failed, continue waiting for OTP: {error}", "yellow")
+
+
+def _platform_send_otp(self: PlatformRegistrar, index: int) -> None:
+    step(index, "start sending OTP")
+    send_url = f"{auth_base}/api/accounts/email-otp/send"
+    resp = self._send_otp_request(send_url, f"{auth_base}/create-account/password", navigate=False, index=index)
+    data = _response_json(resp)
+    verification_url = str(data.get("continue_url") or "").strip()
+    urls = [send_url]
+    if self.otp_send_url and self.otp_send_url not in urls:
+        urls.append(self.otp_send_url)
+        try:
+            self._send_otp_request(self.otp_send_url, str(getattr(resp, "url", "") or send_url), navigate=True, index=index)
+        except Exception as error:
+            step(index, f"continue_url landing failed, continue waiting for OTP: {error}", "yellow")
+    if verification_url.startswith("http") and verification_url not in urls:
+        urls.append(verification_url)
+        try:
+            landing = self._send_otp_request(verification_url, str(getattr(resp, "url", "") or send_url), navigate=True, index=index)
+            step(index, f"email_verification landing: {_response_debug_detail(landing, limit=160)}")
+        except Exception as error:
+            step(index, f"email_verification landing failed, continue waiting for OTP: {error}", "yellow")
+    if str(config.get("otp_resend") or "after_delay").strip().lower() == "always":
+        self._resend_otp(index)
+    debug = _response_debug_detail(resp, limit=300)
+    if debug:
+        step(index, f"send_otp response: {debug}")
+    step(index, "send OTP done")
+
+
+def _platform_wait_for_code_with_resend(self: PlatformRegistrar, mailbox: dict, index: int) -> str | None:
+    mode = str(config.get("otp_resend") or "after_delay").strip().lower()
+    if mode not in {"always", "after_delay", "off"}:
+        mode = "after_delay"
+    if mode != "after_delay":
+        return wait_for_code(mailbox)
+    base_conf = _mail_config()
+    wait_timeout = float(base_conf.get("wait_timeout") or 30)
+    delay = max(0.0, min(float(config.get("otp_resend_delay") or 5), wait_timeout))
+    if delay <= 0:
+        return wait_for_code(mailbox)
+    first_conf = dict(base_conf)
+    first_conf["wait_timeout"] = delay
+    code = mail_provider.wait_for_code(first_conf, mailbox)
+    if code:
+        return code
+    self._resend_otp(index)
+    remaining_conf = dict(base_conf)
+    remaining_conf["wait_timeout"] = max(0.2, wait_timeout - delay)
+    return mail_provider.wait_for_code(remaining_conf, mailbox)
+
+
+def _platform_register_optimized(self: PlatformRegistrar, index: int) -> dict:
+    step(index, "start creating mailbox")
+    mailbox = self._time_stage("create_mailbox_ms", "cloudmail_add", create_mailbox)
+    email = str(mailbox.get("address") or "").strip()
+    if not email:
+        mail_provider.release_mailbox(mailbox)
+        raise RegisterStageError("cloudmail_add", RuntimeError("mail provider did not return address"))
+    self.mailbox_provider = str(mailbox.get("provider") or "").strip()
+    label = str(mailbox.get("label") or "")
+    step(index, f"mailbox created[{label or self.mailbox_provider}]: {email}")
+    if mailbox.get("_cloudmail_account_add_status"):
+        step(
+            index,
+            "CloudMail account/add "
+            f"{mailbox.get('_cloudmail_account_add_status')}: {mailbox.get('_cloudmail_account_add_message', '')}",
+        )
+    try:
+        password = _random_password()
+        first_name, last_name = _random_name()
+        self._time_stage("authorize_ms", "openai_register", self._platform_authorize, email, index)
+        self._time_stage("register_user_ms", "openai_register", self._register_user, email, password, index)
+        self._time_stage("send_otp_ms", "openai_register", self._send_otp, index)
+        step(index, "start waiting for registration OTP")
+        wait_started = time.monotonic()
+        code = self._time_stage("wait_otp_ms", "wait_otp", self._wait_for_code_with_resend, mailbox, index)
+        self.otp_wait_seconds = round(time.monotonic() - wait_started, 1)
+        if not code:
+            if mailbox.get("provider") == "cloudmail_gen":
+                raise RegisterStageError(
+                    "wait_otp",
+                    RuntimeError(
+                        "wait_register_otp_timeout"
+                        f" (cloudmail_raw={mailbox.get('_cloudmail_last_raw_count', 'unknown')},"
+                        f" matched={mailbox.get('_cloudmail_last_matched_count', 'unknown')},"
+                        f" to={mailbox.get('_cloudmail_last_to', '')},"
+                        f" from={mailbox.get('_cloudmail_last_from', '')},"
+                        f" subject={mailbox.get('_cloudmail_last_subject', '')})"
+                    ),
+                )
+            raise RegisterStageError("wait_otp", RuntimeError("wait_register_otp_timeout"))
+        step(index, f"received registration OTP {code}")
+        self._time_stage("validate_otp_ms", "openai_register", self._validate_otp, code, index)
+        self._time_stage("create_account_ms", "openai_register", self._create_account, f"{first_name} {last_name}", _random_birthdate(), index)
+        tokens = self._time_stage("exchange_token_ms", "openai_register", self._exchange_registered_tokens, index)
+    except Exception as error:
+        mail_provider.mark_mailbox_result(mailbox, success=False, error=error)
+        raise
+    mail_provider.mark_mailbox_result(mailbox, success=True)
+    return {
+        "email": email,
+        "password": password,
+        "access_token": str(tokens.get("access_token") or "").strip(),
+        "refresh_token": str(tokens.get("refresh_token") or "").strip(),
+        "id_token": str(tokens.get("id_token") or "").strip(),
+        "source_type": "web",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "_register_metrics": {
+            "stage_ms": dict(self.stage_ms),
+            "mailbox_provider": self.mailbox_provider,
+            "otp_wait_seconds": self.otp_wait_seconds,
+        },
+    }
+
+
+PlatformRegistrar._resend_otp = _platform_resend_otp
+PlatformRegistrar._send_otp = _platform_send_otp
+PlatformRegistrar._wait_for_code_with_resend = _platform_wait_for_code_with_resend
+PlatformRegistrar.register = _platform_register_optimized
+
+
+def _refresh_account_background(index: int, access_token: str) -> None:
+    started = time.monotonic()
+    try:
+        result = account_service.refresh_accounts([access_token])
+        duration_ms = (time.monotonic() - started) * 1000
+        if result.get("errors"):
+            record_refresh_metrics(duration_ms, result["errors"])
+            step(index, f"stage=account_refresh account status refresh failed in background: {result['errors']}", "yellow")
+        else:
+            record_refresh_metrics(duration_ms)
+            step(index, "account status refresh completed in background")
+    except Exception as error:
+        record_refresh_metrics((time.monotonic() - started) * 1000, error)
+        step(index, f"stage=account_refresh account status refresh failed in background: {error}", "yellow")
+
+
 def worker(index: int) -> dict:
     start = time.time()
     registrar = PlatformRegistrar(config["proxy"])
@@ -709,5 +982,44 @@ def worker(index: int) -> dict:
             stats["fail"] += 1
         log(f"任务{index} 注册失败，本次耗时{cost:.1f}s，原因: {e}", "red")
         return {"ok": False, "index": index, "error": str(e)}
+    finally:
+        registrar.close()
+
+
+def worker(index: int) -> dict:
+    start = time.time()
+    registrar = PlatformRegistrar(config["proxy"])
+    try:
+        step(index, "task started")
+        result = registrar.register(index)
+        cost = time.time() - start
+        access_token = str(result["access_token"])
+        metrics = result.pop("_register_metrics", {})
+        account_service.add_account_items([result])
+        step(index, "注册成功，账号已保存")
+        threading.Thread(
+            target=_refresh_account_background,
+            args=(index, access_token),
+            daemon=True,
+            name=f"register-refresh-{index}",
+        ).start()
+        step(index, "账号状态刷新后台进行", "yellow")
+        record_register_success(metrics if isinstance(metrics, dict) else {})
+        with stats_lock:
+            stats["done"] += 1
+            stats["success"] += 1
+            avg = (time.time() - stats["start_time"]) / stats["success"]
+        log(f'{result["email"]} registered successfully, cost={cost:.1f}s, global_avg={avg:.1f}s', "green")
+        return {"ok": True, "index": index, "result": result}
+    except Exception as e:
+        cost = time.time() - start
+        record_register_stage_metrics(dict(getattr(registrar, "stage_ms", {}) or {}))
+        record_register_failure(e)
+        stage = _failure_stage(e)
+        with stats_lock:
+            stats["done"] += 1
+            stats["fail"] += 1
+        log(f"task{index} registration failed, stage={stage}, cost={cost:.1f}s, reason={e}", "red")
+        return {"ok": False, "index": index, "error": str(e), "stage": stage}
     finally:
         registrar.close()

--- a/services/register/openai_register.py
+++ b/services/register/openai_register.py
@@ -211,7 +211,7 @@ def _is_cloudflare_challenge(resp) -> bool:
 
 
 def _mail_config() -> dict:
-    return {**config["mail"], "proxy": config["proxy"]}
+    return dict(config["mail"])
 
 
 def _authorize_landed_page(resp) -> str:
@@ -248,7 +248,13 @@ from utils.sentinel import SentinelTokenGenerator, build_sentinel_token as _buil
 
 def build_sentinel_token(session: requests.Session, device_id: str, flow: str) -> str:
     """请求 sentinel token，返回 sentinel header 字符串（兼容旧接口）。"""
-    sentinel_val, _oai_sc_val = _build_sentinel_token_tuple(session, device_id, flow, user_agent=user_agent, sec_ch_ua=sec_ch_ua)
+    sentinel_val, oai_sc_val = _build_sentinel_token_tuple(session, device_id, flow, user_agent=user_agent, sec_ch_ua=sec_ch_ua)
+    if oai_sc_val:
+        for domain in (".openai.com", "openai.com", ".auth.openai.com", "auth.openai.com"):
+            try:
+                session.cookies.set("oai-sc", oai_sc_val, domain=domain)
+            except Exception:
+                continue
     return sentinel_val
 
 
@@ -386,6 +392,7 @@ class PlatformRegistrar:
         self.device_id = str(uuid.uuid4())
         self.code_verifier = ""
         self.platform_auth_code = ""
+        self.otp_send_url = ""
 
     def close(self) -> None:
         self.session.close()
@@ -500,23 +507,86 @@ class PlatformRegistrar:
                 step(index, "注册失败提示: 邮箱域名很可能因滥用被封禁，请更换邮箱域名", "yellow")
             detail = f", detail={json.dumps(data, ensure_ascii=False)}" if data else ""
             raise RuntimeError(error or f"user_register_http_{getattr(resp, 'status_code', 'unknown')}{detail}")
+        # 记录注册响应体，帮助诊断邮件是否在 _register_user 阶段由服务端触发
+        try:
+            body = (resp.text or "")[:500] if resp is not None else ""
+            if body:
+                step(index, f"register_user 响应: {body}")
+        except Exception:
+            pass
+        # 从 continue_url 提取 otp_send URL（不拼 ?email=xxx，依赖服务端 session 状态）
+        data = _response_json(resp) if resp is not None else {}
+        self.otp_send_url = str(data.get("continue_url") or "").strip()
+        if self.otp_send_url and not self.otp_send_url.startswith("http"):
+            self.otp_send_url = ""
         step(index, "提交注册密码完成")
 
-    def _send_otp(self, index: int) -> None:
-        step(index, "开始发送验证码")
-        url = f"{auth_base}/api/accounts/email-otp/send"
-        headers = _headers_with_clearance(self._navigate_headers(f"{auth_base}/create-account/password"), url, self.proxy, self.clearance_user_agent)
+    def _send_otp_request(self, url: str, referer: str, *, navigate: bool, index: int):
+        headers = self._navigate_headers(referer) if navigate else self._json_headers(referer)
+        headers = _headers_with_clearance(headers, url, self.proxy, self.clearance_user_agent)
         resp, error = request_with_local_retry(self.session, "get", url, headers=headers, allow_redirects=True, verify=False)
         if _is_cloudflare_challenge(resp):
             bundle = self._refresh_cloudflare_clearance(auth_base, index)
             if bundle is None:
                 raise RuntimeError(_cloudflare_block_message(resp, reason=self.clearance_failure_reason))
-            headers = _headers_with_clearance(self._navigate_headers(f"{auth_base}/create-account/password"), url, self.proxy, self.clearance_user_agent)
+            headers = self._navigate_headers(referer) if navigate else self._json_headers(referer)
+            headers = _headers_with_clearance(headers, url, self.proxy, self.clearance_user_agent)
             resp, error = request_with_local_retry(self.session, "get", url, headers=headers, allow_redirects=True, verify=False)
             if _is_cloudflare_challenge(resp):
                 raise RuntimeError(_cloudflare_block_message(resp, "Cloudflare clearance 重试仍被拦截"))
         if resp is None or resp.status_code not in (200, 302):
             raise RuntimeError(error or f"send_otp_http_{getattr(resp, 'status_code', 'unknown')}")
+        data = _response_json(resp)
+        if isinstance(data, dict) and data.get("error"):
+            raise RuntimeError(f"send_otp_api_error: {data.get('error')}")
+        return resp
+
+    def _resend_otp_request(self, index: int):
+        url = f"{auth_base}/api/accounts/email-otp/resend"
+        headers = self._json_headers(f"{auth_base}/email-verification")
+        headers = _headers_with_clearance(headers, url, self.proxy, self.clearance_user_agent)
+        resp, error = request_with_local_retry(self.session, "post", url, headers=headers, allow_redirects=True, verify=False)
+        if _is_cloudflare_challenge(resp):
+            bundle = self._refresh_cloudflare_clearance(auth_base, index)
+            if bundle is None:
+                raise RuntimeError(_cloudflare_block_message(resp, reason=self.clearance_failure_reason))
+            headers = self._json_headers(f"{auth_base}/email-verification")
+            headers = _headers_with_clearance(headers, url, self.proxy, self.clearance_user_agent)
+            resp, error = request_with_local_retry(self.session, "post", url, headers=headers, allow_redirects=True, verify=False)
+            if _is_cloudflare_challenge(resp):
+                raise RuntimeError(_cloudflare_block_message(resp, "Cloudflare clearance 重试仍被拦截"))
+        if resp is None or resp.status_code not in (200, 204):
+            raise RuntimeError(error or f"resend_otp_http_{getattr(resp, 'status_code', 'unknown')}")
+        return resp
+
+    def _send_otp(self, index: int) -> None:
+        step(index, "开始发送验证码")
+        send_url = f"{auth_base}/api/accounts/email-otp/send"
+        resp = self._send_otp_request(send_url, f"{auth_base}/create-account/password", navigate=False, index=index)
+        data = _response_json(resp)
+        verification_url = str(data.get("continue_url") or "").strip()
+        urls = [send_url]
+        if self.otp_send_url and self.otp_send_url not in urls:
+            urls.append(self.otp_send_url)
+            try:
+                self._send_otp_request(self.otp_send_url, str(getattr(resp, "url", "") or send_url), navigate=True, index=index)
+            except Exception as error:
+                step(index, f"continue_url 落页失败，继续等待验证码: {error}", "yellow")
+        if verification_url.startswith("http") and verification_url not in urls:
+            urls.append(verification_url)
+            try:
+                landing = self._send_otp_request(verification_url, str(getattr(resp, "url", "") or send_url), navigate=True, index=index)
+                step(index, f"email_verification 落页: {_response_debug_detail(landing, limit=160)}")
+            except Exception as error:
+                step(index, f"email_verification 落页失败，继续等待验证码: {error}", "yellow")
+        try:
+            resent = self._resend_otp_request(index)
+            step(index, f"resend_otp 响应: {_response_debug_detail(resent, limit=200)}")
+        except Exception as error:
+            step(index, f"resend_otp 触发失败，继续等待验证码: {error}", "yellow")
+        debug = _response_debug_detail(resp, limit=300)
+        if debug:
+            step(index, f"send_otp 响应: {debug}")
         step(index, "发送验证码完成")
 
     def _validate_otp(self, code: str, index: int) -> None:
@@ -585,6 +655,15 @@ class PlatformRegistrar:
             step(index, "开始等待注册验证码")
             code = wait_for_code(mailbox)
             if not code:
+                if mailbox.get("provider") == "cloudmail_gen":
+                    raise RuntimeError(
+                        "wait_register_otp_timeout"
+                        f" (cloudmail_raw={mailbox.get('_cloudmail_last_raw_count', 'unknown')},"
+                        f" matched={mailbox.get('_cloudmail_last_matched_count', 'unknown')},"
+                        f" to={mailbox.get('_cloudmail_last_to', '')},"
+                        f" from={mailbox.get('_cloudmail_last_from', '')},"
+                        f" subject={mailbox.get('_cloudmail_last_subject', '')})"
+                    )
                 raise RuntimeError("等待注册验证码超时")
             step(index, f"收到注册验证码: {code}")
             self._validate_otp(code, index)

--- a/services/register_service.py
+++ b/services/register_service.py
@@ -14,6 +14,31 @@ from services.register import mail_provider, openai_register
 
 
 REGISTER_FILE = DATA_DIR / "register.json"
+PRESETS_FILE = DATA_DIR / "register.presets.json"
+BUILTIN_PRESET_FILES = {
+    "local-proxy": DATA_DIR / "register.local.json",
+    "vps-warp": DATA_DIR / "register.vps.json",
+}
+REGISTER_CONFIG_KEYS = ("mail", "proxy", "total", "threads", "otp_resend", "otp_resend_delay")
+
+
+def _default_stats(threads: int) -> dict:
+    return {
+        "success": 0,
+        "fail": 0,
+        "done": 0,
+        "running": 0,
+        "threads": threads,
+        "elapsed_seconds": 0,
+        "avg_seconds": 0,
+        "success_rate": 0,
+        "current_quota": 0,
+        "current_available": 0,
+        "avg_stage_ms": {},
+        "last_errors_by_stage": {},
+        "mailbox_provider_success": {},
+        "otp_wait_avg_seconds": 0,
+    }
 
 
 def _serialize_outlook_pool(credentials: list[dict]) -> str:
@@ -37,7 +62,7 @@ def _now() -> str:
 
 
 def _default_config() -> dict:
-    return {**openai_register.config, "mode": "total", "target_quota": 100, "target_available": 10, "check_interval": 5, "enabled": False, "stats": {"success": 0, "fail": 0, "done": 0, "running": 0, "threads": openai_register.config["threads"], "elapsed_seconds": 0, "avg_seconds": 0, "success_rate": 0, "current_quota": 0, "current_available": 0}}
+    return {**openai_register.config, "mode": "total", "target_quota": 100, "target_available": 10, "check_interval": 5, "enabled": False, "stats": _default_stats(openai_register.config["threads"])}
 
 
 def _normalize(raw: dict) -> dict:
@@ -45,6 +70,10 @@ def _normalize(raw: dict) -> dict:
     cfg.update({k: v for k, v in raw.items() if k not in {"stats", "logs"}})
     cfg["total"] = max(1, int(cfg.get("total") or 1))
     cfg["threads"] = max(1, int(cfg.get("threads") or 1))
+    cfg["otp_resend"] = str(cfg.get("otp_resend") or "after_delay").strip().lower()
+    if cfg["otp_resend"] not in {"always", "after_delay", "off"}:
+        cfg["otp_resend"] = "after_delay"
+    cfg["otp_resend_delay"] = max(0, int(float(cfg.get("otp_resend_delay") or 5)))
     cfg["mode"] = str(cfg.get("mode") or "total").strip() if str(cfg.get("mode") or "total").strip() in {"total", "quota", "available"} else "total"
     cfg["target_quota"] = max(1, int(cfg.get("target_quota") or 1))
     cfg["target_available"] = max(1, int(cfg.get("target_available") or 1))
@@ -82,9 +111,75 @@ class RegisterService:
 
     def get(self) -> dict:
         with self._lock:
+            if isinstance(self._config.get("stats"), dict):
+                self._config["stats"].update(openai_register.snapshot_extra_stats())
             snapshot = json.loads(json.dumps({**self._config, "logs": self._logs[-300:]}, ensure_ascii=False))
         self._redact_outlook_pools(snapshot)
         return snapshot
+
+    def _preset_payload(self, raw: dict) -> dict:
+        cfg = _normalize({**self._config, **(raw or {}), "enabled": False})
+        return {key: value for key, value in cfg.items() if key not in {"stats", "logs", "enabled"}}
+
+    def _load_presets(self) -> dict[str, dict]:
+        presets: dict[str, dict] = {}
+        for name, path in BUILTIN_PRESET_FILES.items():
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except Exception:
+                continue
+            if isinstance(data, dict):
+                presets[name] = data
+        try:
+            data = json.loads(PRESETS_FILE.read_text(encoding="utf-8"))
+        except Exception:
+            return presets
+        if not isinstance(data, dict):
+            return presets
+        presets.update({str(name): preset for name, preset in data.items() if isinstance(preset, dict)})
+        return presets
+
+    def _save_presets(self, presets: dict[str, dict]) -> None:
+        PRESETS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        PRESETS_FILE.write_text(json.dumps(presets, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def list_presets(self) -> dict:
+        with self._lock:
+            presets = self._load_presets()
+            snapshot = {
+                name: self._preset_payload(preset)
+                for name, preset in sorted(presets.items())
+                if str(name).strip()
+            }
+        for preset in snapshot.values():
+            self._redact_outlook_pools(preset)
+        return {"presets": snapshot}
+
+    def save_preset(self, name: str, updates: dict | None = None) -> dict:
+        preset_name = str(name or "").strip()
+        if not preset_name:
+            raise ValueError("preset name is required")
+        with self._lock:
+            payload = dict(updates or {})
+            self._merge_outlook_pools(payload)
+            presets = self._load_presets()
+            presets[preset_name] = self._preset_payload(payload)
+            self._save_presets(presets)
+        return self.list_presets()
+
+    def apply_preset(self, name: str) -> dict:
+        preset_name = str(name or "").strip()
+        with self._lock:
+            presets = self._load_presets()
+            preset = presets.get(preset_name)
+            if not isinstance(preset, dict):
+                raise ValueError(f"preset not found: {preset_name}")
+            self._config = _normalize({**self._config, **preset, "enabled": self._config.get("enabled", False)})
+            self._drop_mail_proxy()
+            openai_register.config.update({k: self._config[k] for k in REGISTER_CONFIG_KEYS})
+            self._save()
+            self._append_log(f"register preset applied: {preset_name}", "yellow")
+            return self.get()
 
     @staticmethod
     def _mask_email(email: str) -> str:
@@ -164,7 +259,7 @@ class RegisterService:
             self._merge_outlook_pools(updates)
             self._config = _normalize({**self._config, **updates})
             self._drop_mail_proxy()
-            openai_register.config.update({k: self._config[k] for k in ("mail", "proxy", "total", "threads")})
+            openai_register.config.update({k: self._config[k] for k in REGISTER_CONFIG_KEYS})
             self._save()
             return self.get()
 
@@ -178,10 +273,9 @@ class RegisterService:
             self._drop_mail_proxy()
             self._logs = []
             metrics = self._pool_metrics()
-            self._config["stats"] = {"job_id": uuid.uuid4().hex, "success": 0, "fail": 0, "done": 0, "running": 0, "threads": self._config["threads"], **metrics, "started_at": _now(), "updated_at": _now()}
-            openai_register.config.update({k: self._config[k] for k in ("mail", "proxy", "total", "threads")})
-            with openai_register.stats_lock:
-                openai_register.stats.update({"done": 0, "success": 0, "fail": 0, "start_time": time.time()})
+            self._config["stats"] = {**_default_stats(self._config["threads"]), "job_id": uuid.uuid4().hex, **metrics, "started_at": _now(), "updated_at": _now()}
+            openai_register.config.update({k: self._config[k] for k in REGISTER_CONFIG_KEYS})
+            openai_register.reset_stats(time.time())
             self._save()
             self._runner = threading.Thread(target=self._run, daemon=True, name="openai-register")
             self._runner.start()
@@ -199,9 +293,8 @@ class RegisterService:
     def reset(self) -> dict:
         with self._lock:
             self._logs = []
-            self._config["stats"] = {"success": 0, "fail": 0, "done": 0, "running": 0, "threads": self._config["threads"], "elapsed_seconds": 0, "avg_seconds": 0, "success_rate": 0, **self._pool_metrics(), "updated_at": _now()}
-            with openai_register.stats_lock:
-                openai_register.stats.update({"done": 0, "success": 0, "fail": 0, "start_time": 0.0})
+            self._config["stats"] = {**_default_stats(self._config["threads"]), **self._pool_metrics(), "updated_at": _now()}
+            openai_register.reset_stats(0.0)
             self._save()
             return self.get()
 
@@ -210,7 +303,7 @@ class RegisterService:
         if scope == "unused":
             with self._lock:
                 removed = self._prune_unused_outlook_pools()
-                openai_register.config.update({k: self._config[k] for k in ("mail", "proxy", "total", "threads")})
+                openai_register.config.update({k: self._config[k] for k in REGISTER_CONFIG_KEYS})
                 self._save()
                 self._append_log(f"已清空 Outlook 邮箱池未使用邮箱，移除 {removed} 个", "yellow")
             return self.get()
@@ -254,6 +347,7 @@ class RegisterService:
         with self._lock:
             self._config["stats"].update(updates)
             stats = self._config["stats"]
+            stats.update(openai_register.snapshot_extra_stats())
             started_at = str(stats.get("started_at") or "")
             if started_at:
                 try:

--- a/test/test_register_proxy_runtime.py
+++ b/test/test_register_proxy_runtime.py
@@ -1,7 +1,10 @@
 import unittest
+import time
+from threading import Event
 from unittest.mock import patch
 
 from services.proxy_service import ClearanceBundle, ProxyRuntimeProfile
+from services.register import mail_provider
 from services.register import openai_register
 
 
@@ -87,6 +90,123 @@ class RegisterProxyRuntimeTests(unittest.TestCase):
             openai_register.config.update(original)
 
         self.assertNotIn("proxy", mail_config)
+
+    def test_mail_provider_fast_polling_defaults(self):
+        conf = mail_provider._config({"request_timeout": 30, "wait_timeout": 30, "wait_interval": 3})
+
+        self.assertEqual(conf["fast_wait_seconds"], 10)
+        self.assertEqual(conf["fast_wait_interval"], 0.8)
+        self.assertEqual(conf["wait_interval"], 3)
+
+    def test_register_metrics_snapshot_aggregates_stage_provider_and_otp(self):
+        openai_register.reset_stats(time.time())
+        try:
+            openai_register.record_register_success(
+                {
+                    "stage_ms": {"create_mailbox_ms": 100, "wait_otp_ms": 900},
+                    "mailbox_provider": "cloudmail_gen",
+                    "otp_wait_seconds": 0.9,
+                }
+            )
+            openai_register.record_register_failure(openai_register.RegisterStageError("wait_otp", RuntimeError("timeout")))
+            snapshot = openai_register.snapshot_extra_stats()
+        finally:
+            openai_register.reset_stats(0.0)
+
+        self.assertEqual(snapshot["avg_stage_ms"]["create_mailbox_ms"], 100)
+        self.assertEqual(snapshot["avg_stage_ms"]["wait_otp_ms"], 900)
+        self.assertEqual(snapshot["mailbox_provider_success"]["cloudmail_gen"], 1)
+        self.assertEqual(snapshot["otp_wait_avg_seconds"], 0.9)
+        self.assertEqual(snapshot["last_errors_by_stage"]["wait_otp"], "timeout")
+
+    def test_worker_saves_account_before_async_refresh_finishes(self):
+        class FakeRegistrar:
+            def __init__(self, proxy=""):
+                self.proxy = proxy
+                self.closed = False
+
+            def register(self, index):
+                return {
+                    "email": "user@example.com",
+                    "password": "secret",
+                    "access_token": "access-token",
+                    "refresh_token": "refresh-token",
+                    "id_token": "",
+                    "source_type": "web",
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                    "_register_metrics": {
+                        "stage_ms": {"create_mailbox_ms": 10},
+                        "mailbox_provider": "cloudmail_gen",
+                        "otp_wait_seconds": 1,
+                    },
+                }
+
+            def close(self):
+                self.closed = True
+
+        refresh_started = Event()
+        refresh_release = Event()
+        refresh_done = Event()
+        saved_accounts = []
+
+        def fake_add(items):
+            saved_accounts.extend(items)
+
+        def fake_refresh(tokens):
+            refresh_started.set()
+            refresh_release.wait(1)
+            refresh_done.set()
+            return {"errors": []}
+
+        openai_register.reset_stats(time.time())
+        try:
+            with patch.object(openai_register, "PlatformRegistrar", FakeRegistrar), patch.object(
+                openai_register.account_service,
+                "add_account_items",
+                side_effect=fake_add,
+            ), patch.object(openai_register.account_service, "refresh_accounts", side_effect=fake_refresh):
+                result = openai_register.worker(1)
+
+            self.assertTrue(result["ok"])
+            self.assertEqual(saved_accounts[0]["email"], "user@example.com")
+            self.assertNotIn("_register_metrics", saved_accounts[0])
+            self.assertTrue(refresh_started.wait(1))
+            self.assertFalse(refresh_done.is_set())
+            refresh_release.set()
+            self.assertTrue(refresh_done.wait(1))
+        finally:
+            refresh_release.set()
+            openai_register.reset_stats(0.0)
+
+    def test_worker_failure_logs_standardized_stage(self):
+        class FailingRegistrar:
+            def __init__(self, proxy=""):
+                self.stage_ms = {"wait_otp_ms": 5000}
+
+            def register(self, index):
+                raise openai_register.RegisterStageError("wait_otp", RuntimeError("timeout"))
+
+            def close(self):
+                pass
+
+        messages = []
+
+        openai_register.reset_stats(time.time())
+        try:
+            with patch.object(openai_register, "PlatformRegistrar", FailingRegistrar), patch.object(
+                openai_register,
+                "log",
+                side_effect=lambda text, color="": messages.append(text),
+            ):
+                result = openai_register.worker(2)
+            snapshot = openai_register.snapshot_extra_stats()
+        finally:
+            openai_register.reset_stats(0.0)
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["stage"], "wait_otp")
+        self.assertTrue(any("stage=wait_otp" in message for message in messages))
+        self.assertEqual(snapshot["avg_stage_ms"]["wait_otp_ms"], 5000)
 
     def test_create_session_uses_proxy_settings_without_breaking_existing_proxy_argument(self):
         fake_proxy = FakeProxySettings()

--- a/test/test_register_proxy_runtime.py
+++ b/test/test_register_proxy_runtime.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import patch
 
-from services.proxy_service import ClearanceBundle
+from services.proxy_service import ClearanceBundle, ProxyRuntimeProfile
 from services.register import openai_register
 
 
@@ -36,8 +36,9 @@ class FakeSession:
 
 
 class FakeProxySettings:
-    def __init__(self, bundle=None):
+    def __init__(self, bundle=None, clearance_enabled=None):
         self.bundle = bundle
+        self.clearance_enabled = bool(bundle is not None if clearance_enabled is None else clearance_enabled)
         self.refreshed = False
         self.session_kwargs_calls = []
         self.build_headers_calls = []
@@ -46,6 +47,15 @@ class FakeProxySettings:
     def build_session_kwargs(self, **kwargs):
         self.session_kwargs_calls.append(kwargs)
         return dict(kwargs, proxy="http://runtime.example:8118")
+
+    def get_profile(self, **kwargs):
+        return ProxyRuntimeProfile(
+            proxy_url=str(kwargs.get("proxy") or ""),
+            proxy_source="explicit" if kwargs.get("proxy") else "direct",
+            runtime_enabled=self.clearance_enabled,
+            egress_mode="single_proxy",
+            clearance={"enabled": self.clearance_enabled, "mode": "flaresolverr", "timeout_sec": 60},
+        )
 
     def build_headers(self, headers=None, target_url="", proxy="", upstream=True, **kwargs):
         self.build_headers_calls.append({"target_url": target_url, "proxy": proxy, "upstream": upstream})
@@ -61,6 +71,23 @@ class FakeProxySettings:
 
 
 class RegisterProxyRuntimeTests(unittest.TestCase):
+    def test_mail_config_does_not_inherit_openai_register_proxy(self):
+        original = dict(openai_register.config)
+        try:
+            openai_register.config.update(
+                {
+                    "proxy": "http://openai-proxy.example:8080",
+                    "mail": {"request_timeout": 30, "wait_timeout": 30, "wait_interval": 2, "providers": []},
+                }
+            )
+
+            mail_config = openai_register._mail_config()
+        finally:
+            openai_register.config.clear()
+            openai_register.config.update(original)
+
+        self.assertNotIn("proxy", mail_config)
+
     def test_create_session_uses_proxy_settings_without_breaking_existing_proxy_argument(self):
         fake_proxy = FakeProxySettings()
         created = []
@@ -102,7 +129,7 @@ class RegisterProxyRuntimeTests(unittest.TestCase):
             with self.assertRaisesRegex(RuntimeError, "Cloudflare") as ctx:
                 registrar._platform_authorize("user@example.com", 1)
 
-        self.assertEqual(len(fake_proxy.refresh_calls), 1)
+        self.assertEqual(len(fake_proxy.refresh_calls), 0)
         self.assertIn("status=403", str(ctx.exception))
         self.assertIn("Just a moment", str(ctx.exception))
 
@@ -161,7 +188,7 @@ class RegisterProxyRuntimeTests(unittest.TestCase):
         self.assertTrue(fake_proxy.refresh_calls[0]["force"])
 
     def test_refresh_failure_reports_cloudflare_detail_without_infinite_retry(self):
-        fake_proxy = FakeProxySettings(bundle=None)
+        fake_proxy = FakeProxySettings(bundle=None, clearance_enabled=True)
         cf_response = FakeResponse(
             status_code=403,
             text="<html><title>Just a moment...</title><body>challenge body</body></html>",

--- a/web/src/app/register/components/register-card.tsx
+++ b/web/src/app/register/components/register-card.tsx
@@ -22,7 +22,14 @@ export function RegisterCard() {
   const setTargetQuota = useSettingsStore((state) => state.setRegisterTargetQuota);
   const setTargetAvailable = useSettingsStore((state) => state.setRegisterTargetAvailable);
   const setCheckInterval = useSettingsStore((state) => state.setRegisterCheckInterval);
+  const setOtpResend = useSettingsStore((state) => state.setRegisterOtpResend);
+  const setOtpResendDelay = useSettingsStore((state) => state.setRegisterOtpResendDelay);
   const setMailField = useSettingsStore((state) => state.setRegisterMailField);
+  const presets = useSettingsStore((state) => state.registerPresets);
+  const selectedPreset = useSettingsStore((state) => state.selectedRegisterPreset);
+  const setSelectedPreset = useSettingsStore((state) => state.setSelectedRegisterPreset);
+  const applyPreset = useSettingsStore((state) => state.applySelectedRegisterPreset);
+  const savePreset = useSettingsStore((state) => state.saveCurrentRegisterPreset);
   const addProvider = useSettingsStore((state) => state.addRegisterProvider);
   const updateProvider = useSettingsStore((state) => state.updateRegisterProvider);
   const deleteProvider = useSettingsStore((state) => state.deleteRegisterProvider);
@@ -41,14 +48,27 @@ export function RegisterCard() {
 
   if (!config) return null;
 
-  const stats = config.stats || { success: 0, fail: 0, done: 0, running: 0, threads: config.threads };
+  const stats = config.stats || {
+    success: 0,
+    fail: 0,
+    done: 0,
+    running: 0,
+    threads: config.threads,
+    avg_stage_ms: {},
+    last_errors_by_stage: {},
+    mailbox_provider_success: {},
+    otp_wait_avg_seconds: 0,
+  };
   const providers = config.mail.providers || [];
   const logs = config.logs || [];
+  const stageEntries = Object.entries(stats.avg_stage_ms || {});
+  const errorEntries = Object.entries(stats.last_errors_by_stage || {});
+  const providerSuccessEntries = Object.entries(stats.mailbox_provider_success || {});
   const updateProviderType = (index: number, type: string) => {
     updateProvider(index, {
       type,
       enable: true,
-      ...(type === "cloudmail_gen" ? { api_base: "", admin_email: "", admin_password: "", domain: [], subdomain: [], email_prefix: "" } : {}),
+      ...(type === "cloudmail_gen" ? { api_base: "", admin_email: "", admin_password: "", domain: [], subdomain: [], email_prefix: "", auto_add_account: true } : {}),
       ...(type === "cloudflare_temp_email" ? { api_base: "", admin_password: "", domain: [] } : {}),
       ...(type === "tempmail_lol" ? { api_key: "", domain: [] } : {}),
       ...(type === "moemail" ? { api_base: "", api_key: "", domain: [] } : {}),
@@ -82,6 +102,33 @@ export function RegisterCard() {
           <div className="flex items-start gap-2 rounded-xl border border-sky-200 bg-sky-50 px-3 py-2 text-xs leading-5 text-sky-800">
             <AlertTriangle className="mt-0.5 size-4 shrink-0" />
             <span>如果注册日志出现 Cloudflare 拦截，可在设置页启用 FlareSolverr 清障；相关 Docker 容器需要先启动。</span>
+          </div>
+
+          <div className="grid gap-2 border border-stone-200 bg-white/70 p-3 md:grid-cols-[1fr_auto_auto_auto_auto]">
+            <Select value={selectedPreset || undefined} onValueChange={setSelectedPreset} disabled={config.enabled || presets.length === 0}>
+              <SelectTrigger className="h-9 rounded-xl border-stone-200 bg-white">
+                <SelectValue placeholder="Select preset" />
+              </SelectTrigger>
+              <SelectContent>
+                {presets.map((name) => (
+                  <SelectItem key={name} value={name}>{name}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button type="button" variant="outline" className="h-9 rounded-xl border-stone-200 bg-white px-3 text-stone-700" onClick={() => void applyPreset()} disabled={isSaving || config.enabled || !selectedPreset}>
+              <RotateCcw className="size-4" />
+              Apply
+            </Button>
+            <Button type="button" variant="outline" className="h-9 rounded-xl border-stone-200 bg-white px-3 text-stone-700" onClick={() => setProxy("http://127.0.0.1:10808")} disabled={config.enabled}>
+              Local proxy
+            </Button>
+            <Button type="button" variant="outline" className="h-9 rounded-xl border-stone-200 bg-white px-3 text-stone-700" onClick={() => setProxy("")} disabled={config.enabled}>
+              VPS WARP
+            </Button>
+            <Button type="button" variant="outline" className="h-9 rounded-xl border-stone-200 bg-white px-3 text-stone-700" onClick={() => void savePreset()} disabled={isSaving || config.enabled}>
+              <Save className="size-4" />
+              Save preset
+            </Button>
           </div>
 
           <div className="grid gap-4 md:grid-cols-3">
@@ -121,6 +168,23 @@ export function RegisterCard() {
             <div className="space-y-2">
               <label className="text-sm text-stone-700">检查间隔（秒）</label>
               <Input value={String(config.check_interval || "")} onChange={(event) => setCheckInterval(event.target.value)} className="h-10 rounded-xl border-stone-200 bg-white" disabled={config.enabled || config.mode === "total"} />
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm text-stone-700">OTP resend</label>
+              <Select value={config.otp_resend || "after_delay"} onValueChange={(value) => setOtpResend(value as "always" | "after_delay" | "off")} disabled={config.enabled}>
+                <SelectTrigger className="h-10 rounded-xl border-stone-200 bg-white">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="after_delay">After delay</SelectItem>
+                  <SelectItem value="always">Always</SelectItem>
+                  <SelectItem value="off">Off</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm text-stone-700">Resend delay (s)</label>
+              <Input value={String(config.otp_resend_delay ?? 5)} onChange={(event) => setOtpResendDelay(event.target.value)} className="h-10 rounded-xl border-stone-200 bg-white" disabled={config.enabled || (config.otp_resend || "after_delay") !== "after_delay"} />
             </div>
           </div>
 
@@ -205,6 +269,10 @@ export function RegisterCard() {
                                 <label className="text-sm text-stone-700">管理员密码</label>
                                 <Input value={String(provider.admin_password || "")} onChange={(event) => updateProvider(index, { admin_password: event.target.value })} className="h-10 rounded-xl border-stone-200 bg-white" disabled={config.enabled} />
                               </div>
+                              <label className="flex items-center gap-3 pt-8 text-sm text-stone-700">
+                                <Checkbox checked={Boolean(provider.auto_add_account ?? true)} onCheckedChange={(checked) => updateProvider(index, { auto_add_account: Boolean(checked) })} disabled={config.enabled} />
+                                Auto add CloudMail account
+                              </label>
                             </>
                           ) : null}
                           {type === "cloudflare_temp_email" || type === "ddg_mail" ? (
@@ -376,6 +444,45 @@ export function RegisterCard() {
                   <div className="mt-1 text-base font-semibold text-stone-800">{value}</div>
                 </div>
               ))}
+            </div>
+            <div className="grid gap-2 border border-stone-200 bg-white/70 p-3 text-xs md:grid-cols-3">
+              <div>
+                <div className="font-semibold text-stone-700">Avg stage time</div>
+                <div className="mt-2 space-y-1 text-stone-500">
+                  {stageEntries.length ? stageEntries.map(([key, value]) => (
+                    <div key={key} className="flex justify-between gap-3">
+                      <span>{key}</span>
+                      <span className="font-mono text-stone-800">{value}ms</span>
+                    </div>
+                  )) : <span>None</span>}
+                </div>
+              </div>
+              <div>
+                <div className="font-semibold text-stone-700">Provider success</div>
+                <div className="mt-2 space-y-1 text-stone-500">
+                  {providerSuccessEntries.length ? providerSuccessEntries.map(([key, value]) => (
+                    <div key={key} className="flex justify-between gap-3">
+                      <span>{key}</span>
+                      <span className="font-mono text-stone-800">{value}</span>
+                    </div>
+                  )) : <span>None</span>}
+                  <div className="flex justify-between gap-3">
+                    <span>OTP avg wait</span>
+                    <span className="font-mono text-stone-800">{stats.otp_wait_avg_seconds || 0}s</span>
+                  </div>
+                </div>
+              </div>
+              <div>
+                <div className="font-semibold text-stone-700">Recent failure stage</div>
+                <div className="mt-2 space-y-1 text-stone-500">
+                  {errorEntries.length ? errorEntries.slice(-4).map(([key, value]) => (
+                    <div key={key}>
+                      <span className="font-mono text-rose-600">{key}</span>
+                      <span className="ml-2 break-all">{value}</span>
+                    </div>
+                  )) : <span>None</span>}
+                </div>
+              </div>
             </div>
             <div className="grid grid-cols-3 gap-2">
               <Button className="h-10 rounded-xl bg-stone-950 px-3 text-white hover:bg-stone-800" onClick={() => void toggle()} disabled={isSaving}>

--- a/web/src/app/settings/store.ts
+++ b/web/src/app/settings/store.ts
@@ -996,19 +996,17 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
     if (!registerConfig) return;
     set({ isSavingRegister: true });
     try {
-      if (!registerConfig.enabled) {
-        await updateRegisterConfig({
-          mail: registerConfig.mail,
-          proxy: registerConfig.proxy.trim(),
-          total: Math.max(1, Number(registerConfig.total) || 1),
-          threads: Math.max(1, Number(registerConfig.threads) || 1),
-          mode: registerConfig.mode,
-          target_quota: Math.max(1, Number(registerConfig.target_quota) || 1),
-          target_available: Math.max(1, Number(registerConfig.target_available) || 1),
-          check_interval: Math.max(1, Number(registerConfig.check_interval) || 5),
-        });
-      }
-      const data = registerConfig.enabled ? await stopRegister() : await startRegister();
+      const updates = {
+        mail: registerConfig.mail,
+        proxy: registerConfig.proxy.trim(),
+        total: Math.max(1, Number(registerConfig.total) || 1),
+        threads: Math.max(1, Number(registerConfig.threads) || 1),
+        mode: registerConfig.mode,
+        target_quota: Math.max(1, Number(registerConfig.target_quota) || 1),
+        target_available: Math.max(1, Number(registerConfig.target_available) || 1),
+        check_interval: Math.max(1, Number(registerConfig.check_interval) || 5),
+      };
+      const data = registerConfig.enabled ? await stopRegister() : await startRegister(updates);
       set({ registerConfig: data.register });
       toast.success(registerConfig.enabled ? "注册任务已停止" : "注册任务已启动");
     } catch (error) {

--- a/web/src/app/settings/store.ts
+++ b/web/src/app/settings/store.ts
@@ -4,6 +4,7 @@ import { create } from "zustand";
 import { toast } from "sonner";
 
 import {
+  applyRegisterPreset,
   createCPAPool,
   deleteBackup,
   deleteCPAPool,
@@ -11,10 +12,12 @@ import {
   fetchCPAPools,
   fetchBackups,
   fetchRegisterConfig,
+  fetchRegisterPresets,
   resetRegister as resetRegisterApi,
   resetOutlookPool as resetOutlookPoolApi,
   fetchSettingsConfig,
   runBackupNow,
+  saveRegisterPreset,
   syncImageStorage,
   startRegister,
   startCPAImport,
@@ -265,6 +268,8 @@ type SettingsStore = {
   isSyncingImageStorage: boolean;
 
   registerConfig: RegisterConfig | null;
+  registerPresets: string[];
+  selectedRegisterPreset: string;
   isLoadingRegister: boolean;
   isSavingRegister: boolean;
 
@@ -333,7 +338,13 @@ type SettingsStore = {
   setRegisterTargetQuota: (value: string) => void;
   setRegisterTargetAvailable: (value: string) => void;
   setRegisterCheckInterval: (value: string) => void;
+  setRegisterOtpResend: (value: "always" | "after_delay" | "off") => void;
+  setRegisterOtpResendDelay: (value: string) => void;
   setRegisterMailField: (key: "request_timeout" | "wait_timeout" | "wait_interval", value: string) => void;
+  setSelectedRegisterPreset: (value: string) => void;
+  loadRegisterPresets: () => Promise<void>;
+  applySelectedRegisterPreset: () => Promise<void>;
+  saveCurrentRegisterPreset: () => Promise<void>;
   addRegisterProvider: () => void;
   updateRegisterProvider: (index: number, updates: Record<string, unknown>) => void;
   deleteRegisterProvider: (index: number) => void;
@@ -377,6 +388,8 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   isSyncingImageStorage: false,
 
   registerConfig: null,
+  registerPresets: [],
+  selectedRegisterPreset: "",
   isLoadingRegister: true,
   isSavingRegister: false,
 
@@ -883,6 +896,7 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
     try {
       const data = await fetchRegisterConfig();
       set({ registerConfig: data.register });
+      void get().loadRegisterPresets();
     } catch (error) {
       if (!silent) toast.error(error instanceof Error ? error.message : "加载注册配置失败");
     } finally {
@@ -922,6 +936,14 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
     set((state) => state.registerConfig ? { registerConfig: { ...state.registerConfig, check_interval: Number(value) || 0 } } : {});
   },
 
+  setRegisterOtpResend: (value) => {
+    set((state) => state.registerConfig ? { registerConfig: { ...state.registerConfig, otp_resend: value } } : {});
+  },
+
+  setRegisterOtpResendDelay: (value) => {
+    set((state) => state.registerConfig ? { registerConfig: { ...state.registerConfig, otp_resend_delay: Number(value) || 0 } } : {});
+  },
+
   setRegisterMailField: (key, value) => {
     set((state) => state.registerConfig ? {
       registerConfig: {
@@ -929,6 +951,72 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
         mail: { ...state.registerConfig.mail, [key]: Number(value) || 0 },
       },
     } : {});
+  },
+
+  setSelectedRegisterPreset: (value) => {
+    set({ selectedRegisterPreset: value });
+  },
+
+  loadRegisterPresets: async () => {
+    try {
+      const data = await fetchRegisterPresets();
+      const names = Object.keys(data.presets || {});
+      set((state) => ({
+        registerPresets: names,
+        selectedRegisterPreset: state.selectedRegisterPreset && names.includes(state.selectedRegisterPreset)
+          ? state.selectedRegisterPreset
+          : names[0] || "",
+      }));
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Load register presets failed");
+    }
+  },
+
+  applySelectedRegisterPreset: async () => {
+    const name = get().selectedRegisterPreset;
+    if (!name) {
+      toast.error("Select a register preset first");
+      return;
+    }
+    set({ isSavingRegister: true });
+    try {
+      const data = await applyRegisterPreset(name);
+      set({ registerConfig: data.register });
+      toast.success(`Applied preset: ${name}`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Apply register preset failed");
+    } finally {
+      set({ isSavingRegister: false });
+    }
+  },
+
+  saveCurrentRegisterPreset: async () => {
+    const { registerConfig } = get();
+    if (!registerConfig) return;
+    const name = window.prompt("Preset name", get().selectedRegisterPreset || "local-proxy");
+    if (!name?.trim()) return;
+    set({ isSavingRegister: true });
+    try {
+      const data = await saveRegisterPreset(name.trim(), {
+        mail: registerConfig.mail,
+        proxy: registerConfig.proxy.trim(),
+        total: Math.max(1, Number(registerConfig.total) || 1),
+        threads: Math.max(1, Number(registerConfig.threads) || 1),
+        mode: registerConfig.mode,
+        target_quota: Math.max(1, Number(registerConfig.target_quota) || 1),
+        target_available: Math.max(1, Number(registerConfig.target_available) || 1),
+        check_interval: Math.max(1, Number(registerConfig.check_interval) || 5),
+        otp_resend: registerConfig.otp_resend || "after_delay",
+        otp_resend_delay: Math.max(0, Number(registerConfig.otp_resend_delay) || 5),
+      });
+      const names = Object.keys(data.presets || {});
+      set({ registerPresets: names, selectedRegisterPreset: name.trim() });
+      toast.success(`Saved preset: ${name.trim()}`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Save register preset failed");
+    } finally {
+      set({ isSavingRegister: false });
+    }
   },
 
   addRegisterProvider: () => {
@@ -939,7 +1027,7 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
           ...state.registerConfig.mail,
           providers: [
             ...(state.registerConfig.mail.providers || []),
-            { enable: true, type: "cloudmail_gen", api_base: "", admin_email: "", admin_password: "", domain: [], subdomain: [], email_prefix: "" },
+            { enable: true, type: "cloudmail_gen", api_base: "", admin_email: "", admin_password: "", domain: [], subdomain: [], email_prefix: "", auto_add_account: true },
           ],
         },
       },
@@ -981,6 +1069,8 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
         target_quota: Math.max(1, Number(registerConfig.target_quota) || 1),
         target_available: Math.max(1, Number(registerConfig.target_available) || 1),
         check_interval: Math.max(1, Number(registerConfig.check_interval) || 5),
+        otp_resend: registerConfig.otp_resend || "after_delay",
+        otp_resend_delay: Math.max(0, Number(registerConfig.otp_resend_delay) || 5),
       });
       set({ registerConfig: data.register });
       toast.success("注册配置已保存");
@@ -1005,6 +1095,8 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
         target_quota: Math.max(1, Number(registerConfig.target_quota) || 1),
         target_available: Math.max(1, Number(registerConfig.target_available) || 1),
         check_interval: Math.max(1, Number(registerConfig.check_interval) || 5),
+        otp_resend: registerConfig.otp_resend || "after_delay",
+        otp_resend_delay: Math.max(0, Number(registerConfig.otp_resend_delay) || 5),
       };
       const data = registerConfig.enabled ? await stopRegister() : await startRegister(updates);
       set({ registerConfig: data.register });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -331,11 +331,15 @@ export type RegisterConfig = {
     request_timeout: number;
     wait_timeout: number;
     wait_interval: number;
+    fast_wait_seconds?: number;
+    fast_wait_interval?: number;
     providers: Array<Record<string, unknown>>;
   };
   proxy: string;
   total: number;
   threads: number;
+  otp_resend?: "always" | "after_delay" | "off";
+  otp_resend_delay?: number;
   mode: "total" | "quota" | "available";
   target_quota: number;
   target_available: number;
@@ -352,6 +356,10 @@ export type RegisterConfig = {
     success_rate?: number;
     current_quota?: number;
     current_available?: number;
+    avg_stage_ms?: Record<string, number>;
+    last_errors_by_stage?: Record<string, string>;
+    mailbox_provider_success?: Record<string, number>;
+    otp_wait_avg_seconds?: number;
     started_at?: string;
     updated_at?: string;
     finished_at?: string;
@@ -361,6 +369,10 @@ export type RegisterConfig = {
     text: string;
     level: string;
   }>;
+};
+
+export type RegisterPresetsResponse = {
+  presets: Record<string, Partial<RegisterConfig>>;
 };
 
 export async function login(authKey: string) {
@@ -771,6 +783,23 @@ export async function resetOutlookPool(scope: "all" | "failed" | "unused" = "all
   return httpRequest<{ register: RegisterConfig }>("/api/register/outlook-pool/reset", {
     method: "POST",
     body: { scope },
+  });
+}
+
+export async function fetchRegisterPresets() {
+  return httpRequest<RegisterPresetsResponse>("/api/register/presets");
+}
+
+export async function saveRegisterPreset(name: string, updates: Partial<RegisterConfig>) {
+  return httpRequest<RegisterPresetsResponse>(`/api/register/presets/${encodeURIComponent(name)}`, {
+    method: "POST",
+    body: updates,
+  });
+}
+
+export async function applyRegisterPreset(name: string) {
+  return httpRequest<{ register: RegisterConfig }>(`/api/register/presets/${encodeURIComponent(name)}/apply`, {
+    method: "POST",
   });
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -752,8 +752,11 @@ export async function updateRegisterConfig(updates: Partial<RegisterConfig>) {
   });
 }
 
-export async function startRegister() {
-  return httpRequest<{ register: RegisterConfig }>("/api/register/start", { method: "POST" });
+export async function startRegister(updates?: Partial<RegisterConfig>) {
+  return httpRequest<{ register: RegisterConfig }>("/api/register/start", {
+    method: "POST",
+    body: updates ?? {},
+  });
 }
 
 export async function stopRegister() {


### PR DESCRIPTION
## Summary

- Fix `cloudmail_gen` by creating/registering generated CloudMail addresses before OpenAI sends OTPs.
- Update the registration start path so API/UI starts apply the latest config body before launching.
- Improve OpenAI OTP flow diagnostics and CloudMail recipient matching, plus add one-shot diagnostic scripts.
- Add registration stage metrics, standardized failure stages, async account refresh, OTP resend strategy, fast mailbox polling, and register presets.
- Document current CloudMail registration status in `docs/cloudmail-registration-status.md`.

## Validation

- `uv run python -m unittest test.test_register_proxy_runtime`
- `uv run python -m py_compile api/register.py services/register_service.py services/register/mail_provider.py services/register/openai_register.py scripts/test_cloudmail.py scripts/test_openai_delivery.py`
- `npm run build` in Node 22 container for static web export.
- VPS `/api/register` stats verified includes `avg_stage_ms`, `last_errors_by_stage`, `mailbox_provider_success`, `otp_wait_avg_seconds`.
- VPS production staircase:
  - `total=5`, `threads=1`: success `5`, fail `0`, average about `10.0s/account`.
  - `total=10`, `threads=1`: success `9`, fail `1`, failure stage `openai_register`.
  - `total=10`, `threads=2`: success `10`, fail `0`, average about `5.0s/account`; one background `account_refresh` warning did not block registration.
  - `total=20`, `threads=2`: success `20`, fail `0`, average about `5.0s/account`.

## Operational Notes

- Runtime configs are kept under ignored `data/` paths and are not included in this PR.
- CloudMail is direct by default; set `mail.proxy` or provider-level `proxy` only when the mailbox provider itself needs a proxy.
- Account status refresh now runs in the background after successful save; refresh failures are warning-only.