### PR TITLE
feat(register): 支持 mailapi.icu 这类 HTTP 取件邮箱 (email----取件URL)

### DIFF
--- a/services/register/mail_provider.py
+++ b/services/register/mail_provider.py
@@ -13,6 +13,7 @@ from email.header import decode_header, make_header
 from email.utils import parsedate_to_datetime
 from threading import Lock
 from typing import Any, Callable, TypeVar
+from urllib.parse import urlsplit, urlunsplit, parse_qsl, urlencode
 
 from curl_cffi import requests
 
@@ -1075,6 +1076,17 @@ def _clean_outlook_value(value: str) -> str:
     return str(value or "").replace("﻿", "").replace(" ", " ").strip()
 
 
+def _force_query_param(url: str, key: str, value: str) -> str:
+    """把 URL 上的某个 query 参数强制设为指定值（mailapi.icu 取件强制 type=html）。"""
+    try:
+        parts = urlsplit(url)
+        q = dict(parse_qsl(parts.query, keep_blank_values=True))
+        q[key] = value
+        return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(q), parts.fragment))
+    except Exception:
+        return url
+
+
 def parse_outlook_credentials(text: str) -> list[dict[str, str]]:
     """解析邮箱池文本，每行格式：email----password----client_id----refresh_token。"""
     credentials: list[dict[str, str]] = []
@@ -1084,6 +1096,13 @@ def parse_outlook_credentials(text: str) -> list[dict[str, str]]:
         if not line or "----" not in line:
             continue
         parts = [_clean_outlook_value(part) for part in line.split("----", 3)]
+        if len(parts) == 2 and "@" in parts[0] and parts[1].lower().startswith(("http://", "https://")):
+            key = parts[0].lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            credentials.append({"email": parts[0], "password": "", "client_id": "", "refresh_token": "", "read_url": parts[1]})
+            continue
         if len(parts) != 4:
             continue
         email, password, client_id, refresh_token = parts
@@ -1190,6 +1209,7 @@ class OutlookTokenProvider(BaseMailProvider):
             "label": self.label,
             "client_id": credential["client_id"],
             "refresh_token": credential["refresh_token"],
+            "read_url": credential.get("read_url", ""),
         }
 
     def _read_graph(self, access_token: str) -> list[dict[str, Any]]:
@@ -1313,6 +1333,9 @@ class OutlookTokenProvider(BaseMailProvider):
 
     def fetch_recent_messages(self, mailbox: dict[str, Any]) -> list[dict[str, Any]]:
         """拉取最近 N 封邮件（最新在前），供 wait_for_code 逐封扫描验证码。"""
+        read_url = str(mailbox.get("read_url") or "").strip()
+        if read_url:
+            return self._mailapi_messages(mailbox, read_url)
         client_id = str(mailbox.get("client_id") or "").strip()
         refresh_token = str(mailbox.get("refresh_token") or "").strip()
         if not client_id or not refresh_token:
@@ -1337,6 +1360,40 @@ class OutlookTokenProvider(BaseMailProvider):
         if errors:
             raise RuntimeError("; ".join(errors))
         return []
+
+    def _mailapi_messages(self, mailbox: dict[str, Any], read_url: str) -> list[dict[str, Any]]:
+        """mailapi.icu 取件：用 type=html 取完整邮件正文。
+
+        type=json 的 text 字段会被截断、且 verification_code 对 OpenAI 邮件常为空，故改用 type=html，
+        把完整 HTML 交给 _extract_code 抠取 6 位验证码（已自动排除 #hex 颜色等干扰）。
+        无邮件时接口返回 JSON {"error": ...}（常见 404），按"暂无邮件"返回空列表继续轮询。
+        """
+        url = _force_query_param(read_url, "type", "html")
+        try:
+            resp = self.session.get(
+                url,
+                headers={"User-Agent": self.conf["user_agent"]},
+                timeout=self.conf["request_timeout"],
+            )
+        except Exception as error:
+            raise RuntimeError(f"mailapi 取件请求失败: {error}")
+        body = resp.text or ""
+        stripped = body.lstrip()
+        if getattr(resp, "status_code", 200) == 404 or (stripped.startswith("{") and '"error"' in stripped[:200]):
+            return []
+        if not stripped:
+            return []
+        return [{
+            "provider": self.name,
+            "mailbox": mailbox.get("address"),
+            "message_id": "",
+            "subject": "",
+            "sender": "",
+            "text_content": "",
+            "html_content": body,
+            "received_at": None,
+            "raw": None,
+        }]
 
     def fetch_latest_message(self, mailbox: dict[str, Any]) -> dict[str, Any] | None:
         messages = self.fetch_recent_messages(mailbox)

--- a/services/register_service.py
+++ b/services/register_service.py
@@ -17,9 +17,13 @@ REGISTER_FILE = DATA_DIR / "register.json"
 
 
 def _serialize_outlook_pool(credentials: list[dict]) -> str:
-    return "\n".join(
-        f'{c["email"]}----{c.get("password", "")}----{c["client_id"]}----{c["refresh_token"]}' for c in credentials
-    )
+    lines = []
+    for c in credentials:
+        if c.get("read_url"):
+            lines.append(f'{c["email"]}----{c["read_url"]}')
+        else:
+            lines.append(f'{c["email"]}----{c.get("password", "")}----{c["client_id"]}----{c["refresh_token"]}')
+    return "\n".join(lines)
 
 
 def _merge_outlook_pool(old_text: str, new_text: str) -> str:


### PR DESCRIPTION
## 支持 mailapi.icu 这类「HTTP 取件邮箱」（`邮箱----取件URL` 格式）

### 背景
现有 `outlook_token` 邮箱池要求 4 段格式 `email----password----client_id----refresh_token`，通过 Microsoft Graph/IMAP 读验证码。但有一类常见的付费 outlook 邮箱（如 mailapi.icu「微软API取件」）只提供一个 **HTTP 取件 URL**，格式是 2 段：

```
TexannaAspenson@outlook.com----https://mailapi.icu/key?type=html&orderNo=8b1556ab01727983
```

这类 URL 本质也是读 outlook 邮箱（按 orderNo 返回最新邮件），所以本 PR 让 `outlook_token` 槽位**自动识别并支持**这种 2 段取件 URL 行——复用现有的 UI、邮箱池合并/去重/统计逻辑，**无需任何前端改动**。

### 改动
- `parse_outlook_credentials`：识别 2 段 `email----http(s)://...` 行，解析为 `{email, read_url, ...}`（4 段格式行为完全不变，混合池互不干扰）。
- `OutlookTokenProvider`：`create_mailbox` 透出 `read_url`；`fetch_recent_messages` 顶部对带 `read_url` 的邮箱走新的 `_mailapi_messages` 分支。
- `_mailapi_messages`：强制 `type=html` 拉完整邮件正文，交给现有 `_extract_code` 抠取验证码。
- `_serialize_outlook_pool`：序列化时正确往返 2 段取件 URL 行。
- 新增 `_force_query_param` 小工具。

### 为什么用 `type=html` 而不是 `type=json`
实测对 OpenAI 验证码邮件：`type=json` 返回的 `text` 字段会被**截断**（只剩 CSS 头部、不含验证码），且 `verification_code` 字段为空、`type=code` 返回「未找到验证码」。只有 `type=html` 能拿到完整邮件正文，验证码在其中（`_extract_code` 已能排除 `#hex` 颜色等干扰，正确抠出 6 位码）。

### 用法
注册页 provider 选 `outlook_token`，mailboxes 文本框粘贴 `邮箱----取件URL` 行即可（建议把 `mail.wait_timeout` 调到 ≥90s，因为这类取件接口通常有 ~30s 缓存）。

### 兼容性 & 验证
- 向后兼容：原 4 段 `email----password----client_id----refresh_token` 行为不变；4 段与 2 段可在同一池混用。
- 已在真实环境用本路径成功注册数百个账号（authorize → 取码 → 换 token → refresh_token 落库 全链路验证通过）。
