### PR TITLE
feat: add reasoning effort passthrough for text chat

### DIFF
--- a/services/openai_backend_api.py
+++ b/services/openai_backend_api.py
@@ -474,9 +474,26 @@ class OpenAIBackendAPI:
             })
         return conversation_messages
 
-    def _conversation_payload(self, messages: list[Dict[str, Any]], model: str, timezone: str) -> Dict[str, Any]:
+    @staticmethod
+    def _normalize_thinking_effort(value: str) -> str:
+        normalized = str(value or "").strip().lower()
+        if normalized in {"", "none"}:
+            return ""
+        if normalized in {"low", "medium", "high"}:
+            return normalized
+        if normalized in {"xhigh", "extended"}:
+            return "extended"
+        return ""
+
+    def _conversation_payload(
+            self,
+            messages: list[Dict[str, Any]],
+            model: str,
+            timezone: str,
+            thinking_effort: str = "",
+    ) -> Dict[str, Any]:
         """把标准 messages 构造成 web 对话请求体。"""
-        return {
+        payload = {
             "action": "next",
             "messages": self._api_messages_to_conversation_messages(messages),
             "model": model,
@@ -506,6 +523,10 @@ class OpenAIBackendAPI:
                 "screen_width": 2560,
             },
         }
+        normalized_effort = self._normalize_thinking_effort(thinking_effort)
+        if normalized_effort:
+            payload["thinking_effort"] = normalized_effort
+        return payload
 
     def _image_model_slug(self, model: str) -> str:
         """把标准图片模型名映射到底层 model slug。"""
@@ -2479,6 +2500,7 @@ class OpenAIBackendAPI:
             prompt: str = "",
             images: Optional[list[str]] = None,
             system_hints: Optional[list[str]] = None,
+            thinking_effort: str = "",
     ) -> Iterator[str]:
         system_hints = system_hints or []
         if "picture_v2" in system_hints:
@@ -2489,7 +2511,7 @@ class OpenAIBackendAPI:
         self._bootstrap()
         requirements = self._get_chat_requirements()
         path, timezone = self._chat_target()
-        payload = self._conversation_payload(normalized, model, timezone)
+        payload = self._conversation_payload(normalized, model, timezone, thinking_effort=thinking_effort)
         response = self.session.post(
             self.base_url + path,
             headers=self._conversation_headers(path, requirements),

--- a/services/protocol/chat_completion_cache.py
+++ b/services/protocol/chat_completion_cache.py
@@ -22,10 +22,12 @@ CACHEABLE_TEXT_KEYS = {
     "seed",
     "stop",
     "temperature",
+    "thinking_effort",
     "tool_choice",
     "tools",
     "top_p",
     "user",
+    "reasoning",
 }
 
 

--- a/services/protocol/conversation.py
+++ b/services/protocol/conversation.py
@@ -297,6 +297,7 @@ class ConversationRequest:
     model: str = "auto"
     prompt: str = ""
     messages: list[dict[str, Any]] | None = None
+    thinking_effort: str = ""
     images: list[str] | None = None
     n: int = 1
     size: str | None = None
@@ -655,6 +656,7 @@ def conversation_events(
     images: list[str] | None = None,
     size: str | None = None,
     quality: str = "auto",
+    thinking_effort: str = "",
 ) -> Iterator[dict[str, Any]]:
     normalized = normalize_messages(messages or ([{"role": "user", "content": prompt}] if prompt else []))
     image_model = is_supported_image_model(model)
@@ -667,6 +669,7 @@ def conversation_events(
         prompt=final_prompt,
         images=images if image_model else None,
         system_hints=["picture_v2"] if image_model else None,
+        thinking_effort=thinking_effort if not image_model else "",
     )
     yield from iter_conversation_payloads(payloads, history_text, history_messages)
 
@@ -686,7 +689,13 @@ def stream_text_deltas(backend: OpenAIBackendAPI, request: ConversationRequest) 
             attempted_tokens.add(token)
         try:
             active_backend = OpenAIBackendAPI(access_token=token)
-            for event in conversation_events(active_backend, messages=request.messages, model=request.model, prompt=request.prompt):
+            for event in conversation_events(
+                active_backend,
+                messages=request.messages,
+                model=request.model,
+                prompt=request.prompt,
+                thinking_effort=request.thinking_effort,
+            ):
                 if event.get("type") != "conversation.delta":
                     continue
                 delta = str(event.get("delta") or "")

--- a/services/protocol/openai_v1_chat_complete.py
+++ b/services/protocol/openai_v1_chat_complete.py
@@ -44,6 +44,28 @@ TOOL_UNAVAILABLE_SYSTEM_MESSAGE = (
 )
 
 
+def normalize_thinking_effort(value: object) -> str:
+    normalized = str(value or "").strip().lower()
+    if normalized in {"", "none"}:
+        return ""
+    if normalized in {"low", "medium", "high"}:
+        return normalized
+    if normalized in {"xhigh", "extended"}:
+        return "extended"
+    return ""
+
+
+def thinking_effort_from_body(body: dict[str, Any]) -> str:
+    if "thinking_effort" in body:
+        return normalize_thinking_effort(body.get("thinking_effort"))
+    if "reasoning_effort" in body:
+        return normalize_thinking_effort(body.get("reasoning_effort"))
+    reasoning = body.get("reasoning")
+    if isinstance(reasoning, dict):
+        return normalize_thinking_effort(reasoning.get("effort"))
+    return ""
+
+
 def completion_chunk(model: str, delta: dict[str, Any], finish_reason: str | None = None, completion_id: str = "", created: int | None = None) -> dict[str, Any]:
     return {
         "id": completion_id or f"chatcmpl-{uuid.uuid4().hex}",
@@ -96,11 +118,16 @@ def completion_response(
     }
 
 
-def stream_text_chat_completion(backend, messages: list[dict[str, Any]], model: str) -> Iterator[dict[str, Any]]:
+def stream_text_chat_completion(
+    backend,
+    messages: list[dict[str, Any]],
+    model: str,
+    thinking_effort: str = "",
+) -> Iterator[dict[str, Any]]:
     completion_id = f"chatcmpl-{uuid.uuid4().hex}"
     created = int(time.time())
     sent_role = False
-    request = ConversationRequest(model=model, messages=messages)
+    request = ConversationRequest(model=model, messages=messages, thinking_effort=thinking_effort)
     for delta_text in stream_text_deltas(backend, request):
         if not sent_role:
             sent_role = True
@@ -266,22 +293,24 @@ def handle(body: dict[str, Any]) -> dict[str, Any] | Iterator[dict[str, Any]]:
         model, messages = text_chat_parts(body)
         if is_web_search_chat_request(body) and not has_unsupported_tools(body, WEB_SEARCH_TOOL_TYPES):
             return stream_web_search_chat_completion(messages, model)
+        thinking_effort = thinking_effort_from_body(body)
         key = cache_key(body, messages, stream=True)
         return chat_completion_cache.get_or_compute_stream(
             key,
-            lambda: stream_text_chat_completion(text_backend(), messages, model),
+            lambda: stream_text_chat_completion(text_backend(), messages, model, thinking_effort),
         )
     if is_image_chat_request(body):
         return image_chat_response(body)
     model, messages = text_chat_parts(body)
     if is_web_search_chat_request(body) and not has_unsupported_tools(body, WEB_SEARCH_TOOL_TYPES):
         return web_search_chat_response(messages, model)
+    thinking_effort = thinking_effort_from_body(body)
     key = cache_key(body, messages, stream=False)
     return chat_completion_cache.get_or_compute_response(
         key,
         lambda: completion_response(
             model,
-            collect_text(text_backend(), ConversationRequest(model=model, messages=messages)),
+            collect_text(text_backend(), ConversationRequest(model=model, messages=messages, thinking_effort=thinking_effort)),
             messages=messages,
         ),
     )

--- a/services/protocol/openai_v1_response.py
+++ b/services/protocol/openai_v1_response.py
@@ -45,6 +45,28 @@ TOOL_UNAVAILABLE_SYSTEM_MESSAGE = (
 RESPONSE_CONTENT_PART_TYPES = {"text", "input_text", "output_text", "image_url", "input_image", "image"}
 
 
+def normalize_thinking_effort(value: object) -> str:
+    normalized = str(value or "").strip().lower()
+    if normalized in {"", "none"}:
+        return ""
+    if normalized in {"low", "medium", "high"}:
+        return normalized
+    if normalized in {"xhigh", "extended"}:
+        return "extended"
+    return ""
+
+
+def thinking_effort_from_body(body: dict[str, Any]) -> str:
+    reasoning = body.get("reasoning")
+    if isinstance(reasoning, dict):
+        return normalize_thinking_effort(reasoning.get("effort"))
+    if "thinking_effort" in body:
+        return normalize_thinking_effort(body.get("thinking_effort"))
+    if "reasoning_effort" in body:
+        return normalize_thinking_effort(body.get("reasoning_effort"))
+    return ""
+
+
 def is_text_response_request(body: dict[str, Any]) -> bool:
     return not has_response_image_generation_tool(body)
 
@@ -277,13 +299,14 @@ def text_response_parts(body: dict[str, Any]) -> tuple[str, list[dict[str, Any]]
 def stream_text_response(backend, body: dict[str, Any], messages: list[dict[str, Any]] | None = None) -> Iterator[dict[str, Any]]:
     model = str(body.get("model") or "auto").strip() or "auto"
     messages = messages if messages is not None else messages_from_input(body.get("input"), body.get("instructions"))
+    thinking_effort = thinking_effort_from_body(body)
     response_id = f"resp_{uuid.uuid4().hex}"
     item_id = f"msg_{uuid.uuid4().hex}"
     created = int(time.time())
     full_text = ""
     yield response_created(response_id, model, created)
     yield {"type": "response.output_item.added", "output_index": 0, "item": text_output_item("", item_id, "in_progress")}
-    request = ConversationRequest(model=model, messages=messages)
+    request = ConversationRequest(model=model, messages=messages, thinking_effort=thinking_effort)
     for delta in stream_text_deltas(backend, request):
         full_text += delta
         yield {"type": "response.output_text.delta", "item_id": item_id, "output_index": 0, "content_index": 0, "delta": delta}

--- a/test/test_chat_completion_cache.py
+++ b/test/test_chat_completion_cache.py
@@ -7,7 +7,7 @@ import base64
 
 from services.config import config
 from services.protocol import openai_v1_chat_complete, openai_v1_response
-from services.protocol.chat_completion_cache import chat_completion_cache
+from services.protocol.chat_completion_cache import cache_key, chat_completion_cache
 from services.protocol.conversation import iter_conversation_payloads, sanitize_output_text
 from utils.helper import extract_image_from_message_content
 
@@ -65,6 +65,60 @@ class ChatCompletionCacheTests(unittest.TestCase):
             first["choices"][0]["message"]["content"],
             second["choices"][0]["message"]["content"],
         )
+
+    def test_cache_key_distinguishes_thinking_effort_inputs(self) -> None:
+        messages = [{"role": "user", "content": "same prompt"}]
+        base = {"model": "auto", "messages": messages}
+
+        default_key = cache_key(base, messages, stream=False)
+        thinking_key = cache_key({**base, "thinking_effort": "high"}, messages, stream=False)
+        reasoning_key = cache_key({**base, "reasoning": {"effort": "high"}}, messages, stream=False)
+
+        self.assertNotEqual(default_key, thinking_key)
+        self.assertNotEqual(default_key, reasoning_key)
+        self.assertNotEqual(thinking_key, reasoning_key)
+
+    def test_chat_completion_reasoning_effort_reaches_conversation_request(self) -> None:
+        captured_efforts: list[str] = []
+
+        def fake_collect_text(_backend, request):
+            captured_efforts.append(request.thinking_effort)
+            return "ok"
+
+        body = {
+            "model": "auto",
+            "reasoning_effort": "xhigh",
+            "messages": [{"role": "user", "content": "use more reasoning"}],
+        }
+
+        with (
+            mock.patch("services.protocol.openai_v1_chat_complete.text_backend", return_value=object()),
+            mock.patch("services.protocol.openai_v1_chat_complete.collect_text", side_effect=fake_collect_text),
+        ):
+            openai_v1_chat_complete.handle(body)
+
+        self.assertEqual(captured_efforts, ["extended"])
+
+    def test_responses_reasoning_effort_reaches_conversation_request(self) -> None:
+        captured_efforts: list[str] = []
+
+        def fake_stream_text_deltas(_backend, request):
+            captured_efforts.append(request.thinking_effort)
+            yield "ok"
+
+        body = {
+            "model": "auto",
+            "input": "use more reasoning",
+            "reasoning": {"effort": "xhigh"},
+        }
+
+        with (
+            mock.patch("services.protocol.openai_v1_response.text_backend", return_value=object()),
+            mock.patch("services.protocol.openai_v1_response.stream_text_deltas", side_effect=fake_stream_text_deltas),
+        ):
+            openai_v1_response.handle(body)
+
+        self.assertEqual(captured_efforts, ["extended"])
 
     def test_repeated_stream_text_completion_replays_cached_chunks(self) -> None:
         calls = 0

--- a/web/src/app/debug/components/chat-panel.tsx
+++ b/web/src/app/debug/components/chat-panel.tsx
@@ -1,34 +1,117 @@
 "use client";
 
 import { useState } from "react";
-import { LoaderCircle, Send } from "lucide-react";
+import { ImagePlus, LoaderCircle, Send, X } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { httpRequest } from "@/lib/request";
 
-import { pretty, type ChatCompletionResponse, type ChatMessage } from "./types";
+import { pretty, type ChatCompletionResponse, type ChatContentPart, type ChatMessage } from "./types";
+
+type SelectedImage = {
+  id: string;
+  name: string;
+  size: number;
+  url: string;
+};
+
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+
+function readImage(file: File): Promise<SelectedImage> {
+  return new Promise((resolve, reject) => {
+    if (!file.type.startsWith("image/")) {
+      reject(new Error(`${file.name} 不是图片文件`));
+      return;
+    }
+    if (file.size > MAX_IMAGE_BYTES) {
+      reject(new Error(`${file.name} 超过 10MB`));
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      const url = String(reader.result || "");
+      if (!url.startsWith("data:image/")) {
+        reject(new Error(`${file.name} 读取失败`));
+        return;
+      }
+      resolve({
+        id: `${file.name}-${file.size}-${file.lastModified}-${Math.random().toString(16).slice(2)}`,
+        name: file.name,
+        size: file.size,
+        url,
+      });
+    };
+    reader.onerror = () => reject(reader.error || new Error(`${file.name} 读取失败`));
+    reader.readAsDataURL(file);
+  });
+}
+
+function messageText(message: ChatMessage): string {
+  if (typeof message.content === "string") {
+    return message.content;
+  }
+  return message.content
+    .filter((part): part is { type: "text"; text: string } => part.type === "text")
+    .map((part) => part.text)
+    .join("");
+}
+
+function messageImages(message: ChatMessage): string[] {
+  if (!Array.isArray(message.content)) {
+    return [];
+  }
+  return message.content
+    .filter((part): part is { type: "image_url"; image_url: { url: string } } => part.type === "image_url")
+    .map((part) => part.image_url.url);
+}
 
 export function ChatPanel() {
   const [model, setModel] = useState("auto");
+  const [reasoningEffort, setReasoningEffort] = useState("");
   const [input, setInput] = useState("你好，先记住我的项目叫 chatgpt2api。");
+  const [selectedImages, setSelectedImages] = useState<SelectedImage[]>([]);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [raw, setRaw] = useState<ChatCompletionResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
+  const handleImagesChange = async (files: FileList | null) => {
+    if (!files?.length) return;
+    setError("");
+    try {
+      const images = await Promise.all(Array.from(files).map(readImage));
+      setSelectedImages((current) => [...current, ...images].slice(0, 4));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
   const sendChat = async () => {
-    const content = input.trim();
-    if (!content) return;
+    const text = input.trim();
+    if (!text && !selectedImages.length) return;
+    const content: string | ChatContentPart[] = selectedImages.length
+      ? [
+          ...(text ? [{ type: "text" as const, text }] : []),
+          ...selectedImages.map((image) => ({ type: "image_url" as const, image_url: { url: image.url } })),
+        ]
+      : text;
     const nextMessages: ChatMessage[] = [...messages, { role: "user", content }];
     setMessages(nextMessages);
     setInput("");
+    setSelectedImages([]);
     setLoading(true);
     setError("");
     try {
-      const result = await httpRequest<ChatCompletionResponse>("/v1/chat/completions", { method: "POST", body: { model: model.trim() || "auto", messages: nextMessages } });
+      const body = {
+        model: model.trim() || "auto",
+        messages: nextMessages,
+        ...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
+      };
+      const result = await httpRequest<ChatCompletionResponse>("/v1/chat/completions", { method: "POST", body });
       setRaw(result);
       setMessages([...nextMessages, { role: "assistant", content: String(result.choices?.[0]?.message?.content || "") }]);
     } catch (err) {
@@ -40,6 +123,7 @@ export function ChatPanel() {
 
   const clearChat = () => {
     setMessages([]);
+    setSelectedImages([]);
     setRaw(null);
     setError("");
   };
@@ -51,16 +135,57 @@ export function ChatPanel() {
           <h2 className="text-sm font-medium text-stone-500 dark:text-stone-400">请求</h2>
         </div>
         <div className="min-h-0 flex-1 space-y-4 overflow-auto pt-4">
-          <div className="space-y-2">
-            <Label htmlFor="chat-model">Model</Label>
-            <Input id="chat-model" value={model} onChange={(event) => setModel(event.target.value)} className="rounded-md border-stone-200/70 bg-transparent shadow-none dark:border-white/10" />
+          <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_160px]">
+            <div className="space-y-2">
+              <Label htmlFor="chat-model">Model</Label>
+              <Input id="chat-model" value={model} onChange={(event) => setModel(event.target.value)} className="rounded-md border-stone-200/70 bg-transparent shadow-none dark:border-white/10" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="chat-reasoning-effort">思考强度</Label>
+              <Select value={reasoningEffort || "default"} onValueChange={(value) => setReasoningEffort(value === "default" ? "" : value)}>
+                <SelectTrigger id="chat-reasoning-effort" className="h-10 rounded-md border-stone-200/70 bg-transparent shadow-none dark:border-white/10">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="default">默认</SelectItem>
+                  <SelectItem value="low">低</SelectItem>
+                  <SelectItem value="medium">中</SelectItem>
+                  <SelectItem value="high">高</SelectItem>
+                  <SelectItem value="xhigh">超高</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
           </div>
           <div className="space-y-2">
             <Label htmlFor="chat-input">Message</Label>
             <Textarea id="chat-input" value={input} onChange={(event) => setInput(event.target.value)} className="min-h-32 rounded-md border-stone-200/70 bg-transparent shadow-none dark:border-white/10" />
           </div>
+          <div className="space-y-2">
+            <Label htmlFor="chat-images">图片</Label>
+            <label htmlFor="chat-images" className="flex cursor-pointer items-center justify-center gap-2 rounded-md border border-dashed border-stone-300 bg-stone-50/70 px-3 py-3 text-sm text-stone-600 transition hover:border-stone-400 hover:bg-stone-100 dark:border-white/10 dark:bg-white/[0.03] dark:text-stone-300 dark:hover:bg-white/[0.06]">
+              <ImagePlus className="size-4" />
+              选择图片
+            </label>
+            <input id="chat-images" type="file" accept="image/png,image/jpeg,image/webp,image/gif" multiple className="sr-only" onChange={(event) => {
+              void handleImagesChange(event.target.files);
+              event.currentTarget.value = "";
+            }} />
+            {selectedImages.length ? (
+              <div className="grid grid-cols-2 gap-2">
+                {selectedImages.map((image) => (
+                  <div key={image.id} className="group relative overflow-hidden rounded-md border border-stone-200 bg-white dark:border-white/10 dark:bg-white/[0.04]">
+                    <img src={image.url} alt={image.name} className="aspect-square w-full object-cover" />
+                    <button type="button" aria-label={`移除 ${image.name}`} onClick={() => setSelectedImages((current) => current.filter((item) => item.id !== image.id))} className="absolute top-1 right-1 flex size-7 items-center justify-center rounded-md bg-white/90 text-stone-700 shadow-sm transition hover:bg-white dark:bg-stone-950/90 dark:text-stone-100">
+                      <X className="size-4" />
+                    </button>
+                    <div className="absolute inset-x-0 bottom-0 truncate bg-white/90 px-2 py-1 text-xs text-stone-600 dark:bg-stone-950/90 dark:text-stone-300">{image.name}</div>
+                  </div>
+                ))}
+              </div>
+            ) : null}
+          </div>
           <div className="flex gap-2">
-            <Button size="sm" onClick={() => void sendChat()} disabled={loading || !input.trim()}>
+            <Button size="sm" onClick={() => void sendChat()} disabled={loading || (!input.trim() && !selectedImages.length)}>
               {loading ? <LoaderCircle className="animate-spin" /> : <Send />}
               发送
             </Button>
@@ -80,7 +205,14 @@ export function ChatPanel() {
           {messages.length ? messages.map((message, index) => (
             <div key={`${message.role}-${index}`} className="space-y-1.5 text-sm">
               <div className="text-xs font-medium uppercase tracking-wide text-stone-400 dark:text-stone-500">{message.role}</div>
-              <div className="whitespace-pre-wrap leading-7 text-stone-700 dark:text-stone-300">{message.content}</div>
+              {messageImages(message).length ? (
+                <div className="flex flex-wrap gap-2">
+                  {messageImages(message).map((url, imageIndex) => (
+                    <img key={`${index}-${imageIndex}`} src={url} alt="" className="h-28 w-28 rounded-md border border-stone-200 object-cover dark:border-white/10" />
+                  ))}
+                </div>
+              ) : null}
+              {messageText(message) ? <div className="whitespace-pre-wrap leading-7 text-stone-700 dark:text-stone-300">{messageText(message)}</div> : null}
             </div>
           )) : (
             <div className="flex h-full items-center justify-center text-sm text-stone-400 dark:text-stone-500">暂无对话消息</div>

--- a/web/src/app/debug/components/types.ts
+++ b/web/src/app/debug/components/types.ts
@@ -7,8 +7,12 @@ export type SearchResult = {
 
 export type ChatMessage = {
   role: "system" | "user" | "assistant";
-  content: string;
+  content: string | ChatContentPart[];
 };
+
+export type ChatContentPart =
+  | { type: "text"; text: string }
+  | { type: "image_url"; image_url: { url: string } };
 
 export type ChatCompletionResponse = {
   choices?: Array<{ message?: { role?: string; content?: string } }>;


### PR DESCRIPTION
## Summary
- pass `thinking_effort` / `reasoning_effort` / `reasoning.effort` through regular text chat requests
- map `xhigh` and `extended` to ChatGPT Web backend `thinking_effort=extended`, while ignoring empty, `none`, and invalid values
- include effort-related request fields in the text completion cache key
- add debug page controls for reasoning effort and image input testing using the OpenAI-compatible `image_url` message content shape

## Notes
- default behavior is unchanged because `thinking_effort` is only sent when the client explicitly provides a supported value
- image generation, image edit, PPT, and PSD task paths are not changed
- the debug image picker sends data URLs as `messages[].content[]` parts, matching the OpenAI multimodal input style already accepted by this project

## Validation
- `python -m compileall -q services api utils`
- `cd web && npm run build`
- verified the debug page can send `reasoning_effort=xhigh`; in a live deployment the visible reasoning juice increased from 8 to 64
- verified an OpenAI-style `image_url` data URL message parses into both text and image parts on the backend
