### PR TITLE
fix: allow longer access tokens in database storage

### DIFF
--- a/services/storage/database_storage.py
+++ b/services/storage/database_storage.py
@@ -17,7 +17,7 @@ class AccountModel(Base):
     __tablename__ = "accounts"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    access_token = Column(String(2048), unique=True, nullable=False, index=True)
+    access_token = Column(Text, unique=True, nullable=False, index=True)
     data = Column(Text, nullable=False)  # JSON 格式存储完整账号数据
 
 

--- a/test/test_database_storage_long_token.py
+++ b/test/test_database_storage_long_token.py
@@ -1,0 +1,21 @@
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.schema import CreateTable
+
+from services.storage.database_storage import AccountModel, DatabaseStorageBackend
+
+
+def test_accounts_access_token_uses_unbounded_text_for_postgresql():
+    ddl = str(CreateTable(AccountModel.__table__).compile(dialect=postgresql.dialect()))
+
+    assert "access_token TEXT" in ddl
+    assert "VARCHAR(2048)" not in ddl
+
+
+def test_save_accounts_accepts_access_token_longer_than_2048(tmp_path):
+    backend = DatabaseStorageBackend(f"sqlite:///{tmp_path / 'accounts.db'}")
+    access_token = "a" * 2055
+
+    backend.save_accounts([{"access_token": access_token, "name": "long token"}])
+
+    [account] = backend.load_accounts()
+    assert account["access_token"] == access_token


### PR DESCRIPTION
## Summary

- change the database model for `accounts.access_token` from `String(2048)` to unbounded `Text`
- add a PostgreSQL DDL regression test so the column no longer compiles as `VARCHAR(2048)`
- add a storage regression test for a 2055-character access token

## Why

Valid access tokens can be longer than 2048 characters. In one production dataset the maximum observed length was 2055, which requires manual schema changes when PostgreSQL creates the column as `VARCHAR(2048)`.

Closes #356

## Test plan

```bash
uv run --with pytest pytest -q test/test_database_storage_long_token.py
uv run --with pytest pytest -q test/test_database_storage_long_token.py test/test_account_export.py
```

Results:

```text
2 passed
5 passed
```

## Migration note

Existing PostgreSQL databases that already have `accounts.access_token` as `varchar(2048)` will still need a one-time migration because SQLAlchemy `create_all()` does not alter existing columns:

```sql
ALTER TABLE accounts ALTER COLUMN access_token TYPE text;
```

## Compatibility caveat

This is a minimal PostgreSQL-oriented fix. Some MySQL-like backends do not support indexing or unique constraints on an unbounded `TEXT` column without a prefix length. A more portable long-term design would store the original token in `TEXT` and index a separate token digest/hash column. Very large PostgreSQL text values can also hit B-tree index tuple-size limits when uniquely indexed; the digest-column approach would address that too.
