### PR TITLE
feat: add configurable display timezone

### DIFF
--- a/api/system.py
+++ b/api/system.py
@@ -81,6 +81,11 @@ def create_router(app_version: str) -> APIRouter:
         require_admin(authorization)
         return {"config": config.get()}
 
+    @router.get("/api/display-settings")
+    async def get_display_settings(authorization: str | None = Header(default=None)):
+        require_identity(authorization)
+        return {"display_timezone": config.display_timezone}
+
     @router.get("/api/third-party-apps")
     async def get_third_party_apps(authorization: str | None = Header(default=None)):
         require_identity(authorization)

--- a/services/account_service.py
+++ b/services/account_service.py
@@ -114,8 +114,7 @@ class AccountService:
             ts = int(value)
         except (TypeError, ValueError):
             return ""
-        tz = timezone(timedelta(hours=8))
-        return datetime.fromtimestamp(ts, tz=timezone.utc).astimezone(tz).isoformat()
+        return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
 
     def _load_accounts(self) -> dict[str, dict]:
         accounts = self.storage.load_accounts()
@@ -1025,7 +1024,7 @@ class AccountService:
             if current is None:
                 return
             next_item = dict(current)
-            next_item["last_used_at"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            next_item["last_used_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
             account = self._normalize_account(next_item)
             if account is None:
                 return
@@ -1291,7 +1290,7 @@ class AccountService:
             if current is None:
                 return None
             next_item = dict(current)
-            next_item["last_used_at"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            next_item["last_used_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
             image_quota_unknown = bool(next_item.get("image_quota_unknown"))
             if success:
                 next_item["success"] = int(next_item.get("success") or 0) + 1

--- a/services/config.py
+++ b/services/config.py
@@ -4,6 +4,7 @@ import copy
 from dataclasses import dataclass
 import json
 import os
+import re
 import sys
 from pathlib import Path
 import time
@@ -15,6 +16,8 @@ DATA_DIR = BASE_DIR / "data"
 CONFIG_FILE = BASE_DIR / "config.json"
 VERSION_FILE = BASE_DIR / "VERSION"
 BACKUP_STATE_FILE = DATA_DIR / "backup_state.json"
+DEFAULT_DISPLAY_TIMEZONE = "Asia/Shanghai"
+DISPLAY_TIMEZONE_PATTERN = re.compile(r"^[A-Za-z0-9_+\-./]{1,80}$")
 
 DEFAULT_BACKUP_INCLUDE = {
     "config": True,
@@ -103,6 +106,13 @@ def _normalize_positive_int(value: object, default: int, minimum: int = 0) -> in
     except (OverflowError, TypeError, ValueError):
         normalized = default
     return max(minimum, normalized)
+
+
+def _normalize_display_timezone(value: object) -> str:
+    timezone_name = str(value or DEFAULT_DISPLAY_TIMEZONE).strip()
+    if not timezone_name or not DISPLAY_TIMEZONE_PATTERN.fullmatch(timezone_name):
+        return DEFAULT_DISPLAY_TIMEZONE
+    return timezone_name
 
 
 def _normalize_backup_include(value: object) -> dict[str, bool]:
@@ -386,6 +396,10 @@ class ConfigStore:
             return 5
 
     @property
+    def display_timezone(self) -> str:
+        return _normalize_display_timezone(self.data.get("display_timezone"))
+
+    @property
     def image_retention_days(self) -> int:
         try:
             return max(1, int(self.data.get("image_retention_days", 30)))
@@ -542,6 +556,7 @@ class ConfigStore:
     def get(self) -> dict[str, object]:
         data = dict(self.data)
         data["refresh_account_interval_minute"] = self.refresh_account_interval_minute
+        data["display_timezone"] = self.display_timezone
         data["image_retention_days"] = self.image_retention_days
         data["image_poll_timeout_secs"] = self.image_poll_timeout_secs
         data["image_poll_interval_secs"] = self.image_poll_interval_secs
@@ -598,6 +613,8 @@ class ConfigStore:
             )
         if "third_party_apps" in next_data:
             next_data["third_party_apps"] = _normalize_third_party_apps_settings(next_data.get("third_party_apps"))
+        if "display_timezone" in next_data:
+            next_data["display_timezone"] = _normalize_display_timezone(next_data.get("display_timezone"))
         if "proxy_runtime" in next_data:
             incoming_runtime = next_data.get("proxy_runtime")
             if isinstance(incoming_runtime, dict):

--- a/services/editable_file_task_service.py
+++ b/services/editable_file_task_service.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import threading
 import time
-from datetime import datetime
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote
@@ -13,6 +12,7 @@ from services.config import DATA_DIR
 from services.content_filter import request_text
 from services.log_service import LOG_TYPE_CALL, log_service
 from services.openai_backend_api import EDITABLE_FILE_MODEL, OpenAIBackendAPI
+from services.time_utils import utc_now_iso, utc_timestamp_iso
 from utils.helper import new_uuid
 
 TASK_STATUS_QUEUED = "queued"
@@ -26,7 +26,7 @@ EDITABLE_FILE_TASKS_PATH = DATA_DIR / "editable_file_tasks.json"
 
 
 def _now_iso() -> str:
-    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    return utc_now_iso()
 
 
 def _clean(value: object, default: str = "") -> str:
@@ -234,7 +234,7 @@ class EditableFileTaskService:
             "role": identity.get("role"),
             "endpoint": f"/v1/{kind}/generations",
             "model": EDITABLE_FILE_MODEL,
-            "started_at": datetime.fromtimestamp(started).strftime("%Y-%m-%d %H:%M:%S"),
+            "started_at": utc_timestamp_iso(started),
             "ended_at": _now_iso(),
             "duration_ms": int((time.time() - started) * 1000),
             "status": status,

--- a/services/image_storage_service.py
+++ b/services/image_storage_service.py
@@ -5,7 +5,7 @@ import io
 import json
 import time
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from threading import Lock
 from urllib.parse import quote, urlparse
@@ -15,6 +15,7 @@ from fastapi import HTTPException
 from PIL import Image
 
 from services.config import DATA_DIR, config
+from services.time_utils import utc_now_iso, utc_timestamp_iso
 
 IMAGE_INDEX_FILE = DATA_DIR / "image_index.json"
 IMAGE_INDEX_LOCK = Lock()
@@ -38,7 +39,7 @@ def _clean(value: object) -> str:
 
 
 def _now_iso() -> str:
-    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    return utc_now_iso()
 
 
 def _safe_relative_path(path: str) -> str:
@@ -288,9 +289,9 @@ class ImageStorageService:
                     "rel": rel,
                     "path": rel,
                     "name": path.name,
-                    "date": "-".join(rel.split("/")[:3]) if len(rel.split("/")) >= 4 else datetime.fromtimestamp(path.stat().st_mtime).strftime("%Y-%m-%d"),
+                    "date": "-".join(rel.split("/")[:3]) if len(rel.split("/")) >= 4 else datetime.fromtimestamp(path.stat().st_mtime, tz=UTC).strftime("%Y-%m-%d"),
                     "size": path.stat().st_size,
-                    "created_at": datetime.fromtimestamp(path.stat().st_mtime).strftime("%Y-%m-%d %H:%M:%S"),
+                    "created_at": utc_timestamp_iso(path.stat().st_mtime),
                     "storage": "local",
                     "local": True,
                     "webdav": False,
@@ -383,9 +384,9 @@ class ImageStorageService:
                         "rel": rel,
                         "path": rel,
                         "name": path.name,
-                        "date": "-".join(rel.split("/")[:3]) if len(rel.split("/")) >= 4 else datetime.fromtimestamp(path.stat().st_mtime).strftime("%Y-%m-%d"),
+                        "date": "-".join(rel.split("/")[:3]) if len(rel.split("/")) >= 4 else datetime.fromtimestamp(path.stat().st_mtime, tz=UTC).strftime("%Y-%m-%d"),
                         "size": len(payload),
-                        "created_at": str(item.get("created_at") or datetime.fromtimestamp(path.stat().st_mtime).strftime("%Y-%m-%d %H:%M:%S")),
+                        "created_at": str(item.get("created_at") or utc_timestamp_iso(path.stat().st_mtime)),
                         "storage": "both",
                         "local": True,
                         "webdav": True,

--- a/services/image_task_service.py
+++ b/services/image_task_service.py
@@ -4,7 +4,7 @@ import json
 import threading
 import time
 from collections.abc import Callable
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -12,6 +12,7 @@ from services.config import DATA_DIR, config
 from services.content_filter import request_text
 from services.log_service import LOG_TYPE_CALL, log_service
 from services.protocol import openai_v1_image_edit, openai_v1_image_generations
+from services.time_utils import utc_now_iso, utc_timestamp_iso
 
 TASK_STATUS_QUEUED = "queued"
 TASK_STATUS_RUNNING = "running"
@@ -22,19 +23,28 @@ UNFINISHED_STATUSES = {TASK_STATUS_QUEUED, TASK_STATUS_RUNNING}
 
 
 def _now_iso() -> str:
-    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    return utc_now_iso()
 
 
 def _timestamp(value: object) -> float:
     if not isinstance(value, str) or not value.strip():
         return 0.0
+    raw = value.strip()
+    if raw.endswith("Z") or "+" in raw[10:] or "-" in raw[10:]:
+        try:
+            return datetime.fromisoformat(raw.replace("Z", "+00:00")).timestamp()
+        except Exception:
+            pass
     for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S.%f", "%Y-%m-%dT%H:%M:%S"):
         try:
-            return datetime.strptime(value[:26], fmt).timestamp()
+            return datetime.strptime(raw[:26], fmt).replace(tzinfo=timezone.utc).timestamp()
         except ValueError:
             continue
     try:
-        return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.timestamp()
     except Exception:
         return 0.0
 
@@ -328,7 +338,7 @@ class ImageTaskService:
             "role": identity.get("role"),
             "endpoint": endpoint,
             "model": model,
-            "started_at": datetime.fromtimestamp(started).strftime("%Y-%m-%d %H:%M:%S"),
+            "started_at": utc_timestamp_iso(started),
             "ended_at": _now_iso(),
             "duration_ms": int((time.time() - started) * 1000),
             "status": status,

--- a/services/log_service.py
+++ b/services/log_service.py
@@ -5,7 +5,6 @@ import json
 import itertools
 import time
 from dataclasses import dataclass, field
-from datetime import datetime
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
@@ -16,6 +15,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from services.config import DATA_DIR
 from services.protocol.error_response import anthropic_error_response, openai_error_response
+from services.time_utils import utc_now_iso, utc_timestamp_iso
 from utils.helper import anthropic_sse_stream, sse_json_stream
 
 LOG_TYPE_CALL = "call"
@@ -63,7 +63,7 @@ class LogService:
     def add(self, type: str, summary: str = "", detail: dict[str, Any] | None = None, **data: Any) -> None:
         item = {
             "id": uuid4().hex,
-            "time": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            "time": utc_now_iso(),
             "type": type,
             "summary": summary,
             "detail": detail or data,
@@ -307,8 +307,8 @@ class LoggedCall:
             "role": self.identity.get("role"),
             "endpoint": self.endpoint,
             "model": self.model,
-            "started_at": datetime.fromtimestamp(self.started).strftime("%Y-%m-%d %H:%M:%S"),
-            "ended_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            "started_at": utc_timestamp_iso(self.started),
+            "ended_at": utc_now_iso(),
             "duration_ms": int((time.time() - self.started) * 1000),
             "status": status,
         }

--- a/services/time_utils.py
+++ b/services/time_utils.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+
+def utc_now_iso() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def utc_timestamp_iso(value: float) -> str:
+    return datetime.fromtimestamp(value, tz=UTC).isoformat().replace("+00:00", "Z")

--- a/web/src/app/accounts/page.tsx
+++ b/web/src/app/accounts/page.tsx
@@ -58,7 +58,9 @@ import {
   type Model,
   type RefreshProgressResponse,
 } from "@/lib/api";
+import { formatDisplayDateTime, formatDisplayShortDateTime, parseDisplayDate } from "@/lib/display-time";
 import { useAuthGuard } from "@/lib/use-auth-guard";
+import { useDisplayTimezone } from "@/lib/use-display-timezone";
 import { cn } from "@/lib/utils";
 
 import { AccountImportDialog } from "./components/account-import-dialog";
@@ -118,13 +120,13 @@ function formatQuota(account: Account) {
   return String(Math.max(0, account.quota));
 }
 
-function formatRestoreAt(value?: string | null) {
+function formatRestoreAt(value: string | null | undefined, timezone: string) {
   if (!value) {
     return { absolute: "—", relative: "" };
   }
 
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
+  const date = parseDisplayDate(value);
+  if (!date) {
     return { absolute: value, relative: "" };
   }
 
@@ -134,10 +136,7 @@ function formatRestoreAt(value?: string | null) {
   const hours = totalHours % 24;
   const relative = diffMs > 0 ? `剩余 ${days}d ${hours}h` : "已到恢复时间";
 
-  const pad = (num: number) => String(num).padStart(2, "0");
-  const absolute = `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(
-    date.getHours(),
-  )}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+  const absolute = formatDisplayDateTime(value, timezone, value);
 
   return { absolute, relative };
 }
@@ -187,6 +186,7 @@ function displayAccountSource(account: Account) {
 
 function AccountsPageContent() {
   const didLoadRef = useRef(false);
+  const displayTimezone = useDisplayTimezone();
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [availableModels, setAvailableModels] = useState<Model[]>([]);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
@@ -1150,15 +1150,7 @@ function AccountsPageContent() {
                           <div className="text-xs leading-5 text-stone-500">{account.email ?? "—"}</div>
                         </td>
                         <td className="px-4 py-3 text-xs leading-5 text-stone-500">
-                          {(() => {
-                            const raw = (account as any).created_at;
-                            if (!raw) return "—";
-                            try {
-                              const d = new Date(raw + "Z");
-                              if (isNaN(d.getTime())) return String(raw).slice(0, 10);
-                              return d.toLocaleDateString("zh-CN", { month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit" });
-                            } catch { return String(raw).slice(0, 10); }
-                          })()}
+                          {formatDisplayShortDateTime(account.created_at, displayTimezone, "—")}
                         </td>
                         <td className="px-4 py-3">
                           <Badge variant="info" className="rounded-md">
@@ -1167,7 +1159,7 @@ function AccountsPageContent() {
                         </td>
                         <td className="px-4 py-3 text-xs leading-5 text-stone-500">
                           {(() => {
-                            const restore = formatRestoreAt(account.restore_at);
+                            const restore = formatRestoreAt(account.restore_at, displayTimezone);
                             return (
                               <div className="space-y-0.5">
                                 {restore.relative ? <div className="font-medium text-stone-700">{restore.relative}</div> : null}

--- a/web/src/app/debug/components/editable-file-panel.tsx
+++ b/web/src/app/debug/components/editable-file-panel.tsx
@@ -9,7 +9,9 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { formatDisplayDateTime } from "@/lib/display-time";
 import { httpRequest } from "@/lib/request";
+import { useDisplayTimezone } from "@/lib/use-display-timezone";
 import { cn } from "@/lib/utils";
 import {
   listDeletedEditableFileIds,
@@ -91,6 +93,7 @@ function ResultFile({ href, icon, label }: { href?: string; icon: ReactNode; lab
 }
 
 export function EditableFilePanel({ title, kind, endpoint, defaultPrompt, imageRequired }: Props) {
+  const displayTimezone = useDisplayTimezone();
   const [prompt, setPrompt] = useState(defaultPrompt);
   const [images, setImages] = useState<string[]>([]);
   const [tasks, setTasks] = useState<EditableFileTask[]>([]);
@@ -321,7 +324,7 @@ export function EditableFilePanel({ title, kind, endpoint, defaultPrompt, imageR
                     <div className="mt-2 flex items-center gap-2 text-xs text-stone-500 dark:text-stone-400">
                       <Clock3 className="size-3.5" />
                       <span className="tabular-nums">{formatElapsed(elapsedOf(task))}</span>
-                      <span className="truncate">{task.created_at || id}</span>
+                      <span className="truncate">{formatDisplayDateTime(task.created_at, displayTimezone, task.created_at || id)}</span>
                     </div>
                     {(task.prompt_preview || drafts[id]?.prompt) ? <div className="mt-2 line-clamp-2 text-xs leading-5 text-stone-500 dark:text-stone-400">{task.prompt_preview || drafts[id]?.prompt}</div> : null}
                   </button>

--- a/web/src/app/image-manager/page.tsx
+++ b/web/src/app/image-manager/page.tsx
@@ -14,7 +14,9 @@ import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { compressAllImages, deleteImageTag, deleteManagedImages, deleteToTarget, downloadImages, downloadSingleImage, fetchImageStorage, fetchImageTags, fetchManagedImages, setImageTags, type ImageStorageStats, type ManagedImage } from "@/lib/api";
+import { formatDisplayDateTime } from "@/lib/display-time";
 import { useAuthGuard } from "@/lib/use-auth-guard";
+import { useDisplayTimezone } from "@/lib/use-display-timezone";
 
 const LONG_PRESS_MS = 800;
 const IMAGE_MANAGER_CHECKBOX_CLASS = "border-stone-300 bg-white/80 dark:border-white/35 dark:bg-white/5 data-[state=checked]:border-stone-950 dark:data-[state=checked]:border-white";
@@ -58,6 +60,7 @@ function useLongPress(onLongPress: () => void, ms = LONG_PRESS_MS) {
 }
 
 function ImageManagerContent() {
+  const displayTimezone = useDisplayTimezone();
   const [items, setItems] = useState<ManagedImage[]>([]);
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
@@ -516,7 +519,7 @@ function ImageManagerContent() {
                   <div className="flex items-center justify-between gap-2">
                     <div className="flex items-center gap-1 font-medium text-stone-700">
                       <CalendarDays className="size-3.5" />
-                      {item.created_at}
+                      {formatDisplayDateTime(item.created_at, displayTimezone, item.created_at)}
                     </div>
                     <div className="flex items-center gap-1">
                       <Button
@@ -651,7 +654,7 @@ function ImageManagerContent() {
               />
               <div className="min-w-0 overflow-hidden text-xs text-stone-500">
                 <div className="truncate font-medium text-stone-700">{deleteTarget.name}</div>
-                <div className="truncate">{deleteTarget.created_at}</div>
+                <div className="truncate">{formatDisplayDateTime(deleteTarget.created_at, displayTimezone, deleteTarget.created_at)}</div>
                 <div>{formatSize(deleteTarget.size)}</div>
               </div>
             </div>

--- a/web/src/app/image/page.tsx
+++ b/web/src/app/image/page.tsx
@@ -29,8 +29,10 @@ import {
   type Model,
   type ImageTask,
 } from "@/lib/api";
+import { formatDisplayShortDateTime } from "@/lib/display-time";
 import { useAuthGuard } from "@/lib/use-auth-guard";
 import { useSettingsStore } from "@/app/settings/store";
+import { useDisplayTimezone } from "@/lib/use-display-timezone";
 import {
   clearImageConversations,
   deleteImageConversation,
@@ -102,17 +104,8 @@ function buildConversationTitle(prompt: string) {
   return `${trimmed.slice(0, 12)}...`;
 }
 
-function formatConversationTime(value: string) {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return "";
-  }
-  return new Intl.DateTimeFormat("zh-CN", {
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-  }).format(date);
+function formatConversationTime(value: string, timezone: string) {
+  return formatDisplayShortDateTime(value, timezone, "");
 }
 
 function formatAvailableQuota(accounts: Account[]) {
@@ -442,6 +435,7 @@ function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
   const scrollRestoreGenerationRef = useRef(0);
 
   const config = useSettingsStore((state) => state.config);
+  const displayTimezone = useDisplayTimezone();
   const imageTimeoutRetrySecs = Number(config?.image_timeout_retry_secs || 30);
 
   const [imagePrompt, setImagePrompt] = useState("");
@@ -489,6 +483,10 @@ function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
         return sum + stats.queued + stats.running;
       }, 0),
     [conversations],
+  );
+  const formatConversationTimeForDisplay = useCallback(
+    (value: string) => formatConversationTime(value, displayTimezone),
+    [displayTimezone],
   );
   const deleteConfirmTitle =
     deleteConfirm?.type === "all"
@@ -1595,7 +1593,7 @@ function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
             onSelectConversation={setSelectedConversationId}
             onDeleteConversation={openDeleteConversationConfirm}
             onRenameConversation={handleRenameConversation}
-            formatConversationTime={formatConversationTime}
+            formatConversationTime={formatConversationTimeForDisplay}
           />
         </div>
 
@@ -1623,7 +1621,7 @@ function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
                 }}
                 onDeleteConversation={openDeleteConversationConfirm}
                 onRenameConversation={handleRenameConversation}
-                formatConversationTime={formatConversationTime}
+                formatConversationTime={formatConversationTimeForDisplay}
                 hideActionButtons
               />
             </div>
@@ -1675,7 +1673,7 @@ function ImagePageContent({ isAdmin }: { isAdmin: boolean }) {
                 onRetryImage={handleRetryImage}
                 onTimeoutRetryContinue={handleTimeoutRetryContinue}
                 onDismissErrors={handleDismissErrors}
-                formatConversationTime={formatConversationTime}
+                formatConversationTime={formatConversationTimeForDisplay}
               />
             </div>
 

--- a/web/src/app/logs/page.tsx
+++ b/web/src/app/logs/page.tsx
@@ -15,7 +15,9 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { deleteSystemLogs, fetchSystemLogs, type SystemLog } from "@/lib/api";
+import { formatDisplayDateTime } from "@/lib/display-time";
 import { useAuthGuard } from "@/lib/use-auth-guard";
+import { useDisplayTimezone } from "@/lib/use-display-timezone";
 
 const LogType = {
   Call: "call",
@@ -49,7 +51,15 @@ function getStatus(item: SystemLog) {
   return "-";
 }
 
+function formatDetailValue(key: string, value: unknown, timezone: string) {
+  if (key === "time" || key.endsWith("_at")) {
+    return formatDisplayDateTime(value, timezone, String(value));
+  }
+  return String(value);
+}
+
 function LogsContent() {
+  const displayTimezone = useDisplayTimezone();
   const [items, setItems] = useState<SystemLog[]>([]);
   const [type, setType] = useState<string>(LogType.Call);
   const [startDate, setStartDate] = useState("");
@@ -211,7 +221,7 @@ function LogsContent() {
                       <TableCell>
                         <Checkbox checked={selectedSet.has(item.id)} onCheckedChange={(checked) => toggleIds([item.id], Boolean(checked))} />
                       </TableCell>
-                      <TableCell className="whitespace-nowrap">{item.time}</TableCell>
+                      <TableCell className="whitespace-nowrap">{formatDisplayDateTime(item.time, displayTimezone, item.time)}</TableCell>
                       <TableCell><Badge variant="secondary" className="rounded-md">{typeLabels[item.type] || item.type}</Badge></TableCell>
                       {isCallLog ? <TableCell>{getDetailText(item, "key_name")}</TableCell> : null}
                       {isCallLog ? <TableCell>{formatDuration(item)}</TableCell> : null}
@@ -289,7 +299,7 @@ function LogsContent() {
                   .map(([key, value]) => (
                     <div key={key} className="flex items-start justify-between gap-4">
                       <span className="text-stone-400">{key}</span>
-                      <span className="text-right font-medium break-all text-stone-700">{String(value)}</span>
+                      <span className="text-right font-medium break-all text-stone-700">{formatDetailValue(key, value, displayTimezone)}</span>
                     </div>
                   ))}
               </div>

--- a/web/src/app/register/components/register-card.tsx
+++ b/web/src/app/register/components/register-card.tsx
@@ -8,10 +8,13 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
+import { formatDisplayTime } from "@/lib/display-time";
+import { useDisplayTimezone } from "@/lib/use-display-timezone";
 
 import { useSettingsStore } from "../../settings/store";
 
 export function RegisterCard() {
+  const displayTimezone = useDisplayTimezone();
   const config = useSettingsStore((state) => state.registerConfig);
   const isLoading = useSettingsStore((state) => state.isLoadingRegister);
   const isSaving = useSettingsStore((state) => state.isSavingRegister);
@@ -413,7 +416,7 @@ export function RegisterCard() {
               ) : (
                 logs.slice().reverse().map((item, index) => (
                   <div key={`${item.time}-${index}`} className={item.level === "red" ? "text-rose-600" : item.level === "green" ? "text-emerald-700" : item.level === "yellow" ? "text-amber-700" : "text-stone-700"}>
-                    <span className="text-stone-400">{new Date(item.time).toLocaleTimeString()}</span>
+                    <span className="text-stone-400">{formatDisplayTime(item.time, displayTimezone, item.time)}</span>
                     <span className="pl-2">{item.text}</span>
                   </div>
                 ))

--- a/web/src/app/settings/components/backup-settings-card.tsx
+++ b/web/src/app/settings/components/backup-settings-card.tsx
@@ -12,24 +12,12 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/u
 import { Input } from "@/components/ui/input";
 import webConfig from "@/constants/common-env";
 import { fetchBackupDetail, getBackupDownloadUrl, type BackupDetail, type BackupInclude } from "@/lib/api";
+import { DEFAULT_DISPLAY_TIMEZONE, formatDisplayDateTime, normalizeDisplayTimezone } from "@/lib/display-time";
 import { getStoredAuthKey } from "@/store/auth";
 import { useSettingsStore } from "../store";
 
-function formatDateTime(value?: string | null) {
-  if (!value) {
-    return "—";
-  }
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return value;
-  }
-  return new Intl.DateTimeFormat("zh-CN", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-  }).format(date);
+function formatDateTime(value: string | null | undefined, timezone: string) {
+  return formatDisplayDateTime(value, timezone, "—");
 }
 
 function formatBytes(value: number) {
@@ -95,6 +83,7 @@ export function BackupSettingsCard() {
   const testBackup = useSettingsStore((state) => state.testBackup);
   const setBackupField = useSettingsStore((state) => state.setBackupField);
   const setBackupInclude = useSettingsStore((state) => state.setBackupInclude);
+  const displayTimezone = normalizeDisplayTimezone(config?.display_timezone || DEFAULT_DISPLAY_TIMEZONE);
 
   if (isLoadingConfig) {
     return (
@@ -266,11 +255,11 @@ export function BackupSettingsCard() {
           <div className="grid gap-3 rounded-xl border border-stone-200 bg-stone-50 px-4 py-4 text-sm text-stone-600 md:grid-cols-3">
           <div>
             <div className="text-xs text-stone-500">最近开始</div>
-            <div className="mt-1 font-medium text-stone-800">{formatDateTime(backupState?.last_started_at)}</div>
+            <div className="mt-1 font-medium text-stone-800">{formatDateTime(backupState?.last_started_at, displayTimezone)}</div>
           </div>
           <div>
             <div className="text-xs text-stone-500">最近完成</div>
-            <div className="mt-1 font-medium text-stone-800">{formatDateTime(backupState?.last_finished_at)}</div>
+            <div className="mt-1 font-medium text-stone-800">{formatDateTime(backupState?.last_finished_at, displayTimezone)}</div>
           </div>
           <div>
             <div className="text-xs text-stone-500">最近对象</div>
@@ -332,7 +321,7 @@ export function BackupSettingsCard() {
                       </div>
                       <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-stone-500">
                         <span>大小 {formatBytes(item.size)}</span>
-                        <span>更新时间 {formatDateTime(item.updated_at)}</span>
+                        <span>更新时间 {formatDateTime(item.updated_at, displayTimezone)}</span>
                         <span className="break-all">对象 key {item.key}</span>
                       </div>
                     </div>
@@ -394,7 +383,7 @@ export function BackupSettingsCard() {
                   </div>
                   <div>
                     <div className="text-xs text-stone-500">创建时间</div>
-                    <div className="mt-1 font-medium text-stone-800">{formatDateTime(detail.created_at)}</div>
+                    <div className="mt-1 font-medium text-stone-800">{formatDateTime(detail.created_at, displayTimezone)}</div>
                   </div>
                   <div>
                     <div className="text-xs text-stone-500">触发方式</div>

--- a/web/src/app/settings/components/config-card.tsx
+++ b/web/src/app/settings/components/config-card.tsx
@@ -12,6 +12,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Textarea } from "@/components/ui/textarea";
 import type { ImageStorageMode } from "@/lib/api";
 import { testProxy, type ProxyTestResult } from "@/lib/api";
+import { DISPLAY_TIMEZONE_CHOICES, DEFAULT_DISPLAY_TIMEZONE } from "@/lib/display-time";
 
 import { useSettingsStore } from "../store";
 
@@ -44,6 +45,7 @@ export function ConfigCard() {
   const isTestingImageStorage = useSettingsStore((state) => state.isTestingImageStorage);
   const isSyncingImageStorage = useSettingsStore((state) => state.isSyncingImageStorage);
   const saveConfig = useSettingsStore((state) => state.saveConfig);
+  const setDisplayTimezone = useSettingsStore((state) => state.setDisplayTimezone);
 
   const handleTestProxy = async () => {
     const candidate = String(config?.proxy || "").trim();
@@ -78,6 +80,13 @@ export function ConfigCard() {
     );
   }
 
+  const displayTimezone = String(config?.display_timezone || DEFAULT_DISPLAY_TIMEZONE);
+  const timezoneChoices: Array<{ value: string; label: string }> = DISPLAY_TIMEZONE_CHOICES.some(
+    (item) => item.value === displayTimezone,
+  )
+    ? [...DISPLAY_TIMEZONE_CHOICES]
+    : [{ value: displayTimezone, label: "当前自定义时区" }, ...DISPLAY_TIMEZONE_CHOICES];
+
   return (
     <Card className="rounded-2xl border-white/80 bg-white/90 shadow-sm">
       <CardContent className="space-y-4 p-6">
@@ -94,6 +103,24 @@ export function ConfigCard() {
               className="h-10 rounded-xl border-stone-200 bg-white"
             />
             <p className="text-xs text-stone-500">单位分钟，控制账号自动刷新频率。</p>
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm text-stone-700">显示时区</label>
+            <Select value={displayTimezone} onValueChange={setDisplayTimezone}>
+              <SelectTrigger className="h-10 rounded-xl border-stone-200 bg-white">
+                <SelectValue placeholder={DEFAULT_DISPLAY_TIMEZONE} />
+              </SelectTrigger>
+              <SelectContent className="max-h-72">
+                {timezoneChoices.map((item) => (
+                  <SelectItem key={item.value} value={item.value}>
+                    {item.label} · {item.value}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-stone-500">
+              选择常用 IANA 时区，只影响页面时间展示，不改变上游请求。
+            </p>
           </div>
           <div className="space-y-2">
             <label className="text-sm text-stone-700">全局代理</label>

--- a/web/src/app/settings/components/cpa-pools-card.tsx
+++ b/web/src/app/settings/components/cpa-pools-card.tsx
@@ -5,6 +5,7 @@ import { Import, LoaderCircle, Pencil, Plus, ServerCog, Trash2 } from "lucide-re
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { DEFAULT_DISPLAY_TIMEZONE, formatDisplayDateTime, normalizeDisplayTimezone } from "@/lib/display-time";
 
 import { useSettingsStore } from "../store";
 
@@ -17,6 +18,8 @@ export function CPAPoolsCard() {
   const openEditDialog = useSettingsStore((state) => state.openEditDialog);
   const deletePool = useSettingsStore((state) => state.deletePool);
   const browseFiles = useSettingsStore((state) => state.browseFiles);
+  const config = useSettingsStore((state) => state.config);
+  const displayTimezone = normalizeDisplayTimezone(config?.display_timezone || DEFAULT_DISPLAY_TIMEZONE);
 
   return (
     <Card className="rounded-2xl border-white/80 bg-white/90 shadow-sm">
@@ -120,7 +123,7 @@ export function CPAPoolsCard() {
                               状态 {importJob.status}，已处理 {importJob.completed}/{importJob.total}
                             </div>
                             <div className="truncate text-xs text-stone-400">
-                              任务 {importJob.job_id.slice(0, 8)} · {importJob.created_at}
+                              任务 {importJob.job_id.slice(0, 8)} · {formatDisplayDateTime(importJob.created_at, displayTimezone, importJob.created_at)}
                             </div>
                           </div>
                           <Badge

--- a/web/src/app/settings/components/sub2api-connections.tsx
+++ b/web/src/app/settings/components/sub2api-connections.tsx
@@ -52,6 +52,8 @@ import {
   type Sub2APIRemoteGroup,
   type Sub2APIServer,
 } from "@/lib/api";
+import { formatDisplayDateTime } from "@/lib/display-time";
+import { useDisplayTimezone } from "@/lib/use-display-timezone";
 
 const PAGE_SIZE_OPTIONS = ["50", "100", "200"] as const;
 
@@ -80,6 +82,7 @@ function normalizeAccounts(items: Sub2APIRemoteAccount[]) {
 }
 
 export function Sub2APIConnections() {
+  const displayTimezone = useDisplayTimezone();
   const didLoadRef = useRef(false);
   const pollTimerRef = useRef<number | null>(null);
 
@@ -497,7 +500,7 @@ export function Sub2APIConnections() {
                                     状态 {importJob.status}，已处理 {importJob.completed}/{importJob.total}
                                   </div>
                                   <div className="truncate text-xs text-stone-400">
-                                    任务 {importJob.job_id.slice(0, 8)} · {importJob.created_at}
+                                    任务 {importJob.job_id.slice(0, 8)} · {formatDisplayDateTime(importJob.created_at, displayTimezone, importJob.created_at)}
                                   </div>
                                 </div>
                                 <Badge

--- a/web/src/app/settings/components/user-keys-card.tsx
+++ b/web/src/app/settings/components/user-keys-card.tsx
@@ -17,25 +17,17 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { createUserKey, deleteUserKey, fetchUserKeys, updateUserKey, type UserKey } from "@/lib/api";
+import { DEFAULT_DISPLAY_TIMEZONE, formatDisplayDateTime, normalizeDisplayTimezone } from "@/lib/display-time";
 
-function formatDateTime(value?: string | null) {
-  if (!value) {
-    return "—";
-  }
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return value;
-  }
-  return new Intl.DateTimeFormat("zh-CN", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-  }).format(date);
+import { useSettingsStore } from "../store";
+
+function formatDateTime(value: string | null | undefined, timezone: string) {
+  return formatDisplayDateTime(value, timezone, "—");
 }
 
 export function UserKeysCard() {
+  const config = useSettingsStore((state) => state.config);
+  const displayTimezone = normalizeDisplayTimezone(config?.display_timezone || DEFAULT_DISPLAY_TIMEZONE);
   const didLoadRef = useRef(false);
   const [items, setItems] = useState<UserKey[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -231,8 +223,8 @@ export function UserKeysCard() {
                         </Badge>
                       </div>
                       <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-stone-500">
-                        <span>创建时间 {formatDateTime(item.created_at)}</span>
-                        <span>最近使用 {formatDateTime(item.last_used_at)}</span>
+                        <span>创建时间 {formatDateTime(item.created_at, displayTimezone)}</span>
+                        <span>最近使用 {formatDateTime(item.last_used_at, displayTimezone)}</span>
                       </div>
                     </div>
 

--- a/web/src/app/settings/store.ts
+++ b/web/src/app/settings/store.ts
@@ -38,6 +38,7 @@ import {
   type SettingsConfig,
   type ThirdPartyAppsSettings,
 } from "@/lib/api";
+import { DEFAULT_DISPLAY_TIMEZONE, normalizeDisplayTimezone } from "@/lib/display-time";
 
 export const PAGE_SIZE_OPTIONS = ["50", "100", "200"] as const;
 
@@ -117,7 +118,7 @@ function normalizeProxyRuntime(value: unknown): ProxyRuntimeSettings {
 
 function normalizeThirdPartyApps(value: unknown): ThirdPartyAppsSettings {
   const source = typeof value === "object" && value !== null ? value as Partial<ThirdPartyAppsSettings> : {};
-  const canvas = typeof source.infinite_canvas === "object" && source.infinite_canvas
+  const canvas: Partial<ThirdPartyAppsSettings["infinite_canvas"]> = typeof source.infinite_canvas === "object" && source.infinite_canvas
     ? source.infinite_canvas
     : {};
   return {
@@ -174,6 +175,7 @@ function normalizeConfig(config: SettingsConfig): SettingsConfig {
   return {
     ...config,
     refresh_account_interval_minute: Number(config.refresh_account_interval_minute || 5),
+    display_timezone: normalizeDisplayTimezone(config.display_timezone || DEFAULT_DISPLAY_TIMEZONE),
     image_retention_days: Number(config.image_retention_days || 30),
     image_poll_timeout_secs: Number(config.image_poll_timeout_secs || 120),
     image_account_concurrency: Number(config.image_account_concurrency || 3),
@@ -298,6 +300,7 @@ type SettingsStore = {
   removeBackup: (key: string) => Promise<void>;
   testBackup: () => Promise<void>;
   setRefreshAccountIntervalMinute: (value: string) => void;
+  setDisplayTimezone: (value: string) => void;
   setImageRetentionDays: (value: string) => void;
   setImagePollTimeoutSecs: (value: string) => void;
   setImageAccountConcurrency: (value: string) => void;
@@ -444,6 +447,7 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
       const data = await updateSettingsConfig({
         ...config,
         refresh_account_interval_minute: Math.max(1, Number(config.refresh_account_interval_minute) || 1),
+        display_timezone: normalizeDisplayTimezone(config.display_timezone || DEFAULT_DISPLAY_TIMEZONE),
         image_retention_days: Math.max(1, Number(config.image_retention_days) || 30),
         image_poll_timeout_secs: Math.max(1, Number(config.image_poll_timeout_secs) || 120),
         image_account_concurrency: Math.max(1, Number(config.image_account_concurrency) || 3),
@@ -538,6 +542,10 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
         },
       };
     });
+  },
+
+  setDisplayTimezone: (value) => {
+    set((state) => state.config ? { config: { ...state.config, display_timezone: value } } : {});
   },
 
   setImageRetentionDays: (value) => {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -31,6 +31,8 @@ export type Account = {
     reset_after?: string;
   }>;
   default_model_slug?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
   restore_at?: string | null;
   success: number;
   fail: number;
@@ -155,6 +157,7 @@ export type ThirdPartyAppsSettings = {
 export type SettingsConfig = {
   proxy: string;
   base_url?: string;
+  display_timezone?: string;
   global_system_prompt?: string;
   sensitive_words?: string[];
   ai_review?: {
@@ -562,6 +565,10 @@ export async function resumeImagePoll(taskId: string, extraTimeoutSecs = 30) {
 
 export async function fetchSettingsConfig() {
   return httpRequest<{ config: SettingsConfig }>("/api/settings");
+}
+
+export async function fetchDisplaySettings() {
+  return httpRequest<{ display_timezone: string }>("/api/display-settings");
 }
 
 export async function updateSettingsConfig(settings: SettingsConfig) {

--- a/web/src/lib/display-time.ts
+++ b/web/src/lib/display-time.ts
@@ -1,0 +1,133 @@
+export const DEFAULT_DISPLAY_TIMEZONE = "Asia/Shanghai";
+
+export const DISPLAY_TIMEZONE_CHOICES = [
+  { value: "Asia/Shanghai", label: "中国大陆 / 北京时间" },
+  { value: "Asia/Hong_Kong", label: "中国香港" },
+  { value: "Asia/Taipei", label: "中国台湾" },
+  { value: "Asia/Singapore", label: "新加坡" },
+  { value: "Asia/Tokyo", label: "日本东京" },
+  { value: "Asia/Seoul", label: "韩国首尔" },
+  { value: "Asia/Bangkok", label: "泰国曼谷" },
+  { value: "Asia/Jakarta", label: "印尼雅加达" },
+  { value: "Asia/Kolkata", label: "印度加尔各答" },
+  { value: "Asia/Dubai", label: "阿联酋迪拜" },
+  { value: "Australia/Sydney", label: "澳大利亚悉尼" },
+  { value: "Pacific/Auckland", label: "新西兰奥克兰" },
+  { value: "UTC", label: "UTC 标准时间" },
+  { value: "Europe/London", label: "英国伦敦" },
+  { value: "Europe/Paris", label: "法国巴黎" },
+  { value: "Europe/Berlin", label: "德国柏林" },
+  { value: "Europe/Amsterdam", label: "荷兰阿姆斯特丹" },
+  { value: "Europe/Moscow", label: "俄罗斯莫斯科" },
+  { value: "America/New_York", label: "美国纽约 / 东部" },
+  { value: "America/Chicago", label: "美国芝加哥 / 中部" },
+  { value: "America/Denver", label: "美国丹佛 / 山区" },
+  { value: "America/Los_Angeles", label: "美国洛杉矶 / 太平洋" },
+  { value: "America/Toronto", label: "加拿大多伦多" },
+  { value: "America/Vancouver", label: "加拿大温哥华" },
+  { value: "America/Mexico_City", label: "墨西哥城" },
+  { value: "America/Sao_Paulo", label: "巴西圣保罗" },
+] as const;
+
+export const DISPLAY_TIMEZONE_OPTIONS = DISPLAY_TIMEZONE_CHOICES.map((item) => item.value);
+
+const TIMEZONE_FORMAT_CACHE = new Map<string, boolean>();
+const UTC_OFFSET_PATTERN = /(?:z|[+-]\d{2}:?\d{2})$/i;
+const NAIVE_DATE_TIME_PATTERN = /^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}(?::\d{2}(?:\.\d{1,6})?)?$/;
+
+export function normalizeDisplayTimezone(value: unknown): string {
+  const timezone = String(value || DEFAULT_DISPLAY_TIMEZONE).trim();
+  if (!timezone) {
+    return DEFAULT_DISPLAY_TIMEZONE;
+  }
+  const cached = TIMEZONE_FORMAT_CACHE.get(timezone);
+  if (cached !== undefined) {
+    return cached ? timezone : DEFAULT_DISPLAY_TIMEZONE;
+  }
+  try {
+    new Intl.DateTimeFormat("zh-CN", { timeZone: timezone }).format(new Date(0));
+    TIMEZONE_FORMAT_CACHE.set(timezone, true);
+    return timezone;
+  } catch {
+    TIMEZONE_FORMAT_CACHE.set(timezone, false);
+    return DEFAULT_DISPLAY_TIMEZONE;
+  }
+}
+
+export function parseDisplayDate(value: unknown): Date | null {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const timestamp = value > 10_000_000_000 ? value : value * 1000;
+    const date = new Date(timestamp);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+
+  const raw = String(value ?? "").trim();
+  if (!raw) {
+    return null;
+  }
+  if (/^\d+$/.test(raw)) {
+    return parseDisplayDate(Number(raw));
+  }
+
+  const normalized = raw.replace(" ", "T");
+  const source = UTC_OFFSET_PATTERN.test(normalized) || !NAIVE_DATE_TIME_PATTERN.test(raw)
+    ? normalized
+    : `${normalized}Z`;
+  const date = new Date(source);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function dateParts(date: Date, timezone: string) {
+  const formatter = new Intl.DateTimeFormat("zh-CN", {
+    timeZone: normalizeDisplayTimezone(timezone),
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+  });
+  const parts = formatter.formatToParts(date).reduce<Record<string, string>>((acc, part) => {
+    acc[part.type] = part.value;
+    return acc;
+  }, {});
+  return {
+    year: parts.year || "0000",
+    month: parts.month || "00",
+    day: parts.day || "00",
+    hour: parts.hour || "00",
+    minute: parts.minute || "00",
+    second: parts.second || "00",
+  };
+}
+
+export function formatDisplayDateTime(value: unknown, timezone: string, fallback = "-"): string {
+  const date = parseDisplayDate(value);
+  if (!date) {
+    return fallback;
+  }
+  const parts = dateParts(date, timezone);
+  return `${parts.year}-${parts.month}-${parts.day} ${parts.hour}:${parts.minute}:${parts.second}`;
+}
+
+export function formatDisplayShortDateTime(value: unknown, timezone: string, fallback = "-"): string {
+  const date = parseDisplayDate(value);
+  if (!date) {
+    return fallback;
+  }
+  const parts = dateParts(date, timezone);
+  return `${parts.month}-${parts.day} ${parts.hour}:${parts.minute}`;
+}
+
+export function formatDisplayTime(value: unknown, timezone: string, fallback = "-"): string {
+  const date = parseDisplayDate(value);
+  if (!date) {
+    return fallback;
+  }
+  const parts = dateParts(date, timezone);
+  return `${parts.hour}:${parts.minute}:${parts.second}`;
+}

--- a/web/src/lib/use-display-timezone.ts
+++ b/web/src/lib/use-display-timezone.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { useSettingsStore } from "@/app/settings/store";
+import { fetchDisplaySettings } from "@/lib/api";
+import { DEFAULT_DISPLAY_TIMEZONE, normalizeDisplayTimezone } from "@/lib/display-time";
+
+export function useDisplayTimezone() {
+  const didLoadRef = useRef(false);
+  const config = useSettingsStore((state) => state.config);
+  const [displayTimezone, setDisplayTimezone] = useState(DEFAULT_DISPLAY_TIMEZONE);
+
+  useEffect(() => {
+    if (config?.display_timezone) {
+      setDisplayTimezone(normalizeDisplayTimezone(config.display_timezone));
+      return;
+    }
+    if (didLoadRef.current) {
+      return;
+    }
+    didLoadRef.current = true;
+    void fetchDisplaySettings()
+      .then((data) => setDisplayTimezone(normalizeDisplayTimezone(data.display_timezone)))
+      .catch(() => setDisplayTimezone(DEFAULT_DISPLAY_TIMEZONE));
+  }, [config?.display_timezone]);
+
+  return normalizeDisplayTimezone(config?.display_timezone || displayTimezone);
+}


### PR DESCRIPTION
## Summary
- add a `display_timezone` setting with `Asia/Shanghai` as the default
- expose `/api/display-settings` so authenticated pages can read display-only timezone safely
- format account, log, image, backup, register, and debug timestamps using the configured IANA timezone
- store new UI-facing server timestamps as UTC ISO strings so display is independent from server timezone
- replace manual timezone entry with a common timezone dropdown in settings
<img width="1167" height="174" alt="1782645611234_d" src="https://github.com/user-attachments/assets/d018df8f-bba8-4528-bae7-41a20186a837" />
<img width="1188" height="624" alt="1782645629670_d" src="https://github.com/user-attachments/assets/19ccc209-0590-49a4-be30-e9d4cece4c00" />

## Tests
- `python -m compileall services api utils`
- `cd web && npx tsc --noEmit`
- `cd web && npm run build`
