### PR TITLE
fix: close curl_cffi Session to prevent memory leak (~210MB/h)

### DIFF
--- a/services/account_service.py
+++ b/services/account_service.py
@@ -1329,12 +1329,20 @@ class AccountService:
         active_token = self.refresh_access_token(access_token, event=f"{event}:preflight") or access_token
         try:
             from services.openai_backend_api import InvalidAccessTokenError, OpenAIBackendAPI
-            result = OpenAIBackendAPI(active_token).get_user_info()
+            backend = OpenAIBackendAPI(active_token)
+            try:
+                result = backend.get_user_info()
+            finally:
+                backend.close()
         except InvalidAccessTokenError as exc:
             refreshed_token = self.refresh_access_token(active_token, force=True, event=f"{event}:invalid_access_token")
             if refreshed_token and refreshed_token != active_token:
                 try:
-                    result = OpenAIBackendAPI(refreshed_token).get_user_info()
+                    backend = OpenAIBackendAPI(refreshed_token)
+                    try:
+                        result = backend.get_user_info()
+                    finally:
+                        backend.close()
                 except InvalidAccessTokenError as retry_exc:
                     if self._record_invalid_token_seen(
                         refreshed_token,

--- a/services/editable_file_task_service.py
+++ b/services/editable_file_task_service.py
@@ -131,6 +131,7 @@ class EditableFileTaskService:
         token = ""
         account_email = ""
         self._update_task(key, status=TASK_STATUS_RUNNING, error="", started_ts=started)
+        backend = None
         try:
             if kind == "psd" and not base64_images:
                 raise ValueError("base64_images is empty")
@@ -148,6 +149,9 @@ class EditableFileTaskService:
             error = str(exc) or "editable file task failed"
             self._update_task(key, status=TASK_STATUS_ERROR, error=error, account_email=account_email, ended_ts=time.time())
             self._log_call(identity, kind, started, request_text(prompt), status="failed", error=error, account_email=account_email)
+        finally:
+            if backend is not None:
+                backend.close()
 
     def public_file_path(self, relative_path: str) -> Path:
         raw = str(relative_path or "").replace("\\", "/").lstrip("/")

--- a/services/image_task_service.py
+++ b/services/image_task_service.py
@@ -482,6 +482,7 @@ class ImageTaskService:
     ) -> None:
         """后台线程：继续轮询已有 conversation_id 的图片结果。"""
         started = time.time()
+        backend = None
         try:
             from services.openai_backend_api import OpenAIBackendAPI
             from services.protocol.conversation import format_image_result
@@ -541,6 +542,9 @@ class ImageTaskService:
                 status="failed",
                 error=error_message,
             )
+        finally:
+            if backend is not None:
+                backend.close()
 
 
 image_task_service = ImageTaskService(DATA_DIR / "image_tasks.json")

--- a/services/openai_backend_api.py
+++ b/services/openai_backend_api.py
@@ -201,6 +201,27 @@ class OpenAIBackendAPI:
         if self.access_token:
             self.session.headers["Authorization"] = f"Bearer {self.access_token}"
 
+    def close(self) -> None:
+        if getattr(self, "_closed", False):
+            return
+        self._closed = True
+        session = getattr(self, "session", None)
+        if session:
+            try:
+                session.close()
+            except Exception:
+                pass
+
+    def __del__(self):
+        self.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+        return False
+
     def _build_fp(self) -> Dict[str, str]:
         account = self.account
         raw_fp = account.get("fp")

--- a/services/protocol/conversation.py
+++ b/services/protocol/conversation.py
@@ -684,6 +684,7 @@ def stream_text_deltas(backend: OpenAIBackendAPI, request: ConversationRequest) 
             raise RuntimeError("no available text account")
         if token:
             attempted_tokens.add(token)
+        active_backend = None
         try:
             active_backend = OpenAIBackendAPI(access_token=token)
             for event in conversation_events(active_backend, messages=request.messages, model=request.model, prompt=request.prompt):
@@ -707,6 +708,9 @@ def stream_text_deltas(backend: OpenAIBackendAPI, request: ConversationRequest) 
                 if token:
                     continue
             raise
+        finally:
+            if active_backend is not None:
+                active_backend.close()
 
 
 def collect_text(backend: OpenAIBackendAPI, request: ConversationRequest) -> str:
@@ -1263,6 +1267,7 @@ def _generate_single_image(
             "account_found": bool(account),
             "index": index,
         })
+        backend = None
         try:
             backend = OpenAIBackendAPI(access_token=token)
             if request.progress_callback:
@@ -1436,6 +1441,9 @@ def _generate_single_image(
                     time.sleep(wait_secs)
                     continue
             raise ImageGenerationError(image_stream_error_message(last_error), account_email=account_email, conversation_id="") from exc
+        finally:
+            if backend is not None:
+                backend.close()
 
 
 def stream_image_outputs_with_pool(request: ConversationRequest) -> Iterator[ImageOutput]:

--- a/services/protocol/openai_search.py
+++ b/services/protocol/openai_search.py
@@ -9,7 +9,11 @@ MODEL = SEARCH_MODEL
 def handle(body: dict[str, object]) -> dict[str, object]:
     token = account_service.get_text_access_token()
     account = account_service.get_account(token) or {}
-    result = OpenAIBackendAPI(token).search(str(body["prompt"]))
+    backend = OpenAIBackendAPI(token)
+    try:
+        result = backend.search(str(body["prompt"]))
+    finally:
+        backend.close()
     account_service.mark_text_used(token)
     result["_account_email"] = str(account.get("email") or "")
     return result

--- a/services/protocol/openai_v1_models.py
+++ b/services/protocol/openai_v1_models.py
@@ -8,7 +8,11 @@ from utils.helper import CODEX_IMAGE_MODEL
 
 
 def list_models() -> dict[str, Any]:
-    result = OpenAIBackendAPI().list_models()
+    backend = OpenAIBackendAPI()
+    try:
+        result = backend.list_models()
+    finally:
+        backend.close()
     data = result.get("data")
     if not isinstance(data, list):
         return result


### PR DESCRIPTION
## Summary

`OpenAIBackendAPI.__init__` creates a `curl_cffi.requests.Session` (wrapping a libcurl handle, ~50KB of C-allocated memory) but has no `close()` method. Since libcurl handles are C-heap allocated, Python's GC cannot reclaim them.

The account-watcher refreshes ~378 accounts every 5 minutes via `fetch_remote_info`, creating a new `OpenAIBackendAPI` instance (and session) for each — none are ever closed. This leaks **~210MB/hour**, observed as RSS growing from 50MB to 3.7GB over 16 hours, eventually exhausting swap.

## Changes

- **`OpenAIBackendAPI`**: add `close()`, `__del__`, `__enter__`, `__exit__` with idempotent `_closed` flag and `getattr` safety for partial init failures
- **8 call sites** wrapped with `try/finally` to ensure `session.close()`:

| File | Call site | Frequency |
|------|-----------|-----------|
| `account_service.py` | `fetch_remote_info` ×2 | 378×12/h (**primary leak**) |
| `conversation.py` | `stream_text_deltas` generator | per-request |
| `conversation.py` | `_generate_single_image` retry loop | per-image |
| `image_task_service.py` | `_run_resume_poll` | per-resume |
| `openai_search.py` | `handle` | per-search |
| `openai_v1_models.py` | `list_models` | per-list |
| `editable_file_task_service.py` | background task | per-task |

Note: `__del__` serves as a safety net for the remaining 3 call sites (`text_backend`, `anthropic_v1_messages.message_request`, `web_search_tool`) where refactoring the caller would be more invasive.

## Why `finally` instead of just `__del__`

Generator functions (like `stream_text_deltas`) can be suspended at `yield` — if the consumer stops iterating, the generator object may not be collected promptly, and `__del__` timing is unreliable. A `finally` block inside the generator ensures cleanup on all exit paths (normal return, exception, `GeneratorExit`).

## Verification

After applying this fix, memory stabilized at ~330MB after 3 account-watcher cycles (15 minutes), compared to ~946MB and still climbing without the fix. `VmPeak` stopped increasing, confirming libcurl handles are being freed and reused.

## Test plan

- [x] `py_compile` all 7 modified files — passes
- [x] Container restart with patched code — no import errors or runtime exceptions
- [x] Monitor RSS over 15+ minutes — growth stops after initial stabilization
- [x] `VmPeak` stable (no new high-water allocations after first watcher cycle)
- [x] Docker logs show normal operation (account registration, search, image gen all functional)