### PR TITLE
fix: filter internal assistant tool messages

### DIFF
--- a/services/protocol/conversation.py
+++ b/services/protocol/conversation.py
@@ -380,6 +380,33 @@ def assistant_message_text(message: dict[str, Any]) -> str:
     return ""
 
 
+def is_visible_assistant_message(message: dict[str, Any]) -> bool:
+    """Return whether an upstream assistant message is intended for the user."""
+    author = message.get("author")
+    if not isinstance(author, dict):
+        return False
+    role = str(author.get("role") or "").strip().lower()
+    if role != "assistant":
+        return False
+
+    metadata = message.get("metadata") or {}
+    if isinstance(metadata, dict) and metadata.get("is_visually_hidden_from_conversation") is True:
+        return False
+
+    # Tool commands are emitted as assistant messages addressed to recipients
+    # such as "web". Only messages addressed to everyone are user-visible.
+    recipient = str(message.get("recipient") or "").strip().lower()
+    if recipient and recipient != "all":
+        return False
+
+    # Reasoning and other internal channels must not leak into API text output.
+    channel = str(message.get("channel") or "").strip().lower()
+    if channel and channel != "final":
+        return False
+
+    return True
+
+
 def strip_history(text: str, history_text: str = "") -> str:
     text = str(text or "")
     history_text = str(history_text or "")
@@ -438,10 +465,7 @@ def assistant_raw_text(event: dict[str, Any], current_text: str = "", history_te
         if not isinstance(candidate, dict):
             continue
         message = candidate.get("message")
-        if not isinstance(message, dict):
-            continue
-        role = str((message.get("author") or {}).get("role") or "").strip().lower()
-        if role != "assistant":
+        if not isinstance(message, dict) or not is_visible_assistant_message(message):
             continue
         text = assistant_message_text(message)
         if text:
@@ -458,7 +482,7 @@ def event_assistant_text(event: dict[str, Any], history_text: str = "") -> str:
         if not isinstance(candidate, dict):
             continue
         message = candidate.get("message")
-        if isinstance(message, dict) and (message.get("author") or {}).get("role") == "assistant":
+        if isinstance(message, dict) and is_visible_assistant_message(message):
             return strip_history(assistant_message_text(message), history_text)
     return ""
 

--- a/test/test_chat_completion_cache.py
+++ b/test/test_chat_completion_cache.py
@@ -280,6 +280,119 @@ class ChatCompletionCacheTests(unittest.TestCase):
         self.assertEqual("".join(deltas), "Repo: chatgpt2api done.")
         self.assertFalse(any("\ue200" in delta or "\ue202" in delta or "\ue201" in delta for delta in deltas))
 
+    def test_stream_ignores_internal_tool_recipient_messages(self) -> None:
+        events = [
+            {
+                "message": {
+                    "author": {"role": "assistant"},
+                    "content": {
+                        "content_type": "code",
+                        "text": 'search("\\u56fd\\u5bb6\\u6d77\\u6d0b")',
+                    },
+                    "recipient": "web",
+                    "status": "finished_successfully",
+                },
+            },
+            {
+                "message": {
+                    "author": {"name": "web.run", "role": "tool"},
+                    "content": {"content_type": "text", "parts": [""]},
+                    "recipient": "all",
+                    "status": "finished_successfully",
+                },
+            },
+            {
+                "v": {
+                    "message": {
+                        "author": {"role": "assistant"},
+                        "content": {
+                            "content_type": "code",
+                            "text": '{"aspect_ratio":"16:9","query":["museum"],"num_per_query":2}',
+                        },
+                        "recipient": "web",
+                        "status": "finished_successfully",
+                    },
+                },
+            },
+            {
+                "message": {
+                    "author": {"role": "assistant"},
+                    "channel": "final",
+                    "content": {"content_type": "text", "parts": ["Final answer."]},
+                    "recipient": "all",
+                    "status": "finished_successfully",
+                },
+            },
+            "[DONE]",
+        ]
+        payloads = [json.dumps(event, ensure_ascii=False) if isinstance(event, dict) else event for event in events]
+        deltas = [
+            str(event.get("delta") or "")
+            for event in iter_conversation_payloads(iter(payloads))
+            if event.get("type") == "conversation.delta"
+        ]
+
+        self.assertEqual("".join(deltas), "Final answer.")
+
+    def test_stream_ignores_hidden_and_non_final_assistant_messages(self) -> None:
+        events = [
+            {
+                "message": {
+                    "author": {"role": "assistant"},
+                    "channel": "final",
+                    "content": {"content_type": "text", "parts": ["Hidden text."]},
+                    "metadata": {"is_visually_hidden_from_conversation": True},
+                    "recipient": "all",
+                },
+            },
+            {
+                "message": {
+                    "author": {"role": "assistant"},
+                    "channel": "analysis",
+                    "content": {"content_type": "text", "parts": ["Private reasoning."]},
+                    "recipient": "all",
+                },
+            },
+            {
+                "message": {
+                    "author": {"role": "assistant"},
+                    "channel": "final",
+                    "content": {"content_type": "text", "parts": ["Visible text."]},
+                    "recipient": "all",
+                },
+            },
+            "[DONE]",
+        ]
+        payloads = [json.dumps(event, ensure_ascii=False) if isinstance(event, dict) else event for event in events]
+        deltas = [
+            str(event.get("delta") or "")
+            for event in iter_conversation_payloads(iter(payloads))
+            if event.get("type") == "conversation.delta"
+        ]
+
+        self.assertEqual("".join(deltas), "Visible text.")
+
+    def test_stream_preserves_user_visible_code_messages(self) -> None:
+        events = [
+            {
+                "message": {
+                    "author": {"role": "assistant"},
+                    "channel": "final",
+                    "content": {"content_type": "code", "text": 'print("hello")'},
+                    "recipient": "all",
+                },
+            },
+            "[DONE]",
+        ]
+        payloads = [json.dumps(event, ensure_ascii=False) if isinstance(event, dict) else event for event in events]
+        deltas = [
+            str(event.get("delta") or "")
+            for event in iter_conversation_payloads(iter(payloads))
+            if event.get("type") == "conversation.delta"
+        ]
+
+        self.assertEqual("".join(deltas), 'print("hello")')
+
     def test_responses_tools_add_honest_no_tool_guard(self) -> None:
         model, messages = openai_v1_response.text_response_parts({
             "model": "auto",


### PR DESCRIPTION
## Summary

- filter upstream assistant messages by visibility metadata, recipient, and channel before emitting API deltas
- prevent internal web tool commands such as `search(...)` and raw image-query JSON from leaking into client-visible responses
- preserve normal user-visible final text and code messages

## Root cause

ChatGPT Web emits internal tool invocations as assistant-authored `code` messages addressed to recipients such as `web`. The conversation parser only checked `author.role == "assistant"`, so those internal messages were serialized as normal response text and displayed verbatim by downstream clients.

## Tests

- `uv run python -m unittest test.test_chat_completion_cache` (28 passed)
- selected offline unit suite (91 passed)
- `uv run python -m compileall -q services test`
- `git diff --check`