### PR TITLE
Enforce request deadlines across image, text, search, and editable flows

### DIFF
--- a/services/config.py
+++ b/services/config.py
@@ -417,6 +417,13 @@ class ConfigStore:
             return 10.0
 
     @property
+    def image_timeout_retry_secs(self) -> int:
+        try:
+            return max(1, int(self.data.get("image_timeout_retry_secs", 30)))
+        except (TypeError, ValueError):
+            return 30
+
+    @property
     def image_account_concurrency(self) -> int:
         try:
             return max(1, int(self.data.get("image_account_concurrency", 3)))
@@ -546,6 +553,7 @@ class ConfigStore:
         data["image_poll_timeout_secs"] = self.image_poll_timeout_secs
         data["image_poll_interval_secs"] = self.image_poll_interval_secs
         data["image_poll_initial_wait_secs"] = self.image_poll_initial_wait_secs
+        data["image_timeout_retry_secs"] = self.image_timeout_retry_secs
         data["image_account_concurrency"] = self.image_account_concurrency
         data["image_parallel_generation"] = self.image_parallel_generation
         data["auto_remove_invalid_accounts"] = self.auto_remove_invalid_accounts

--- a/services/openai_backend_api.py
+++ b/services/openai_backend_api.py
@@ -9,6 +9,7 @@ import time
 import urllib.error
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from dataclasses import dataclass
 from io import BytesIO
 from pathlib import Path
@@ -56,6 +57,7 @@ DEFAULT_CLIENT_BUILD_NUMBER = "6708908"
 DEFAULT_POW_SCRIPT = "https://chatgpt.com/backend-api/sentinel/sdk.js"
 CODEX_IMAGE_MODEL = "codex-gpt-image-2"
 CODEX_RESPONSES_MODEL = "gpt-5.5"
+TEXT_STREAM_TIMEOUT_SECS = 300.0
 SEARCH_MODEL = "gpt-5-5"
 SEARCH_TIMEOUT_SECS = 300.0
 SEARCH_POLL_INTERVAL_SECS = 3.0
@@ -201,8 +203,43 @@ class OpenAIBackendAPI:
         if self.access_token:
             self.session.headers["Authorization"] = f"Bearer {self.access_token}"
 
+    def _active_request_deadline(self) -> float | None:
+        for attr_name in ("request_deadline", "image_request_deadline"):
+            deadline = getattr(self, attr_name, None)
+            if deadline is None:
+                continue
+            try:
+                return float(deadline)
+            except (TypeError, ValueError):
+                continue
+        return None
+
+    @contextmanager
+    def _request_deadline_scope(self, timeout_secs: float) -> Iterator[None]:
+        had_deadline = hasattr(self, "request_deadline")
+        previous_deadline = getattr(self, "request_deadline", None)
+        try:
+            next_deadline = time.monotonic() + max(0.0, float(timeout_secs))
+        except (TypeError, ValueError):
+            next_deadline = time.monotonic()
+
+        previous_deadline_float: float | None = None
+        if previous_deadline is not None:
+            try:
+                previous_deadline_float = float(previous_deadline)
+            except (TypeError, ValueError):
+                previous_deadline_float = None
+        self.request_deadline = min(previous_deadline_float, next_deadline) if previous_deadline_float is not None else next_deadline
+        try:
+            yield
+        finally:
+            if had_deadline:
+                self.request_deadline = previous_deadline
+            elif hasattr(self, "request_deadline"):
+                delattr(self, "request_deadline")
+
     def _deadline_timeout_secs(self, default_secs: float) -> float:
-        deadline = getattr(self, "image_request_deadline", None)
+        deadline = self._active_request_deadline()
         if deadline is not None:
             try:
                 remaining = float(deadline) - time.monotonic()
@@ -210,6 +247,22 @@ class OpenAIBackendAPI:
             except (TypeError, ValueError):
                 pass
         return float(default_secs)
+
+    def _deadline_expired(self) -> bool:
+        deadline = self._active_request_deadline()
+        return deadline is not None and time.monotonic() >= deadline
+
+    def _sleep_with_request_deadline(self, seconds: float) -> None:
+        sleep_for = max(0.0, float(seconds))
+        deadline = self._active_request_deadline()
+        if deadline is not None:
+            sleep_for = min(sleep_for, max(0.0, deadline - time.monotonic()))
+        if sleep_for > 0:
+            time.sleep(sleep_for)
+
+    @staticmethod
+    def _request_timeout_message(label: str, timeout_secs: float) -> str:
+        return f"ChatGPT {label}超时（已等待 {timeout_secs:g} 秒）。"
 
     def _image_request_timeout_secs(self) -> float:
         return self._deadline_timeout_secs(float(config.image_poll_timeout_secs))
@@ -1190,32 +1243,33 @@ class OpenAIBackendAPI:
         self.session.headers["OAI-Client-Build-Number"] = EDITABLE_FILE_CLIENT_BUILD_NUMBER
         output_path = Path(output_dir).expanduser().resolve()
         output_path.mkdir(parents=True, exist_ok=True)
-        uploaded = [self._upload_editable_base64_image(item, index) for index, item in enumerate(base64_images, start=1)]
-        conduit_token = self._prepare_editable_conversation(prompt, [item["mime_type"] for item in uploaded])
-        conversation_id = self._run_editable_conversation(prompt, uploaded, conduit_token)
-        artifacts = self._wait_editable_output_artifacts(
-            conversation_id,
-            primary_label,
-            primary_suffixes,
-            primary_mime_types,
-            primary_mime_keywords,
-            export_file_re,
-            timeout_secs,
-            poll_interval_secs,
-        )
-        downloaded = [self._download_editable_artifact(
-            conversation_id,
-            item,
-            output_path,
-            primary_mime_types,
-            primary_mime_keywords,
-            primary_default_extension,
-        ) for item in artifacts]
-        primary_path = next((item for item in downloaded if item.suffix.lower() in primary_suffixes), None)
-        zip_path = next((item for item in downloaded if item.suffix.lower() == ".zip"), None)
-        if not primary_path or not zip_path:
-            raise RuntimeError(f"download finished but did not get both {primary_label} and zip files: {downloaded}")
-        return EditableFileExportResult(conversation_id=conversation_id, primary_path=primary_path, zip_path=zip_path)
+        with self._request_deadline_scope(timeout_secs):
+            uploaded = [self._upload_editable_base64_image(item, index) for index, item in enumerate(base64_images, start=1)]
+            conduit_token = self._prepare_editable_conversation(prompt, [item["mime_type"] for item in uploaded])
+            conversation_id = self._run_editable_conversation(prompt, uploaded, conduit_token)
+            artifacts = self._wait_editable_output_artifacts(
+                conversation_id,
+                primary_label,
+                primary_suffixes,
+                primary_mime_types,
+                primary_mime_keywords,
+                export_file_re,
+                timeout_secs,
+                poll_interval_secs,
+            )
+            downloaded = [self._download_editable_artifact(
+                conversation_id,
+                item,
+                output_path,
+                primary_mime_types,
+                primary_mime_keywords,
+                primary_default_extension,
+            ) for item in artifacts]
+            primary_path = next((item for item in downloaded if item.suffix.lower() in primary_suffixes), None)
+            zip_path = next((item for item in downloaded if item.suffix.lower() == ".zip"), None)
+            if not primary_path or not zip_path:
+                raise RuntimeError(f"download finished but did not get both {primary_label} and zip files: {downloaded}")
+            return EditableFileExportResult(conversation_id=conversation_id, primary_path=primary_path, zip_path=zip_path)
 
     def _upload_editable_base64_image(self, base64_image: str, index: int) -> Dict[str, Any]:
         data, file_name, mime_type, width, height = self._decode_editable_base64_image(base64_image, index)
@@ -1232,7 +1286,7 @@ class OpenAIBackendAPI:
                 "store_in_library": True,
                 "library_persistence_mode": "opportunistic",
             },
-            timeout=60,
+            timeout=self._deadline_timeout_secs(60),
         )
         ensure_ok(response, path)
         payload = response.json()
@@ -1253,7 +1307,7 @@ class OpenAIBackendAPI:
                 "Accept-Language": "en-US,en;q=0.8",
             },
             data=data,
-            timeout=120,
+            timeout=self._deadline_timeout_secs(120),
         )
         ensure_ok(response, "image_upload")
         path = f"/backend-api/files/{file_id}/uploaded"
@@ -1261,7 +1315,7 @@ class OpenAIBackendAPI:
             self.base_url + path,
             headers=self._headers(path, {"Accept": "*/*", "Content-Type": "application/json"}),
             data="{}",
-            timeout=60,
+            timeout=self._deadline_timeout_secs(60),
         )
         ensure_ok(response, path)
         return {
@@ -1316,7 +1370,7 @@ class OpenAIBackendAPI:
             self.base_url + path,
             headers=self._headers(path, {"Accept": "*/*", "Content-Type": "application/json", "X-Conduit-Token": "no-token"}),
             json=payload,
-            timeout=60,
+            timeout=self._deadline_timeout_secs(60),
         )
         ensure_ok(response, path)
         conduit_token = str(response.json().get("conduit_token") or "")
@@ -1389,18 +1443,22 @@ class OpenAIBackendAPI:
                 "force_parallel_switch": "auto",
                 "thinking_effort": EDITABLE_FILE_THINKING_EFFORT,
             },
-            timeout=300,
+            timeout=self._deadline_timeout_secs(300),
             stream=True,
         )
         ensure_ok(response, path)
         conversation_id = ""
         try:
-            for payload in iter_sse_payloads(response):
+            for payload in iter_sse_payloads(
+                    response,
+                    deadline=self._active_request_deadline(),
+                    timeout_message=self._request_timeout_message("可编辑文件生成", EDITABLE_FILE_TIMEOUT_SECS),
+            ):
                 if payload == "[DONE]":
                     break
                 conversation_id = conversation_id or self._find_editable_value(payload, "conversation_id")
         finally:
-            response.close()
+            self._close_stream_response(response)
         if not conversation_id:
             raise RuntimeError("conversation_id not found in stream")
         return conversation_id
@@ -1417,12 +1475,12 @@ class OpenAIBackendAPI:
             poll_interval_secs: float,
     ) -> list[EditableFileArtifact]:
         deadline = time.time() + timeout_secs
-        while time.time() < deadline:
+        while time.time() < deadline and not self._deadline_expired():
             try:
                 conversation = self._get_editable_conversation_detail(conversation_id)
             except UpstreamHTTPError as exc:
                 if exc.status_code in {404, 409, 423, 429, 500, 502, 503, 504}:
-                    time.sleep(poll_interval_secs)
+                    self._sleep_with_request_deadline(poll_interval_secs)
                     continue
                 raise
             targeted = self._pick_editable_target_artifacts(
@@ -1433,12 +1491,16 @@ class OpenAIBackendAPI:
             )
             if targeted:
                 return targeted
-            time.sleep(poll_interval_secs)
+            self._sleep_with_request_deadline(poll_interval_secs)
         raise RuntimeError(f"timed out waiting for {primary_label}/zip outputs")
 
     def _get_editable_conversation_detail(self, conversation_id: str) -> Dict[str, Any]:
         path = f"/backend-api/conversation/{conversation_id}"
-        response = self.session.get(self.base_url + path, headers=self._editable_conversation_document_headers(path, conversation_id), timeout=60)
+        response = self.session.get(
+            self.base_url + path,
+            headers=self._editable_conversation_document_headers(path, conversation_id),
+            timeout=self._deadline_timeout_secs(60),
+        )
         ensure_ok(response, path)
         return response.json()
 
@@ -1547,7 +1609,7 @@ class OpenAIBackendAPI:
         download_url = self._resolve_editable_download_url(conversation_id, artifact)
         if not download_url:
             raise RuntimeError(f"download url not found for artifact: {artifact}")
-        response = self.session.get(download_url, timeout=300)
+        response = self.session.get(download_url, timeout=self._deadline_timeout_secs(300))
         ensure_ok(response, "artifact_download")
         content_type = self._clean_editable_mime_type(response.headers.get("Content-Type") or artifact.mime_type)
         file_name = self._resolve_editable_output_name(artifact, response.url, response.headers.get("Content-Disposition"), content_type, primary_mime_types, primary_mime_keywords, primary_default_extension)
@@ -1566,7 +1628,7 @@ class OpenAIBackendAPI:
                 self.base_url + path,
                 headers=self._editable_download_headers(path, conversation_id, "/backend-api/conversation/{conversation_id}/interpreter/download"),
                 params={"message_id": artifact.message_id, "sandbox_path": artifact.sandbox_path},
-                timeout=60,
+                timeout=self._deadline_timeout_secs(60),
             )
             if 200 <= response.status_code < 300:
                 url = self._download_url_from_response(response)
@@ -1577,7 +1639,7 @@ class OpenAIBackendAPI:
             response = self.session.get(
                 self.base_url + path,
                 headers=self._editable_download_headers(path, conversation_id, "/backend-api/conversation/{conversation_id}/attachment/{attachment_id}/download"),
-                timeout=60,
+                timeout=self._deadline_timeout_secs(60),
             )
             if 200 <= response.status_code < 300:
                 url = self._download_url_from_response(response)
@@ -1589,7 +1651,7 @@ class OpenAIBackendAPI:
                 self.base_url + path,
                 headers=self._editable_download_headers(path, conversation_id, "/backend-api/files/download/{file_id}"),
                 params={"post_id": "", "inline": "false"},
-                timeout=60,
+                timeout=self._deadline_timeout_secs(60),
             )
             if 200 <= response.status_code < 300:
                 url = self._download_url_from_response(response)
@@ -1600,7 +1662,7 @@ class OpenAIBackendAPI:
             response = self.session.get(
                 self.base_url + path,
                 headers=self._editable_download_headers(path, conversation_id, "/backend-api/files/download/{file_id}"),
-                timeout=60,
+                timeout=self._deadline_timeout_secs(60),
             )
             if 200 <= response.status_code < 300:
                 url = self._download_url_from_response(response)
@@ -1782,10 +1844,11 @@ class OpenAIBackendAPI:
                poll_interval_secs: float = SEARCH_POLL_INTERVAL_SECS) -> Dict[str, Any]:
         if not self.access_token:
             raise RuntimeError("access_token is required for search")
-        conduit_token = self._prepare_search_conversation(prompt, model)
-        self._bootstrap()
-        conversation_id = self._run_search_conversation(prompt, conduit_token, model)
-        return self._wait_search_result(conversation_id, timeout_secs, poll_interval_secs)
+        with self._request_deadline_scope(timeout_secs):
+            conduit_token = self._prepare_search_conversation(prompt, model)
+            self._bootstrap()
+            conversation_id = self._run_search_conversation(prompt, conduit_token, model)
+            return self._wait_search_result(conversation_id, timeout_secs, poll_interval_secs)
 
     def _prepare_search_conversation(self, prompt: str, model: str) -> str:
         path = "/backend-api/f/conversation/prepare"
@@ -1807,7 +1870,7 @@ class OpenAIBackendAPI:
                 "supported_encodings": ["v1"],
                 "client_contextual_info": {"app_name": "chatgpt.com"},
             },
-            timeout=60,
+            timeout=self._deadline_timeout_secs(60),
         )
         ensure_ok(response, path)
         token = str(response.json().get("conduit_token") or "")
@@ -1852,18 +1915,22 @@ class OpenAIBackendAPI:
                 "paragen_cot_summary_display_override": "allow",
                 "force_parallel_switch": "auto",
             },
-            timeout=300,
+            timeout=self._deadline_timeout_secs(300),
             stream=True,
         )
         ensure_ok(response, path)
         conversation_id = ""
         try:
-            for payload in iter_sse_payloads(response):
+            for payload in iter_sse_payloads(
+                    response,
+                    deadline=self._active_request_deadline(),
+                    timeout_message=self._request_timeout_message("联网搜索", SEARCH_TIMEOUT_SECS),
+            ):
                 conversation_id = conversation_id or self._find_search_value(payload, "conversation_id")
                 if payload == "[DONE]":
                     break
         finally:
-            response.close()
+            self._close_stream_response(response)
         if not conversation_id:
             raise RuntimeError("conversation_id not found in stream")
         return conversation_id
@@ -1873,7 +1940,7 @@ class OpenAIBackendAPI:
         last_result: Dict[str, Any] | None = None
         last_answer = ""
         stable_hits = 0
-        while time.time() < deadline:
+        while time.time() < deadline and not self._deadline_expired():
             try:
                 last_result = self._extract_search_result(conversation_id, self._get_search_conversation(conversation_id))
             except UpstreamHTTPError as exc:
@@ -1887,7 +1954,7 @@ class OpenAIBackendAPI:
                 last_answer = answer
                 if stable_hits >= 2:
                     return last_result
-            time.sleep(poll_interval_secs)
+            self._sleep_with_request_deadline(poll_interval_secs)
         if last_result:
             return last_result
         raise RuntimeError(f"timed out waiting for search result: {conversation_id}")
@@ -1897,7 +1964,7 @@ class OpenAIBackendAPI:
         headers = self._headers(path, {"Accept": "*/*"})
         headers["Referer"] = f"{self.base_url}/c/{conversation_id}"
         headers["X-OpenAI-Target-Route"] = "/backend-api/conversation/{conversation_id}"
-        response = self.session.get(self.base_url + path, headers=headers, timeout=60)
+        response = self.session.get(self.base_url + path, headers=headers, timeout=self._deadline_timeout_secs(60))
         ensure_ok(response, path)
         return response.json()
 
@@ -2540,23 +2607,28 @@ class OpenAIBackendAPI:
             yield from self._stream_picture_conversation(prompt, model, images or [])
             return
 
-        normalized = messages or [{"role": "user", "content": prompt}]
-        self._bootstrap()
-        requirements = self._get_chat_requirements()
-        path, timezone = self._chat_target()
-        payload = self._conversation_payload(normalized, model, timezone)
-        response = self.session.post(
-            self.base_url + path,
-            headers=self._conversation_headers(path, requirements),
-            json=payload,
-            timeout=300,
-            stream=True,
-        )
-        ensure_ok(response, path)
-        try:
-            yield from iter_sse_payloads(response)
-        finally:
-            response.close()
+        with self._request_deadline_scope(TEXT_STREAM_TIMEOUT_SECS):
+            normalized = messages or [{"role": "user", "content": prompt}]
+            self._bootstrap()
+            requirements = self._get_chat_requirements()
+            path, timezone = self._chat_target()
+            payload = self._conversation_payload(normalized, model, timezone)
+            response = self.session.post(
+                self.base_url + path,
+                headers=self._conversation_headers(path, requirements),
+                json=payload,
+                timeout=self._deadline_timeout_secs(TEXT_STREAM_TIMEOUT_SECS),
+                stream=True,
+            )
+            ensure_ok(response, path)
+            try:
+                yield from iter_sse_payloads(
+                    response,
+                    deadline=self._active_request_deadline(),
+                    timeout_message=self._request_timeout_message("文本生成", TEXT_STREAM_TIMEOUT_SECS),
+                )
+            finally:
+                self._close_stream_response(response)
 
     def _report_progress(self, step: str) -> None:
         """Report progress step to the callback if set."""

--- a/services/openai_backend_api.py
+++ b/services/openai_backend_api.py
@@ -201,7 +201,7 @@ class OpenAIBackendAPI:
         if self.access_token:
             self.session.headers["Authorization"] = f"Bearer {self.access_token}"
 
-    def _image_request_timeout_secs(self) -> float:
+    def _deadline_timeout_secs(self, default_secs: float) -> float:
         deadline = getattr(self, "image_request_deadline", None)
         if deadline is not None:
             try:
@@ -209,7 +209,23 @@ class OpenAIBackendAPI:
                 return max(1.0, remaining)
             except (TypeError, ValueError):
                 pass
-        return float(config.image_poll_timeout_secs)
+        return float(default_secs)
+
+    def _image_request_timeout_secs(self) -> float:
+        return self._deadline_timeout_secs(float(config.image_poll_timeout_secs))
+
+    def _image_timeout_message(self) -> str:
+        return (
+            f"ChatGPT 生图超时（已等待 {config.image_poll_timeout_secs} 秒）。"
+            f"当前超时阈值可在 config.json 中调大 image_poll_timeout_secs，"
+            f"也可能是账号被限流或生图队列拥堵导致。"
+        )
+
+    @staticmethod
+    def _close_stream_response(response: Any) -> None:
+        if getattr(response, "_stream_closed", False):
+            return
+        response.close()
 
     def _build_fp(self) -> Dict[str, str]:
         account = self.account
@@ -665,10 +681,24 @@ class OpenAIBackendAPI:
             },
         })
 
-    @staticmethod
-    def _iter_codex_response_events(raw: Any) -> Iterator[Dict[str, Any]]:
+    def _read_codex_response_text(self, raw: Any) -> str:
+        deadline = getattr(self, "image_request_deadline", None)
+        if deadline is None:
+            return raw.read().decode("utf-8", "replace")
+        chunks: list[bytes] = []
+        while True:
+            remaining = float(deadline) - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(self._image_timeout_message())
+            chunk = raw.read(65536)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        return b"".join(chunks).decode("utf-8", "replace")
+
+    def _iter_codex_response_events(self, raw: Any) -> Iterator[Dict[str, Any]]:
         content_type = str(raw.headers.get("content-type") or "").lower()
-        text = raw.read().decode("utf-8", "replace")
+        text = self._read_codex_response_text(raw)
         status_code = getattr(raw, "status", None)
         parse_errors: list[str] = []
         events: list[Dict[str, Any]] = []
@@ -838,7 +868,7 @@ class OpenAIBackendAPI:
             self.base_url + path,
             headers=self._image_headers(path, requirements),
             json=payload,
-            timeout=60,
+            timeout=self._deadline_timeout_secs(60),
         )
         ensure_ok(response, path)
         return response.json().get("conduit_token", "")
@@ -880,7 +910,7 @@ class OpenAIBackendAPI:
             headers=self._headers(path, {"Content-Type": "application/json", "Accept": "application/json"}),
             json={"file_name": file_name, "file_size": len(data), "use_case": "multimodal", "width": width,
                   "height": height},
-            timeout=60,
+            timeout=self._deadline_timeout_secs(60),
         )
         ensure_ok(response, path)
         upload_meta = response.json()
@@ -897,7 +927,7 @@ class OpenAIBackendAPI:
                 "Accept-Language": "en-US,en;q=0.8",
             },
             data=data,
-            timeout=120,
+            timeout=self._deadline_timeout_secs(120),
         )
         ensure_ok(response, "image_upload")
         path = f"/backend-api/files/{upload_meta['file_id']}/uploaded"
@@ -905,7 +935,7 @@ class OpenAIBackendAPI:
             self.base_url + path,
             headers=self._headers(path, {"Content-Type": "application/json", "Accept": "application/json"}),
             data="{}",
-            timeout=60,
+            timeout=self._deadline_timeout_secs(60),
         )
         ensure_ok(response, path)
         return {
@@ -990,11 +1020,11 @@ class OpenAIBackendAPI:
         ensure_ok(response, path)
         return response
 
-    def _get_conversation(self, conversation_id: str) -> Dict[str, Any]:
+    def _get_conversation(self, conversation_id: str, timeout_secs: float = 60.0) -> Dict[str, Any]:
         """获取完整 conversation 详情。"""
         path = f"/backend-api/conversation/{conversation_id}"
         response = self.session.get(self.base_url + path, headers=self._headers(path, {"Accept": "application/json"}),
-                                    timeout=60)
+                                    timeout=timeout_secs)
         ensure_ok(response, path)
         return response.json()
 
@@ -2135,7 +2165,10 @@ class OpenAIBackendAPI:
             # 内容政策违规检测通过对话文本进行（在 _find_content_policy_error_in_conversation 中）
             last_task_error = ""
             try:
-                tasks = self._query_backend_tasks(conversation_id=conversation_id, timeout_secs=5.0)
+                tasks = self._query_backend_tasks(
+                    conversation_id=conversation_id,
+                    timeout_secs=min(5.0, max(0.001, _remaining())),
+                )
                 for task in tasks:
                     is_error, error_msg, metadata = self.check_task_error(task)
                     if is_error and error_msg:
@@ -2157,7 +2190,10 @@ class OpenAIBackendAPI:
                 })
 
             try:
-                conversation = self._get_conversation(conversation_id)
+                conversation = self._get_conversation(
+                    conversation_id,
+                    timeout_secs=min(60.0, max(0.001, _remaining())),
+                )
             except UpstreamHTTPError as exc:
                 if exc.status_code in (429, 500, 502, 503, 504):
                     if _retry_sleep("upstream_status", exc.status_code, None, exc.retry_after):
@@ -2243,20 +2279,25 @@ class OpenAIBackendAPI:
         setattr(exc, "conversation_id", conversation_id or "")
         raise exc
 
-    def _get_file_download_url(self, file_id: str) -> str:
+    def _get_file_download_url(self, file_id: str, timeout_secs: float = 60.0) -> str:
         """获取文件下载地址。"""
         path = f"/backend-api/files/{file_id}/download"
         response = self.session.get(self.base_url + path, headers=self._headers(path, {"Accept": "application/json"}),
-                                    timeout=60)
+                                    timeout=timeout_secs)
         ensure_ok(response, path)
         data = response.json()
         return data.get("download_url") or data.get("url") or ""
 
-    def _get_attachment_download_url(self, conversation_id: str, attachment_id: str) -> str:
+    def _get_attachment_download_url(
+        self,
+        conversation_id: str,
+        attachment_id: str,
+        timeout_secs: float = 60.0,
+    ) -> str:
         """通过 conversation 附件接口获取下载地址。"""
         path = f"/backend-api/conversation/{conversation_id}/attachment/{attachment_id}/download"
         response = self.session.get(self.base_url + path, headers=self._headers(path, {"Accept": "application/json"}),
-                                    timeout=60)
+                                    timeout=timeout_secs)
         ensure_ok(response, path)
         data = response.json()
         return data.get("download_url") or data.get("url") or ""
@@ -2347,7 +2388,7 @@ class OpenAIBackendAPI:
                 })
                 continue
             try:
-                url = self._get_file_download_url(file_id)
+                url = self._get_file_download_url(file_id, timeout_secs=self._deadline_timeout_secs(60))
             except Exception as exc:
                 logger.debug({
                     "event": "image_download_url_failed",
@@ -2378,7 +2419,11 @@ class OpenAIBackendAPI:
             return urls
         for sediment_id in sediment_ids:
             try:
-                url = self._get_attachment_download_url(conversation_id, sediment_id)
+                url = self._get_attachment_download_url(
+                    conversation_id,
+                    sediment_id,
+                    timeout_secs=self._deadline_timeout_secs(60),
+                )
             except Exception as exc:
                 logger.debug({
                     "event": "image_download_url_failed",
@@ -2476,7 +2521,7 @@ class OpenAIBackendAPI:
     def download_image_bytes(self, urls: list[str]) -> list[bytes]:
         images = []
         for url in urls:
-            response = self.session.get(url, timeout=120)
+            response = self.session.get(url, timeout=self._deadline_timeout_secs(120))
             ensure_ok(response, "image_download")
             if response.content not in images:
                 images.append(response.content)
@@ -2541,16 +2586,20 @@ class OpenAIBackendAPI:
         response = self._start_image_generation(prompt, requirements, conduit_token, model, references)
         self._report_progress("generating")
         try:
-            yield from iter_sse_payloads(response)
+            yield from iter_sse_payloads(
+                response,
+                deadline=getattr(self, "image_request_deadline", None),
+                timeout_message=self._image_timeout_message(),
+            )
         finally:
-            response.close()
+            self._close_stream_response(response)
 
     def _bootstrap(self) -> None:
         """预热首页，并提取 PoW 相关脚本引用。"""
         response = self.session.get(
             self.base_url + "/",
             headers=self._bootstrap_headers(),
-            timeout=30,
+            timeout=self._deadline_timeout_secs(30),
         )
         ensure_ok(response, "bootstrap")
         self.pow_script_sources, self.pow_data_build = parse_pow_resources(response.text)
@@ -2567,7 +2616,7 @@ class OpenAIBackendAPI:
             self.base_url + prepare_path,
             headers=self._headers(prepare_path, {"Content-Type": "application/json"}),
             json={"p": p_token},
-            timeout=30,
+            timeout=self._deadline_timeout_secs(30),
         )
         ensure_ok(response, "chat_requirements_prepare")
         prepare_data = response.json()
@@ -2600,7 +2649,7 @@ class OpenAIBackendAPI:
                 "proof_token": proof_token,
                 "turnstile_token": turnstile_token,
             },
-            timeout=30,
+            timeout=self._deadline_timeout_secs(30),
         )
         ensure_ok(response, "chat_requirements_finalize")
         data = response.json()

--- a/services/openai_backend_api.py
+++ b/services/openai_backend_api.py
@@ -201,6 +201,16 @@ class OpenAIBackendAPI:
         if self.access_token:
             self.session.headers["Authorization"] = f"Bearer {self.access_token}"
 
+    def _image_request_timeout_secs(self) -> float:
+        deadline = getattr(self, "image_request_deadline", None)
+        if deadline is not None:
+            try:
+                remaining = float(deadline) - time.monotonic()
+                return max(1.0, remaining)
+            except (TypeError, ValueError):
+                pass
+        return float(config.image_poll_timeout_secs)
+
     def _build_fp(self) -> Dict[str, str]:
         account = self.account
         raw_fp = account.get("fp")
@@ -755,7 +765,7 @@ class OpenAIBackendAPI:
             "event": "codex_responses_request_debug",
             "url": self.base_url + path,
             "transport": "urllib.request",
-            "timeout_secs": 1200,
+            "timeout_secs": self._image_request_timeout_secs(),
             "account_email": str(account.get("email") or "").strip(),
             "source_type": str(account.get("source_type") or "").strip(),
             "account_type": str(account.get("type") or "").strip(),
@@ -788,7 +798,7 @@ class OpenAIBackendAPI:
             },
         })
         try:
-            with urllib.request.urlopen(request, timeout=1200) as raw:
+            with urllib.request.urlopen(request, timeout=self._image_request_timeout_secs()) as raw:
                 yield from self._iter_codex_response_events(raw)
         except urllib.error.HTTPError as error:
             body_text = error.read().decode("utf-8", "replace")
@@ -974,7 +984,7 @@ class OpenAIBackendAPI:
             self.base_url + path,
             headers=self._image_headers(path, requirements, conduit_token, "text/event-stream"),
             json=payload,
-            timeout=300,
+            timeout=self._image_request_timeout_secs(),
             stream=True,
         )
         ensure_ok(response, path)

--- a/services/protocol/conversation.py
+++ b/services/protocol/conversation.py
@@ -13,7 +13,7 @@ import tiktoken
 from services.account_service import account_service
 from services.config import config
 from services.image_storage_service import image_storage_service
-from services.openai_backend_api import ImageContentPolicyError, ImagePollTimeoutError, OpenAIBackendAPI
+from services.openai_backend_api import ImageContentPolicyError, ImagePollTimeoutError, OpenAIBackendAPI, TEXT_STREAM_TIMEOUT_SECS
 from utils.helper import (
     IMAGE_MODELS,
     extract_image_from_message_content,
@@ -703,34 +703,48 @@ def stream_text_deltas(backend: OpenAIBackendAPI, request: ConversationRequest) 
     attempted_tokens: set[str] = set()
     token = getattr(backend, "access_token", "")
     emitted = False
-    while True:
-        if token and token in attempted_tokens:
-            raise RuntimeError("no available text account")
-        if token:
-            attempted_tokens.add(token)
-        try:
-            active_backend = OpenAIBackendAPI(access_token=token)
-            for event in conversation_events(active_backend, messages=request.messages, model=request.model, prompt=request.prompt):
-                if event.get("type") != "conversation.delta":
-                    continue
-                delta = str(event.get("delta") or "")
-                if delta:
-                    emitted = True
-                    yield delta
-            account_service.mark_text_used(token)
-            return
-        except Exception as exc:
-            error_message = str(exc)
-            if token and not emitted and is_token_invalid_error(error_message):
-                refreshed_token = account_service.refresh_access_token(token, force=True, event="text_stream")
-                if refreshed_token and refreshed_token != token and refreshed_token not in attempted_tokens:
-                    token = refreshed_token
-                else:
-                    account_service.remove_invalid_token(token, "text_stream")
-                    token = account_service.get_text_access_token(attempted_tokens)
-                if token:
-                    continue
-            raise
+    had_deadline = hasattr(backend, "request_deadline")
+    previous_deadline = getattr(backend, "request_deadline", None)
+    try:
+        request_deadline = float(previous_deadline) if previous_deadline is not None else time.monotonic() + TEXT_STREAM_TIMEOUT_SECS
+    except (TypeError, ValueError):
+        request_deadline = time.monotonic() + TEXT_STREAM_TIMEOUT_SECS
+    backend.request_deadline = request_deadline
+    try:
+        while True:
+            if token and token in attempted_tokens:
+                raise RuntimeError("no available text account")
+            if token:
+                attempted_tokens.add(token)
+            try:
+                active_backend = OpenAIBackendAPI(access_token=token)
+                active_backend.request_deadline = request_deadline
+                for event in conversation_events(active_backend, messages=request.messages, model=request.model, prompt=request.prompt):
+                    if event.get("type") != "conversation.delta":
+                        continue
+                    delta = str(event.get("delta") or "")
+                    if delta:
+                        emitted = True
+                        yield delta
+                account_service.mark_text_used(token)
+                return
+            except Exception as exc:
+                error_message = str(exc)
+                if token and not emitted and is_token_invalid_error(error_message):
+                    refreshed_token = account_service.refresh_access_token(token, force=True, event="text_stream")
+                    if refreshed_token and refreshed_token != token and refreshed_token not in attempted_tokens:
+                        token = refreshed_token
+                    else:
+                        account_service.remove_invalid_token(token, "text_stream")
+                        token = account_service.get_text_access_token(attempted_tokens)
+                    if token:
+                        continue
+                raise
+    finally:
+        if had_deadline:
+            backend.request_deadline = previous_deadline
+        elif hasattr(backend, "request_deadline"):
+            delattr(backend, "request_deadline")
 
 
 def collect_text(backend: OpenAIBackendAPI, request: ConversationRequest) -> str:

--- a/services/protocol/conversation.py
+++ b/services/protocol/conversation.py
@@ -88,6 +88,8 @@ def is_tls_connection_error(message: str) -> bool:
         or "connection aborted" in text
         or "remote disconnected" in text
         or "connection reset by peer" in text
+        or "curl: (92)" in text
+        or ("http/2 stream" in text and "internal_error" in text)
     )
 
 

--- a/services/protocol/conversation.py
+++ b/services/protocol/conversation.py
@@ -114,6 +114,28 @@ def image_stream_error_message(message: str) -> str:
     return text or "image generation failed"
 
 
+def _image_remaining_timeout_secs(backend: object) -> float:
+    deadline = getattr(backend, "image_request_deadline", None)
+    if deadline is not None:
+        try:
+            return max(0.0, float(deadline) - time.monotonic())
+        except (TypeError, ValueError):
+            pass
+    return float(config.image_poll_timeout_secs)
+
+
+def _sleep_image_retry(backend: object, seconds: float) -> None:
+    sleep_for = min(max(0.0, seconds), _image_remaining_timeout_secs(backend))
+    if sleep_for > 0:
+        time.sleep(sleep_for)
+
+
+def _sleep_until_deadline(deadline: float, seconds: float) -> None:
+    sleep_for = min(max(0.0, seconds), max(0.0, deadline - time.monotonic()))
+    if sleep_for > 0:
+        time.sleep(sleep_for)
+
+
 REFERENCED_IMAGE_IDS_RE = re.compile(r'"referenced_image_ids"\s*:\s*\[([^\]]+)\]')
 # 检测模型返回的部分工具调用 JSON（如 {"size":"1920x1088","n":1}）
 # 这些 JSON 包含图片生成工具的参数，但没有实际生成图片
@@ -803,6 +825,7 @@ def stream_image_outputs(
     file_ids = [str(item) for item in last.get("file_ids") or []]
     sediment_ids = [str(item) for item in last.get("sediment_ids") or []]
     message = str(last.get("text") or "").strip()
+    is_text_reply = bool(message and is_model_text_reply_instead_of_image(message))
     logger.info({
         "event": "image_stream_resolve_start",
         "conversation_id": conversation_id,
@@ -820,14 +843,13 @@ def stream_image_outputs(
         yield ImageOutput(kind="message", model=request.model, index=index, total=total, text=error_text, conversation_id=conversation_id)
         return
     should_poll_for_image = bool(request.images) or last.get("turn_use_case") == "image gen"
-    if message and not file_ids and not sediment_ids and not should_poll_for_image:
+    if message and not file_ids and not sediment_ids and not should_poll_for_image and not is_text_reply:
         yield ImageOutput(kind="message", model=request.model, index=index, total=total, text=message, conversation_id=conversation_id)
         return
 
     # 检测模型是否返回了文本描述（含 referenced_image_ids）而非实际生成图片
     # 这说明模型已发起图片生成工具调用，但 SSE 在工具完成前断开，
     # 图片可能正在异步生成中。需要使用更积极的轮询策略来获取结果。
-    is_text_reply = bool(message and is_model_text_reply_instead_of_image(message))
     if is_text_reply:
         logger.info({
             "event": "image_detected_text_reply_with_ids",
@@ -884,10 +906,8 @@ def stream_image_outputs(
     # 当检测到文本回复（含 referenced_image_ids）时，使用更长的超时来轮询图片结果。
     # 因为上游可能将图片生成作为异步任务执行，SSE 流在工具完成前就断开了，
     # 导致对话文档中尚未写入图片工具的响应记录。
-    poll_timeout = config.image_poll_timeout_secs
+    poll_timeout = _image_remaining_timeout_secs(backend)
     if is_text_reply and conversation_id:
-        # 文本回复场景下图片可能仍在异步生成，使用更长超时（默认 120s → 额外 180s = 300s）
-        poll_timeout = max(poll_timeout, 300)
         logger.info({
             "event": "image_text_reply_extended_poll",
             "conversation_id": conversation_id,
@@ -971,10 +991,12 @@ def stream_image_outputs(
                 "message_preview": message[:200],
             })
             # 文本回复场景下，图片可能需要 4-5 分钟才能异步生成完成。
-            # 使用 300s 超时并允许多次重试，避免因临时网络问题提前退出。
-            retry_poll_timeout = max(config.image_poll_timeout_secs, 300)
+            # 使用配置的剩余总预算并允许短重试，避免因临时网络问题提前退出。
             MAX_POLL_RETRIES = 3
             for poll_attempt in range(1, MAX_POLL_RETRIES + 1):
+                retry_poll_timeout = _image_remaining_timeout_secs(backend)
+                if retry_poll_timeout <= 0:
+                    break
                 try:
                     polled_file_ids, polled_sediment_ids = backend._poll_image_results(
                         conversation_id,
@@ -1011,7 +1033,7 @@ def stream_image_outputs(
                             "poll_attempt": poll_attempt,
                             "backoff_secs": backoff,
                         })
-                        time.sleep(backoff)
+                        _sleep_image_retry(backend, backoff)
                         continue
                     # 超时错误或重试次数用尽，停止重试
                     break
@@ -1075,8 +1097,7 @@ def stream_image_outputs(
             })
     if should_poll_for_image and conversation_id:
         # 图片可能仍在异步处理中（上游 SSE 流在图片生成完成前就结束了）。
-        # 使用 300s 超时并允许多次重试，避免因临时网络问题或图片尚未提交而提前退出。
-        retry_poll_timeout = max(config.image_poll_timeout_secs, 300)
+        # 使用配置的剩余总预算并允许短重试，避免因临时网络问题或图片尚未提交而提前退出。
         MAX_FALLBACK_POLL_RETRIES = 3
         for poll_attempt in range(1, MAX_FALLBACK_POLL_RETRIES + 1):
             retry_wait_secs = min(30.0 * poll_attempt, config.image_poll_initial_wait_secs * poll_attempt)
@@ -1086,7 +1107,10 @@ def stream_image_outputs(
                 "retry_wait_secs": retry_wait_secs,
                 "poll_attempt": poll_attempt,
             })
-            time.sleep(retry_wait_secs)
+            _sleep_image_retry(backend, retry_wait_secs)
+            retry_poll_timeout = _image_remaining_timeout_secs(backend)
+            if retry_poll_timeout <= 0:
+                break
             try:
                 polled_file_ids, polled_sediment_ids = backend._poll_image_results(
                     conversation_id,
@@ -1123,7 +1147,7 @@ def stream_image_outputs(
                         "poll_attempt": poll_attempt,
                         "backoff_secs": backoff,
                     })
-                    time.sleep(backoff)
+                    _sleep_image_retry(backend, backoff)
                     continue
                 # 超时错误或重试次数用尽，停止重试
                 break
@@ -1236,8 +1260,16 @@ def _generate_single_image(
     conn_timeout_retry_count = 0
     poll_timeout_retry_count = 0
     account_email = ""
+    request_deadline = time.monotonic() + float(config.image_poll_timeout_secs)
 
     while True:
+        remaining_before_attempt = request_deadline - time.monotonic()
+        if remaining_before_attempt <= 0:
+            raise ImagePollTimeoutError(
+                f"ChatGPT 生图超时（已等待 {config.image_poll_timeout_secs} 秒）。"
+                f"当前超时阈值可在 config.json 中调大 image_poll_timeout_secs，"
+                f"也可能是账号被限流或生图队列拥堵导致。"
+            )
         try:
             if request.progress_callback:
                 request.progress_callback("getting_account")
@@ -1265,6 +1297,7 @@ def _generate_single_image(
         })
         try:
             backend = OpenAIBackendAPI(access_token=token)
+            backend.image_request_deadline = request_deadline
             if request.progress_callback:
                 backend.progress_callback = request.progress_callback
             stream_fn = stream_codex_image_outputs if is_codex_image_model(request.model) else stream_image_outputs
@@ -1310,7 +1343,7 @@ def _generate_single_image(
             # 轮询超时：换账号重试
             if not emitted_for_token:
                 poll_timeout_retry_count += 1
-                if poll_timeout_retry_count <= MAX_POLL_TIMEOUT_RETRIES:
+                if poll_timeout_retry_count <= MAX_POLL_TIMEOUT_RETRIES and request_deadline > time.monotonic():
                     logger.warning({
                         "event": "image_poll_timeout_retry",
                         "request_token": token,
@@ -1408,21 +1441,23 @@ def _generate_single_image(
             # TLS/SSL 连接错误：自动重试
             if not emitted_for_token and is_tls_connection_error(last_error):
                 tls_retry_count += 1
-                if tls_retry_count <= MAX_TLS_RETRIES:
+                if tls_retry_count <= MAX_TLS_RETRIES and request_deadline > time.monotonic():
+                    wait_secs = min(2.0 * tls_retry_count, 10.0)
                     logger.warning({
                         "event": "image_stream_tls_retry",
                         "request_token": token,
                         "account_email": account_email,
                         "retry_count": tls_retry_count,
                         "index": index,
+                        "wait_secs": wait_secs,
                         "error": last_error[:200],
                     })
-                    time.sleep(min(2.0 * tls_retry_count, 10.0))
+                    _sleep_until_deadline(request_deadline, wait_secs)
                     continue
             # 连接超时错误（curl 28）：同账号短等待重试，不切换账号
             if not emitted_for_token and is_connection_timeout_error(last_error):
                 conn_timeout_retry_count += 1
-                if conn_timeout_retry_count <= MAX_CONN_TIMEOUT_RETRIES:
+                if conn_timeout_retry_count <= MAX_CONN_TIMEOUT_RETRIES and request_deadline > time.monotonic():
                     wait_secs = min(3.0 * conn_timeout_retry_count, 9.0)
                     logger.warning({
                         "event": "image_stream_conn_timeout_retry",
@@ -1433,7 +1468,7 @@ def _generate_single_image(
                         "wait_secs": wait_secs,
                         "error": last_error[:200],
                     })
-                    time.sleep(wait_secs)
+                    _sleep_until_deadline(request_deadline, wait_secs)
                     continue
             raise ImageGenerationError(image_stream_error_message(last_error), account_email=account_email, conversation_id="") from exc
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -58,6 +58,19 @@ class ConfigLoadingTests(unittest.TestCase):
                 else:
                     module.os.environ["CHATGPT2API_AUTH_KEY"] = old_env_auth_key
 
+    def test_image_timeout_retry_secs_is_normalized_in_public_config(self) -> None:
+        module = self.config_module
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config_file = Path(tmp_dir) / "config.json"
+            config_file.write_text(
+                json.dumps({"auth-key": "test-auth", "image_timeout_retry_secs": "0"}),
+                encoding="utf-8",
+            )
+            store = module.ConfigStore(config_file)
+
+            self.assertEqual(store.image_timeout_retry_secs, 1)
+            self.assertEqual(store.get()["image_timeout_retry_secs"], 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_multi_image_results.py
+++ b/test/test_multi_image_results.py
@@ -5,8 +5,14 @@ import unittest
 from unittest import mock
 
 from services.config import config
-from services.openai_backend_api import OpenAIBackendAPI
-from services.protocol.conversation import ImageOutput, extract_conversation_ids
+from services.openai_backend_api import ImagePollTimeoutError, OpenAIBackendAPI
+from services.protocol.conversation import (
+    ConversationRequest,
+    ImageOutput,
+    _generate_single_image,
+    extract_conversation_ids,
+    stream_image_outputs,
+)
 from services.protocol.openai_v1_response import stream_image_response
 
 
@@ -119,7 +125,12 @@ class MultiImageResultTests(unittest.TestCase):
         ])
 
         with (
-            mock.patch.dict(config.data, {"image_poll_initial_wait_secs": 0, "image_poll_interval_secs": 0.5}),
+            mock.patch.dict(config.data, {
+                "image_poll_initial_wait_secs": 0,
+                "image_poll_interval_secs": 0.5,
+                "image_check_before_hit_enabled": True,
+                "image_settle_enabled": True,
+            }),
             mock.patch("services.openai_backend_api.time.sleep", lambda _seconds: None),
         ):
             file_ids, sediment_ids = backend._poll_image_results("conv-1", timeout_secs=10)
@@ -174,6 +185,64 @@ class MultiImageResultTests(unittest.TestCase):
 
         self.assertEqual([event["output_index"] for event in done_events], [0, 1])
         self.assertEqual([item["result"] for item in completed["output"]], [first, second])
+
+    def test_text_reply_retry_poll_uses_configured_timeout_without_300_second_floor(self) -> None:
+        backend = mock.Mock()
+        backend.stream_conversation.return_value = iter([
+            '{"conversation_id":"conv-1","message":{"author":{"role":"assistant"},'
+            '"content":{"parts":["{\\"referenced_image_ids\\":[\\"file-input\\"]}"]}}}',
+            "[DONE]",
+        ])
+        backend.resolve_conversation_image_urls.return_value = []
+        backend._poll_image_results.side_effect = RuntimeError("temporary upstream failure")
+
+        with (
+            mock.patch.dict(config.data, {"image_poll_timeout_secs": 7, "image_poll_initial_wait_secs": 0}),
+            mock.patch("services.protocol.conversation.time.sleep", lambda _seconds: None),
+        ):
+            outputs = list(stream_image_outputs(
+                backend,
+                ConversationRequest(prompt="draw", model="gpt-image-2"),
+            ))
+
+        self.assertEqual(outputs[-1].kind, "message")
+        self.assertEqual([call.args[1] for call in backend._poll_image_results.call_args_list], [7, 7, 7])
+
+    def test_image_generation_sse_request_uses_configured_image_timeout(self) -> None:
+        backend = OpenAIBackendAPI.__new__(OpenAIBackendAPI)
+        backend.base_url = "https://chatgpt.test"
+        backend.session = mock.Mock()
+        backend.session.post.return_value.status_code = 200
+        backend._image_headers = mock.Mock(return_value={"Accept": "text/event-stream"})
+        requirements = mock.Mock(token="token", proof_token="", turnstile_token="", so_token="")
+
+        with mock.patch.dict(config.data, {"image_poll_timeout_secs": 11}):
+            backend._start_image_generation("draw", requirements, "conduit", "gpt-image-2")
+
+        self.assertEqual(backend.session.post.call_args.kwargs["timeout"], 11)
+
+    def test_image_poll_timeout_retry_stops_when_configured_budget_is_exhausted(self) -> None:
+        backend = mock.Mock()
+        backend.image_request_deadline = None
+        token = "token-1"
+
+        def fail_poll(*_args, **_kwargs):
+            raise ImagePollTimeoutError("timed out")
+
+        with (
+            mock.patch.dict(config.data, {"image_poll_timeout_secs": 1}),
+            mock.patch("services.protocol.conversation.time.monotonic", side_effect=[100.0, 100.1, 101.2]),
+            mock.patch("services.protocol.conversation.account_service.get_available_access_token", return_value=token) as get_token,
+            mock.patch("services.protocol.conversation.account_service.get_account", return_value={"email": "a@example.test"}),
+            mock.patch("services.protocol.conversation.account_service.mark_image_result"),
+            mock.patch("services.protocol.conversation.OpenAIBackendAPI", return_value=backend),
+            mock.patch("services.protocol.conversation.stream_image_outputs", side_effect=fail_poll),
+        ):
+            with self.assertRaises(ImagePollTimeoutError):
+                _generate_single_image(ConversationRequest(prompt="draw", model="gpt-image-2"), 1, 1)
+
+        self.assertEqual(get_token.call_count, 1)
+        self.assertEqual(backend.image_request_deadline, 101.0)
 
 
 if __name__ == "__main__":

--- a/test/test_multi_image_results.py
+++ b/test/test_multi_image_results.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import base64
+import queue
 import unittest
 from unittest import mock
+
+from curl_cffi.requests.models import STREAM_END
 
 from services.config import config
 from services.openai_backend_api import ImagePollTimeoutError, OpenAIBackendAPI
@@ -11,9 +14,16 @@ from services.protocol.conversation import (
     ImageOutput,
     _generate_single_image,
     extract_conversation_ids,
+    is_tls_connection_error,
     stream_image_outputs,
 )
 from services.protocol.openai_v1_response import stream_image_response
+from utils.helper import iter_sse_payloads
+
+
+PNG_BYTES = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lm2C6wAAAABJRU5ErkJggg=="
+)
 
 
 def _conversation(file_ids: list[str], sediment_ids: list[str] | None = None) -> dict:
@@ -43,15 +53,20 @@ class FakeBackend(OpenAIBackendAPI):
         self.file_urls: dict[str, str] = {}
         self.sediment_urls: dict[str, str] = {}
 
-    def _get_conversation(self, conversation_id: str) -> dict:
+    def _get_conversation(self, conversation_id: str, timeout_secs: float = 60.0) -> dict:
         self.calls += 1
         index = min(self.calls - 1, len(self.conversations) - 1)
         return self.conversations[index]
 
-    def _get_file_download_url(self, file_id: str) -> str:
+    def _get_file_download_url(self, file_id: str, timeout_secs: float = 60.0) -> str:
         return self.file_urls.get(file_id, "")
 
-    def _get_attachment_download_url(self, conversation_id: str, attachment_id: str) -> str:
+    def _get_attachment_download_url(
+        self,
+        conversation_id: str,
+        attachment_id: str,
+        timeout_secs: float = 60.0,
+    ) -> str:
         return self.sediment_urls.get(attachment_id, "")
 
 
@@ -67,6 +82,11 @@ class MultiImageResultTests(unittest.TestCase):
         self.assertEqual(conversation_id, "conv-1")
         self.assertEqual(file_ids, ["file-first_123-extra"])
         self.assertEqual(sediment_ids, ["sed-second_456-extra"])
+
+    def test_http2_internal_error_is_treated_as_retryable_stream_error(self) -> None:
+        message = "curl: (92) HTTP/2 stream 1 was not closed cleanly: INTERNAL_ERROR (err 2)"
+
+        self.assertTrue(is_tls_connection_error(message))
 
     def test_conversation_record_extractor_finds_all_generated_assets(self) -> None:
         backend = FakeBackend()
@@ -221,6 +241,121 @@ class MultiImageResultTests(unittest.TestCase):
 
         self.assertEqual(backend.session.post.call_args.kwargs["timeout"], 11)
 
+    def test_image_prepare_request_uses_remaining_deadline(self) -> None:
+        backend = OpenAIBackendAPI.__new__(OpenAIBackendAPI)
+        backend.base_url = "https://chatgpt.test"
+        backend.image_request_deadline = 105.0
+        backend.session = mock.Mock()
+        backend.session.post.return_value.status_code = 200
+        backend.session.post.return_value.json.return_value = {"conduit_token": "conduit"}
+        backend._image_headers = mock.Mock(return_value={})
+        requirements = mock.Mock(token="token", proof_token="", turnstile_token="", so_token="")
+
+        with mock.patch("services.openai_backend_api.time.monotonic", return_value=100.0):
+            token = backend._prepare_image_conversation("draw", requirements, "gpt-image-2")
+
+        self.assertEqual(token, "conduit")
+        self.assertEqual(backend.session.post.call_args.kwargs["timeout"], 5.0)
+
+    def test_image_upload_requests_use_remaining_deadline(self) -> None:
+        backend = OpenAIBackendAPI.__new__(OpenAIBackendAPI)
+        backend.base_url = "https://chatgpt.test"
+        backend.user_agent = "ua"
+        backend.image_request_deadline = 105.0
+        backend.session = mock.Mock()
+        backend._headers = mock.Mock(return_value={})
+        create_response = mock.Mock(status_code=200)
+        create_response.json.return_value = {"file_id": "file-1", "upload_url": "https://upload.test/blob"}
+        uploaded_response = mock.Mock(status_code=200)
+        put_response = mock.Mock(status_code=200)
+        backend.session.post.side_effect = [create_response, uploaded_response]
+        backend.session.put.return_value = put_response
+
+        with mock.patch("services.openai_backend_api.time.monotonic", return_value=100.0):
+            meta = backend._upload_image(f"data:image/png;base64,{base64.b64encode(PNG_BYTES).decode('ascii')}")
+
+        self.assertEqual(meta["file_id"], "file-1")
+        self.assertEqual([call.kwargs["timeout"] for call in backend.session.post.call_args_list], [5.0, 5.0])
+        self.assertEqual(backend.session.put.call_args.kwargs["timeout"], 5.0)
+
+    def test_chat_requirements_keep_default_timeouts_without_image_deadline(self) -> None:
+        backend = OpenAIBackendAPI.__new__(OpenAIBackendAPI)
+        backend.base_url = "https://chatgpt.test"
+        backend.access_token = "token"
+        backend.user_agent = "ua"
+        backend.pow_script_sources = []
+        backend.pow_data_build = ""
+        backend.session = mock.Mock()
+        backend._headers = mock.Mock(return_value={})
+        prepare_response = mock.Mock(status_code=200)
+        prepare_response.json.return_value = {"prepare_token": "prepare"}
+        finalize_response = mock.Mock(status_code=200)
+        finalize_response.json.return_value = {"token": "requirements"}
+        backend.session.post.side_effect = [prepare_response, finalize_response]
+
+        with mock.patch.dict(config.data, {"image_poll_timeout_secs": 7}):
+            requirements = backend._get_chat_requirements()
+
+        self.assertEqual(requirements.token, "requirements")
+        self.assertEqual([call.kwargs["timeout"] for call in backend.session.post.call_args_list], [30.0, 30.0])
+
+    def test_poll_image_results_caps_conversation_fetch_to_remaining_budget(self) -> None:
+        backend = OpenAIBackendAPI.__new__(OpenAIBackendAPI)
+        backend.base_url = "https://chatgpt.test"
+        backend.session = mock.Mock()
+        backend._headers = mock.Mock(return_value={})
+        backend._query_backend_tasks = mock.Mock(return_value=[])
+        response = mock.Mock(status_code=200)
+        response.json.return_value = _conversation(["file-result"])
+        backend.session.get.return_value = response
+
+        with (
+            mock.patch.dict(config.data, {
+                "image_poll_initial_wait_secs": 0,
+                "image_check_before_hit_enabled": False,
+            }),
+            mock.patch("services.openai_backend_api.time.time", side_effect=[100.0, 100.0, 101.0, 101.0]),
+        ):
+            file_ids, sediment_ids = backend._poll_image_results("conv-1", timeout_secs=5.0)
+
+        self.assertEqual(file_ids, ["file-result"])
+        self.assertEqual(sediment_ids, [])
+        self.assertEqual(backend.session.get.call_args.kwargs["timeout"], 4.0)
+
+    def test_image_download_uses_remaining_deadline(self) -> None:
+        backend = OpenAIBackendAPI.__new__(OpenAIBackendAPI)
+        backend.image_request_deadline = 105.0
+        backend.session = mock.Mock()
+        response = mock.Mock(status_code=200, content=b"image")
+        backend.session.get.return_value = response
+
+        with mock.patch("services.openai_backend_api.time.monotonic", return_value=100.0):
+            images = backend.download_image_bytes(["https://download.test/image.png"])
+
+        self.assertEqual(images, [b"image"])
+        self.assertEqual(backend.session.get.call_args.kwargs["timeout"], 5.0)
+
+    def test_picture_conversation_passes_deadline_to_sse_payload_iterator(self) -> None:
+        backend = OpenAIBackendAPI.__new__(OpenAIBackendAPI)
+        backend.access_token = "token"
+        backend.image_request_deadline = 123.0
+        backend.progress_callback = None
+        backend._upload_image = mock.Mock()
+        backend._bootstrap = mock.Mock()
+        backend._get_chat_requirements = mock.Mock(return_value=mock.Mock(token="token", proof_token="", turnstile_token="", so_token=""))
+        backend._prepare_image_conversation = mock.Mock(return_value="conduit")
+        response = mock.Mock()
+        response._stream_closed = False
+        response.close = mock.Mock()
+        backend._start_image_generation = mock.Mock(return_value=response)
+
+        with mock.patch("services.openai_backend_api.iter_sse_payloads", return_value=iter(["[DONE]"])) as iter_payloads:
+            list(backend._stream_picture_conversation("draw", "gpt-image-2", []))
+
+        self.assertEqual(iter_payloads.call_args.kwargs["deadline"], 123.0)
+        self.assertIn("ChatGPT 生图超时", iter_payloads.call_args.kwargs["timeout_message"])
+        response.close.assert_called_once()
+
     def test_image_poll_timeout_retry_stops_when_configured_budget_is_exhausted(self) -> None:
         backend = mock.Mock()
         backend.image_request_deadline = None
@@ -243,6 +378,36 @@ class MultiImageResultTests(unittest.TestCase):
 
         self.assertEqual(get_token.call_count, 1)
         self.assertEqual(backend.image_request_deadline, 101.0)
+
+    def test_sse_payload_iterator_enforces_application_deadline_for_idle_curl_stream(self) -> None:
+        response = mock.Mock()
+        response.queue = queue.Queue()
+        response.quit_now = mock.Mock()
+        response.quit_now.set = mock.Mock()
+        response._stream_closed = False
+        response.iter_lines.side_effect = AssertionError("deadline path should not use blocking iter_lines")
+
+        with mock.patch("utils.helper.time.monotonic", side_effect=[100.0, 100.6]):
+            with self.assertRaises(TimeoutError):
+                list(iter_sse_payloads(response, deadline=100.5, timeout_message="image stream timed out"))
+
+        response.quit_now.set.assert_called_once()
+        self.assertTrue(response._stream_closed)
+
+    def test_sse_payload_iterator_preserves_line_parsing_with_deadline_queue(self) -> None:
+        response = mock.Mock()
+        response.queue = queue.Queue()
+        response.quit_now = mock.Mock()
+        response._stream_closed = False
+        response.iter_lines.side_effect = AssertionError("deadline path should not use blocking iter_lines")
+        response.queue.put(b"data: one\n\ndata: t")
+        response.queue.put(b"wo\n\n")
+        response.queue.put(STREAM_END)
+
+        with mock.patch("utils.helper.time.monotonic", side_effect=[100.0, 100.0, 100.0]):
+            payloads = list(iter_sse_payloads(response, deadline=101.0))
+
+        self.assertEqual(payloads, ["one", "two"])
 
 
 if __name__ == "__main__":

--- a/test/test_request_deadlines.py
+++ b/test/test_request_deadlines.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import base64
+import unittest
+from unittest import mock
+
+from services.openai_backend_api import ChatRequirements, OpenAIBackendAPI
+from services.protocol.conversation import ConversationRequest, stream_text_deltas
+
+
+PNG_BYTES = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+)
+
+
+class RequestDeadlineTests(unittest.TestCase):
+    def test_text_stream_passes_deadline_to_sse_reader(self) -> None:
+        backend = OpenAIBackendAPI.__new__(OpenAIBackendAPI)
+        backend.base_url = "https://chatgpt.test"
+        backend.session = mock.Mock()
+        response = mock.Mock(status_code=200)
+        response._stream_closed = False
+        response.close = mock.Mock()
+        backend.session.post.return_value = response
+        backend._bootstrap = mock.Mock()
+        backend._get_chat_requirements = mock.Mock(return_value=ChatRequirements(token="requirements"))
+        backend._chat_target = mock.Mock(return_value=("/backend-api/conversation", "Asia/Shanghai"))
+        backend._conversation_payload = mock.Mock(return_value={"action": "next"})
+        backend._conversation_headers = mock.Mock(return_value={})
+
+        with (
+            mock.patch("services.openai_backend_api.time.monotonic", return_value=100.0),
+            mock.patch("services.openai_backend_api.iter_sse_payloads", return_value=iter(["[DONE]"])) as iter_payloads,
+        ):
+            list(backend.stream_conversation(prompt="hello", model="gpt-5"))
+
+        self.assertEqual(backend.session.post.call_args.kwargs["timeout"], 300.0)
+        self.assertEqual(iter_payloads.call_args.kwargs["deadline"], 400.0)
+        response.close.assert_called_once()
+        self.assertFalse(hasattr(backend, "request_deadline"))
+
+    def test_text_retry_backend_inherits_original_request_deadline(self) -> None:
+        parent_backend = OpenAIBackendAPI.__new__(OpenAIBackendAPI)
+        parent_backend.access_token = "token-1"
+        created_backends: list[OpenAIBackendAPI] = []
+
+        def new_backend(access_token: str = "") -> OpenAIBackendAPI:
+            backend = OpenAIBackendAPI.__new__(OpenAIBackendAPI)
+            backend.access_token = access_token
+            created_backends.append(backend)
+            return backend
+
+        def fake_events(active_backend: OpenAIBackendAPI, **_kwargs):
+            if active_backend.access_token == "token-1":
+                raise RuntimeError("token_invalidated")
+            yield {"type": "conversation.delta", "delta": "ok"}
+
+        with (
+            mock.patch("services.protocol.conversation.time.monotonic", return_value=100.0),
+            mock.patch("services.protocol.conversation.OpenAIBackendAPI", side_effect=new_backend),
+            mock.patch("services.protocol.conversation.conversation_events", side_effect=fake_events),
+            mock.patch("services.protocol.conversation.account_service.refresh_access_token", return_value="token-2"),
+            mock.patch("services.protocol.conversation.account_service.mark_text_used"),
+        ):
+            chunks = list(stream_text_deltas(parent_backend, ConversationRequest(prompt="hello", model="gpt-5")))
+
+        self.assertEqual(chunks, ["ok"])
+        self.assertEqual([getattr(backend, "request_deadline", None) for backend in created_backends], [400.0, 400.0])
+
+    def test_shared_bootstrap_and_token_requests_use_request_deadline_when_present(self) -> None:
+        backend = OpenAIBackendAPI.__new__(OpenAIBackendAPI)
+        backend.base_url = "https://chatgpt.test"
+        backend.access_token = "token"
+        backend.user_agent = "ua"
+        backend.request_deadline = 105.0
+        backend.pow_script_sources = []
+        backend.pow_data_build = ""
+        backend.session = mock.Mock()
+        backend._headers = mock.Mock(return_value={})
+        backend._bootstrap_headers = mock.Mock(return_value={})
+        bootstrap_response = mock.Mock(status_code=200, text="")
+        prepare_response = mock.Mock(status_code=200)
+        prepare_response.json.return_value = {"prepare_token": "prepare"}
+        finalize_response = mock.Mock(status_code=200)
+        finalize_response.json.return_value = {"token": "requirements"}
+        backend.session.get.return_value = bootstrap_response
+        backend.session.post.side_effect = [prepare_response, finalize_response]
+
+        with mock.patch("services.openai_backend_api.time.monotonic", return_value=100.0):
+            backend._bootstrap()
+            requirements = backend._get_chat_requirements()
+
+        self.assertEqual(requirements.token, "requirements")
+        self.assertEqual(backend.session.get.call_args.kwargs["timeout"], 5.0)
+        self.assertEqual([call.kwargs["timeout"] for call in backend.session.post.call_args_list], [5.0, 5.0])
+
+    def test_search_sets_request_deadline_for_prepare_run_and_wait(self) -> None:
+        backend = OpenAIBackendAPI.__new__(OpenAIBackendAPI)
+        backend.access_token = "token"
+        seen_deadlines: list[float | None] = []
+
+        def record_prepare(*_args):
+            seen_deadlines.append(getattr(backend, "request_deadline", None))
+            return "conduit"
+
+        def record_run(*_args):
+            seen_deadlines.append(getattr(backend, "request_deadline", None))
+            return "conversation"
+
+        def record_wait(*_args):
+            seen_deadlines.append(getattr(backend, "request_deadline", None))
+            return {"answer": "done"}
+
+        backend._prepare_search_conversation = mock.Mock(side_effect=record_prepare)
+        backend._bootstrap = mock.Mock()
+        backend._run_search_conversation = mock.Mock(side_effect=record_run)
+        backend._wait_search_result = mock.Mock(side_effect=record_wait)
+
+        with mock.patch("services.openai_backend_api.time.monotonic", return_value=100.0):
+            result = backend.search("query", timeout_secs=5.0)
+
+        self.assertEqual(result, {"answer": "done"})
+        self.assertEqual(seen_deadlines, [105.0, 105.0, 105.0])
+        self.assertFalse(hasattr(backend, "request_deadline"))
+
+    def test_search_stream_and_poll_requests_use_remaining_deadline(self) -> None:
+        backend = OpenAIBackendAPI.__new__(OpenAIBackendAPI)
+        backend.base_url = "https://chatgpt.test"
+        backend.request_deadline = 105.0
+        backend.session = mock.Mock()
+        response = mock.Mock(status_code=200)
+        response._stream_closed = False
+        response.close = mock.Mock()
+        backend.session.post.return_value = response
+        backend._get_chat_requirements = mock.Mock(return_value=ChatRequirements(token="requirements"))
+        backend._image_headers = mock.Mock(return_value={})
+
+        with (
+            mock.patch("services.openai_backend_api.time.monotonic", return_value=100.0),
+            mock.patch("services.openai_backend_api.iter_sse_payloads", return_value=iter(['{"conversation_id":"conv"}'])) as iter_payloads,
+        ):
+            conversation_id = backend._run_search_conversation("query", "conduit", "gpt-5-search-api")
+
+        self.assertEqual(conversation_id, "conv")
+        self.assertEqual(backend.session.post.call_args.kwargs["timeout"], 5.0)
+        self.assertEqual(iter_payloads.call_args.kwargs["deadline"], 105.0)
+
+        backend._headers = mock.Mock(return_value={})
+        backend.session.get.return_value = mock.Mock(status_code=200)
+        backend.session.get.return_value.json.return_value = {}
+        with mock.patch("services.openai_backend_api.time.monotonic", return_value=100.0):
+            backend._get_search_conversation("conv")
+
+        self.assertEqual(backend.session.get.call_args.kwargs["timeout"], 5.0)
+
+    def test_editable_upload_and_stream_requests_use_remaining_deadline(self) -> None:
+        backend = OpenAIBackendAPI.__new__(OpenAIBackendAPI)
+        backend.base_url = "https://chatgpt.test"
+        backend.user_agent = "ua"
+        backend.request_deadline = 105.0
+        backend.session = mock.Mock()
+        backend._headers = mock.Mock(return_value={})
+        create_response = mock.Mock(status_code=200)
+        create_response.json.return_value = {
+            "file_id": "file-1",
+            "library_file_id": "library-1",
+            "upload_url": "https://upload.test/blob",
+        }
+        uploaded_response = mock.Mock(status_code=200)
+        put_response = mock.Mock(status_code=200)
+        backend.session.post.side_effect = [create_response, uploaded_response]
+        backend.session.put.return_value = put_response
+
+        with mock.patch("services.openai_backend_api.time.monotonic", return_value=100.0):
+            meta = backend._upload_editable_base64_image(
+                f"data:image/png;base64,{base64.b64encode(PNG_BYTES).decode('ascii')}",
+                1,
+            )
+
+        self.assertEqual(meta["file_id"], "file-1")
+        self.assertEqual([call.kwargs["timeout"] for call in backend.session.post.call_args_list], [5.0, 5.0])
+        self.assertEqual(backend.session.put.call_args.kwargs["timeout"], 5.0)
+
+        backend.session.post.reset_mock()
+        backend.session.post.side_effect = None
+        stream_response = mock.Mock(status_code=200)
+        stream_response._stream_closed = False
+        stream_response.close = mock.Mock()
+        backend.session.post.return_value = stream_response
+        backend._bootstrap = mock.Mock()
+        backend._get_chat_requirements = mock.Mock(return_value=ChatRequirements(token="requirements"))
+        backend._image_headers = mock.Mock(return_value={})
+
+        with (
+            mock.patch("services.openai_backend_api.time.monotonic", return_value=100.0),
+            mock.patch("services.openai_backend_api.iter_sse_payloads", return_value=iter(['{"conversation_id":"conv"}'])) as iter_payloads,
+        ):
+            conversation_id = backend._run_editable_conversation("make ppt", [meta], "conduit")
+
+        self.assertEqual(conversation_id, "conv")
+        self.assertEqual(backend.session.post.call_args.kwargs["timeout"], 5.0)
+        self.assertEqual(iter_payloads.call_args.kwargs["deadline"], 105.0)
+
+    def test_editable_poll_and_download_requests_use_remaining_deadline(self) -> None:
+        backend = OpenAIBackendAPI.__new__(OpenAIBackendAPI)
+        backend.base_url = "https://chatgpt.test"
+        backend.request_deadline = 105.0
+        backend.session = mock.Mock()
+        backend._editable_conversation_document_headers = mock.Mock(return_value={})
+        backend._editable_download_headers = mock.Mock(return_value={})
+        backend._editable_browser_headers = mock.Mock(return_value={})
+
+        detail_response = mock.Mock(status_code=200)
+        detail_response.json.return_value = {}
+        backend.session.get.return_value = detail_response
+        with mock.patch("services.openai_backend_api.time.monotonic", return_value=100.0):
+            backend._get_editable_conversation_detail("conv")
+
+        self.assertEqual(backend.session.get.call_args.kwargs["timeout"], 5.0)
+
+        artifact = mock.Mock()
+        artifact.attachment_id = "file-1"
+        artifact.file_id = ""
+        artifact.sandbox_path = ""
+        artifact.message_id = ""
+        artifact.name = "deck.pptx"
+        artifact.mime_type = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        download_url_response = mock.Mock(status_code=200)
+        download_url_response.json.return_value = {"download_url": "https://download.test/deck.pptx"}
+        backend.session.get.return_value = download_url_response
+        with mock.patch("services.openai_backend_api.time.monotonic", return_value=100.0):
+            download_url = backend._resolve_editable_download_url("conv", artifact)
+
+        self.assertEqual(download_url, "https://download.test/deck.pptx")
+        self.assertEqual(backend.session.get.call_args.kwargs["timeout"], 5.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/helper.py
+++ b/utils/helper.py
@@ -2,6 +2,7 @@ import base64
 import hashlib
 import json
 import mimetypes
+import queue
 import re
 import time
 import uuid
@@ -10,6 +11,8 @@ from typing import Any, Iterator
 from urllib.parse import urlparse
 
 from curl_cffi import requests
+from curl_cffi.requests.exceptions import RequestException
+from curl_cffi.requests.models import STREAM_END
 from fastapi import HTTPException
 from services.proxy_service import proxy_settings
 from utils.log import logger
@@ -226,8 +229,71 @@ def anthropic_sse_stream(items) -> Iterator[str]:
         yield f"data: {json.dumps(error, ensure_ascii=False)}\n\n"
 
 
-def iter_sse_payloads(response: requests.Response) -> Iterator[str]:
-    for raw_line in response.iter_lines():
+def _detach_stream_response(response: requests.Response) -> None:
+    quit_now = getattr(response, "quit_now", None)
+    if quit_now is not None:
+        try:
+            quit_now.set()
+        except Exception:
+            pass
+    try:
+        response._stream_closed = True
+    except Exception:
+        pass
+
+
+def _iter_sse_chunks(response: requests.Response, deadline: float | None, timeout_message: str) -> Iterator[object]:
+    if deadline is None:
+        yield from response.iter_content()
+        return
+
+    stream_queue = getattr(response, "queue", None)
+    if stream_queue is None:
+        yield from response.iter_content()
+        return
+
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            _detach_stream_response(response)
+            raise TimeoutError(timeout_message)
+        try:
+            raw_line = stream_queue.get(timeout=remaining)
+        except queue.Empty as exc:
+            _detach_stream_response(response)
+            raise TimeoutError(timeout_message) from exc
+        if isinstance(raw_line, RequestException):
+            _detach_stream_response(response)
+            raise raw_line
+        if raw_line is STREAM_END:
+            break
+        yield raw_line
+
+
+def _iter_sse_lines(response: requests.Response, deadline: float | None, timeout_message: str) -> Iterator[object]:
+    pending = None
+    for chunk in _iter_sse_chunks(response, deadline, timeout_message):
+        if pending is not None:
+            chunk = pending + chunk
+        lines = chunk.splitlines()
+        pending = (
+            lines.pop()
+            if lines and lines[-1] and chunk and lines[-1][-1] == chunk[-1]
+            else None
+        )
+        yield from lines
+
+    if pending is not None:
+        yield pending
+
+
+def iter_sse_payloads(
+    response: requests.Response,
+    *,
+    deadline: float | None = None,
+    timeout_message: str = "SSE stream timed out",
+) -> Iterator[str]:
+    for raw_line in _iter_sse_lines(response, deadline, timeout_message):
         if not raw_line:
             continue
         line = raw_line.decode("utf-8", errors="ignore") if isinstance(raw_line, bytes) else str(raw_line)


### PR DESCRIPTION
## Summary
- enforce the configured image timeout while reading curl_cffi SSE streams so idle image generation no longer waits for the upstream ~30 minute HTTP/2 failure
- add a shared request deadline budget for text generation, web search, and PPT/PSD editable-file generation
- carry remaining deadline through bootstrap, sentinel token requests, prepare/upload/run/poll/download calls, SSE readers, and retry-created text backends
- classify curl (92) / HTTP/2 INTERNAL_ERROR as a retryable image stream connection error

Fixes #290

## Test Plan
- uv run python -m unittest test.test_request_deadlines
- uv run python -m unittest test.test_multi_image_results test.test_request_deadlines
- uv run python -m unittest test.test_config test.test_image_task_service test.test_image_tasks_api test.test_multi_image_results test.test_request_deadlines test.test_chat_completion_cache
- uv run python -m py_compile services/openai_backend_api.py services/protocol/conversation.py services/protocol/web_search_tool.py services/editable_file_task_service.py test/test_request_deadlines.py