### PR TITLE
feat: 支持导入本项目导出的账号 JSON

### DIFF
--- a/web/src/app/accounts/components/account-import-dialog.tsx
+++ b/web/src/app/accounts/components/account-import-dialog.tsx
@@ -38,17 +38,17 @@ import {
 } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
-type ImportMethod = "menu" | "token" | "session" | "codex-auth" | "cpa" | "oauth";
+type ImportMethod = "menu" | "token" | "session" | "codex-auth" | "account-json" | "oauth";
 
 type AccountImportDialogProps = {
   disabled?: boolean;
   onImported: (items: Account[]) => void;
 };
 
-type PendingCpaImport = {
+type PendingAccountJsonImport = {
   tokens: string[];
   accounts: AccountImportPayload[];
-  parsedFileCount: number;
+  parsedAccountCount: number;
   errorCount: number;
 };
 
@@ -66,7 +66,7 @@ function getSessionAccessToken(value: unknown) {
   return typeof token === "string" ? token.trim() : "";
 }
 
-function getCpaAccount(value: unknown): AccountImportPayload | null {
+function getAccountJsonAccount(value: unknown): AccountImportPayload | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return null;
   }
@@ -88,6 +88,31 @@ function getCpaAccount(value: unknown): AccountImportPayload | null {
     delete payload.type;
   }
   return payload;
+}
+
+function getAccountJsonAccounts(value: unknown): AccountImportPayload[] {
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => getAccountJsonAccount(item))
+      .filter((item): item is AccountImportPayload => Boolean(item));
+  }
+
+  const singleAccount = getAccountJsonAccount(value);
+  if (singleAccount) {
+    return [singleAccount];
+  }
+
+  if (value && typeof value === "object") {
+    const raw = value as Record<string, unknown>;
+    const nested = raw.accounts ?? raw.items;
+    if (Array.isArray(nested)) {
+      return nested
+        .map((item) => getAccountJsonAccount(item))
+        .filter((item): item is AccountImportPayload => Boolean(item));
+    }
+  }
+
+  return [];
 }
 
 function getCodexAuthAccount(value: unknown): AccountImportPayload | null {
@@ -163,7 +188,7 @@ export function AccountImportDialog({ disabled, onImported }: AccountImportDialo
   const [sessionInput, setSessionInput] = useState("");
   const [codexAuthInput, setCodexAuthInput] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [pendingCpaImport, setPendingCpaImport] = useState<PendingCpaImport | null>(null);
+  const [pendingAccountJsonImport, setPendingAccountJsonImport] = useState<PendingAccountJsonImport | null>(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [oauthEmailHint, setOauthEmailHint] = useState("");
   const [oauthSession, setOauthSession] = useState<OAuthLoginStartResponse | null>(null);
@@ -171,14 +196,14 @@ export function AccountImportDialog({ disabled, onImported }: AccountImportDialo
   const [oauthStarting, setOauthStarting] = useState(false);
 
   const txtInputRef = useRef<HTMLInputElement | null>(null);
-  const cpaInputRef = useRef<HTMLInputElement | null>(null);
+  const accountJsonInputRef = useRef<HTMLInputElement | null>(null);
 
   const resetState = () => {
     setMethod("menu");
     setTokenInput("");
     setSessionInput("");
     setCodexAuthInput("");
-    setPendingCpaImport(null);
+    setPendingAccountJsonImport(null);
     setConfirmOpen(false);
     setOauthEmailHint("");
     setOauthSession(null);
@@ -375,7 +400,7 @@ export function AccountImportDialog({ disabled, onImported }: AccountImportDialo
     }
   };
 
-  const handleCpaSelected = async (event: ChangeEvent<HTMLInputElement>) => {
+  const handleAccountJsonSelected = async (event: ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(event.target.files ?? []);
     event.target.value = "";
 
@@ -388,32 +413,32 @@ export function AccountImportDialog({ disabled, onImported }: AccountImportDialo
         files.map(async (file) => {
           const raw = await readFileAsText(file);
           const parsed = JSON.parse(raw) as unknown;
-          const account = getCpaAccount(parsed);
+          const accounts = getAccountJsonAccounts(parsed);
           return {
-            account,
+            accounts,
           };
         }),
       );
 
-      const accounts = results.map((item) => item.account).filter((item): item is AccountImportPayload => Boolean(item));
+      const accounts = results.flatMap((item) => item.accounts);
       const tokens = accounts.map((item) => item.access_token);
-      const parsedFileCount = accounts.length;
-      const errorCount = results.length - parsedFileCount;
+      const parsedAccountCount = accounts.length;
+      const errorCount = results.filter((item) => item.accounts.length === 0).length;
 
-      if (parsedFileCount === 0) {
-        toast.error("这些 CPA JSON 文件里没有读取到可用 access_token");
+      if (parsedAccountCount === 0) {
+        toast.error("这些账号 JSON 文件里没有读取到可用 access_token");
         return;
       }
 
-      setPendingCpaImport({
+      setPendingAccountJsonImport({
         tokens,
         accounts,
-        parsedFileCount,
+        parsedAccountCount,
         errorCount,
       });
       setConfirmOpen(true);
     } catch (error) {
-      const message = error instanceof Error ? error.message : "读取 CPA JSON 文件失败";
+      const message = error instanceof Error ? error.message : "读取账号 JSON 文件失败";
       toast.error(message);
     }
   };
@@ -616,7 +641,7 @@ export function AccountImportDialog({ disabled, onImported }: AccountImportDialo
       );
     }
 
-    if (method === "cpa") {
+    if (method === "account-json") {
       return (
         <div className="space-y-4">
           <button
@@ -629,33 +654,34 @@ export function AccountImportDialog({ disabled, onImported }: AccountImportDialo
           </button>
           <div className="rounded-2xl border border-dashed border-stone-200 bg-stone-50 p-5">
             <div className="space-y-2">
-              <div className="text-sm font-medium text-stone-800">多选本地 CPA JSON 文件</div>
+              <div className="text-sm font-medium text-stone-800">选择本地账号 JSON 文件</div>
               <div className="text-sm leading-6 text-stone-500">
-                每个文件应为一个 JSON 对象。系统会从对象中自动提取 `access_token` 或 `accessToken`，
+                支持本项目导出的单账号对象或全部账号数组，也兼容每个文件一个账号对象的 CPA JSON。
+                系统会自动提取 `access_token` 或 `accessToken`。
               </div>
             </div>
             <Button
               type="button"
               className="mt-4 rounded-xl bg-stone-950 text-white hover:bg-stone-800"
-              onClick={() => cpaInputRef.current?.click()}
+              onClick={() => accountJsonInputRef.current?.click()}
               disabled={isSubmitting}
             >
               <Files className="size-4" />
-              选择多个 JSON 文件
+              选择 JSON 文件
             </Button>
           </div>
           <input
-            ref={cpaInputRef}
+            ref={accountJsonInputRef}
             type="file"
             accept=".json,application/json"
             multiple
             className="hidden"
-            onChange={(event) => void handleCpaSelected(event)}
+            onChange={(event) => void handleAccountJsonSelected(event)}
           />
-          {pendingCpaImport ? (
+          {pendingAccountJsonImport ? (
             <div className="rounded-2xl border border-stone-200 bg-white p-4 text-sm leading-6 text-stone-600">
-              最近一次读取到 {pendingCpaImport.parsedFileCount} 个 Token
-              {pendingCpaImport.errorCount > 0 ? `，另有 ${pendingCpaImport.errorCount} 个文件未提取成功` : ""}。
+              最近一次读取到 {pendingAccountJsonImport.parsedAccountCount} 个 Token
+              {pendingAccountJsonImport.errorCount > 0 ? `，另有 ${pendingAccountJsonImport.errorCount} 个文件未提取成功` : ""}。
             </div>
           ) : null}
         </div>
@@ -713,10 +739,10 @@ export function AccountImportDialog({ disabled, onImported }: AccountImportDialo
           onClick={() => setMethod("codex-auth")}
         />
         <MethodCard
-          title="导入 CPA JSON 文件"
-          description="支持一次多选多个本地 JSON 文件，逐个读取对象里的 access_token 后导入。"
+          title="导入账号 JSON 文件"
+          description="支持本项目导出的单账号 JSON 或全部账号数组，也兼容 CPA JSON 文件。"
           icon={Files}
-          onClick={() => setMethod("cpa")}
+          onClick={() => setMethod("account-json")}
         />
         <MethodCard
           title="从远程 CPA 服务器导入"
@@ -768,7 +794,7 @@ export function AccountImportDialog({ disabled, onImported }: AccountImportDialo
                       ? "导入 Codex 认证 JSON"
                     : method === "oauth"
                       ? "OAuth 登录已有账号"
-                      : "导入 CPA JSON"}
+                      : "导入账号 JSON"}
             </DialogTitle>
             <DialogDescription className="text-sm leading-6">
               {method === "menu"
@@ -781,7 +807,7 @@ export function AccountImportDialog({ disabled, onImported }: AccountImportDialo
                       ? "粘贴 Codex 认证 JSON，系统会按 codex 来源导入。"
                     : method === "oauth"
                       ? "用浏览器跑一遍 OpenAI 标准 OAuth，拿回 refresh_token 后系统会自动续期。"
-                      : "支持一次读取多个本地 JSON 文件，并在提交前做数量确认。"}
+                      : "支持读取本项目导出的单账号对象或全部账号数组，并在提交前做数量确认。"}
             </DialogDescription>
           </DialogHeader>
 
@@ -839,14 +865,14 @@ export function AccountImportDialog({ disabled, onImported }: AccountImportDialo
                 完成导入
               </Button>
             ) : null}
-            {method === "cpa" ? (
+            {method === "account-json" ? (
               <Button
                 className={cn(
                   "h-10 rounded-xl bg-stone-950 px-5 text-white hover:bg-stone-800",
-                  !pendingCpaImport ? "hidden" : "",
+                  !pendingAccountJsonImport ? "hidden" : "",
                 )}
                 onClick={() => setConfirmOpen(true)}
-                disabled={footerDisabled || !pendingCpaImport}
+                disabled={footerDisabled || !pendingAccountJsonImport}
               >
                 查看导入确认
               </Button>
@@ -858,13 +884,13 @@ export function AccountImportDialog({ disabled, onImported }: AccountImportDialo
       <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
         <DialogContent className="rounded-2xl p-6">
           <DialogHeader className="gap-2">
-            <DialogTitle>确认导入 CPA Token</DialogTitle>
+            <DialogTitle>确认导入账号 Token</DialogTitle>
             <DialogDescription className="text-sm leading-6">
-              {pendingCpaImport
-                ? `确认识别到 ${pendingCpaImport.parsedFileCount} 个 Token，是否确认导入？`
+              {pendingAccountJsonImport
+                ? `确认识别到 ${pendingAccountJsonImport.parsedAccountCount} 个 Token，是否确认导入？`
                 : "尚未读取到可导入的 Token。"}
-              {pendingCpaImport?.errorCount
-                ? `，另有 ${pendingCpaImport.errorCount} 个文件未提取成功。`
+              {pendingAccountJsonImport?.errorCount
+                ? `，另有 ${pendingAccountJsonImport.errorCount} 个文件未提取成功。`
                 : "。"}
             </DialogDescription>
           </DialogHeader>
@@ -881,12 +907,12 @@ export function AccountImportDialog({ disabled, onImported }: AccountImportDialo
               className="h-10 rounded-xl bg-stone-950 px-5 text-white hover:bg-stone-800"
               onClick={() =>
                 void submitTokens(
-                  pendingCpaImport?.tokens ?? [],
-                  "CPA JSON 导入完成",
-                  pendingCpaImport?.accounts ?? [],
+                  pendingAccountJsonImport?.tokens ?? [],
+                  "账号 JSON 导入完成",
+                  pendingAccountJsonImport?.accounts ?? [],
                 )
               }
-              disabled={isSubmitting || !pendingCpaImport}
+              disabled={isSubmitting || !pendingAccountJsonImport}
             >
               {isSubmitting ? <LoaderCircle className="size-4 animate-spin" /> : null}
               确认导入


### PR DESCRIPTION
## 概述

这个 PR 为号池管理的账号导入功能增加了对本项目导出 JSON 格式的支持。

之前号池支持导出全部账号为 JSON，但导出的 JSON 无法直接通过导入功能重新导入，导致导出/导入流程不能闭环。现在导入账号 JSON 时，可以直接选择本项目导出的 JSON 文件并完成导入。

## 改动内容

- 将原来的「导入 CPA JSON 文件」入口调整为「导入账号 JSON 文件」。
- 支持导入本项目导出的单账号 JSON 对象。
- 支持导入本项目导出的全部账号 JSON 数组。
- 兼容 `{ accounts: [...] }` 和 `{ items: [...] }` 这类包裹格式。
- 保留对原有单对象 CPA JSON 文件的兼容。
- 导入时会继续传递完整账号对象，保留 `refresh_token`、`id_token`、`email`、`account_id`、`password` 等字段。

## 支持的导入格式示例

单账号对象：

```json
{
  "type": "codex",
  "email": "user@example.com",
  "account_id": "account-id",
  "access_token": "access-token",
  "refresh_token": "refresh-token",
  "id_token": "id-token"
}