### PR TITLE
fix: 为图片 SSE 流增加硬超时上限，避免约 30 分钟挂起

### DIFF
--- a/services/openai_backend_api.py
+++ b/services/openai_backend_api.py
@@ -4,6 +4,7 @@ import mimetypes
 import os
 import random
 import re
+import threading
 import time
 
 import urllib.error
@@ -38,6 +39,11 @@ class ImagePollTimeoutError(RuntimeError):
 
 class ImageContentPolicyError(RuntimeError):
     """Raised when image generation is blocked by content policy moderation."""
+    pass
+
+
+class ImageStreamHardTimeoutError(RuntimeError):
+    """图片 SSE 流读取超过硬上限时抛出，用于快速中断被挂起的长连接。"""
     pass
 
 
@@ -2589,10 +2595,40 @@ class OpenAIBackendAPI:
         self._report_progress("starting_generation")
         response = self._start_image_generation(prompt, requirements, conduit_token, model, references)
         self._report_progress("generating")
+        yield from self._iter_sse_payloads_capped(response, float(config.image_poll_timeout_secs))
+
+    def _iter_sse_payloads_capped(self, response: Any, hard_cap_secs: float) -> Iterator[str]:
+        """按墙钟硬上限消费图片 SSE 流，避免上游异常时长连接被无限挂起。
+
+        curl_cffi 在 stream=True + 标量 timeout 下不限制流式 body 的总读取时长，
+        上游未生成图片却保持连接时，读取会一直阻塞直到边缘重置（曾观测到单条流
+        挂起约 29.5 分钟才失败）。这里复用「图片轮询超时」作为硬上限：到点后关闭
+        底层连接以解除阻塞，并抛出明确错误，让任务快速失败而非长时间挂起。
+        """
+        deadline = time.monotonic() + hard_cap_secs
+        # 看门狗：SSE 读取可能阻塞在底层 curl 调用中，超时后关闭连接以强制解除阻塞
+        watchdog = threading.Timer(hard_cap_secs, response.close)
+        watchdog.daemon = True
+        watchdog.start()
+        timeout_message = f"图片生成流已超过硬上限 {int(hard_cap_secs)} 秒，已强制中断（上游可能未生成图片）"
         try:
-            yield from iter_sse_payloads(response)
+            for payload in iter_sse_payloads(response):
+                yield payload
+                if time.monotonic() >= deadline:
+                    raise ImageStreamHardTimeoutError(timeout_message)
+        except ImageStreamHardTimeoutError:
+            raise
+        except Exception as exc:
+            # 看门狗关闭连接后，底层读取会抛出 curl 错误，这里统一转成明确的硬上限错误
+            if time.monotonic() >= deadline:
+                raise ImageStreamHardTimeoutError(timeout_message) from exc
+            raise
         finally:
-            response.close()
+            watchdog.cancel()
+            try:
+                response.close()
+            except Exception:
+                pass
 
     def _bootstrap(self) -> None:
         """预热首页，并提取 PoW 相关脚本引用。"""


### PR DESCRIPTION
图片生成/编辑会打开一条 HTTP/2 长连接 SSE 流，而 curl_cffi 在 stream=True + 标量 timeout 下不限制流式 body 的总读取时长。当上游返回未处理的错误、未生成
图片却保持连接时，读取会一直阻塞直到边缘重置连接（约 29.5 分钟后报 curl 92）。

复用可配置的「图片轮询超时」(image_poll_timeout_secs) 作为墙钟硬上限：到点后 关闭连接并以明确错误快速失败，避免任务长时间挂起。