### PR TITLE
fix: stabilize image generation streams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,12 @@ dist/
 wheels/
 *.egg-info
 web_dist
+node_modules/
+web/node_modules/
+web/.next/
+web/out/
+.bun-cache/
+.tmp/
 # Virtual environments
 .venv
 .idea
@@ -16,6 +22,7 @@ edit
 docker-compose-local.yml
 
 .claude/settings.local.json
+.codex/runtime/
 
 # Environment variables
 .env

--- a/services/account_service.py
+++ b/services/account_service.py
@@ -24,6 +24,8 @@ from utils.helper import anonymize_token
 class AccountService:
     """账号池服务，使用 token -> account 的 dict 保存账号。"""
 
+    _IMAGE_ACCOUNT_CHECK_RETRIES = 3
+    _IMAGE_ACCOUNT_CHECK_RETRY_BACKOFF_SECONDS = 0.5
     _NEW_ACCOUNT_INVALID_GRACE_SECONDS = 10 * 60
     _INVALID_CONFIRM_SECONDS = 30
     _ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 24 * 60 * 60
@@ -953,6 +955,35 @@ class AccountService:
                 self._image_inflight[access_token] = current_inflight - 1
             self._image_slot_condition.notify_all()
 
+    @staticmethod
+    def _is_transient_image_account_check_error(exc: Exception) -> bool:
+        if exc.__class__.__name__ == "InvalidAccessTokenError":
+            return False
+        status_code = getattr(exc, "status_code", None)
+        if status_code in {408, 409, 423, 425, 429, 500, 502, 503, 504}:
+            return True
+        if isinstance(status_code, int) and 400 <= status_code < 500:
+            return False
+        message = str(exc).lower()
+        return any(marker in message for marker in (
+            "failed to perform",
+            "curl:",
+            "tls",
+            "ssl",
+            "timeout",
+            "timed out",
+            "connection",
+            "http/2",
+            "temporarily unavailable",
+            "remote disconnected",
+            "unexpected eof",
+        ))
+
+    @staticmethod
+    def _account_check_error_message(exc: Exception, attempts: int) -> str:
+        detail = str(exc).strip() or exc.__class__.__name__
+        return f"image account availability check failed after {attempts} attempt(s): {detail}"
+
     def get_available_access_token(
             self,
             plan_type: str | None = None,
@@ -966,19 +997,64 @@ class AccountService:
         """
         max_attempts = 20  # 防止无限循环
         attempted_tokens: set[str] = set()
+        remote_errors: list[tuple[Exception, int]] = []
         for _attempt in range(max_attempts):
-            access_token = self._acquire_next_candidate_token(
-                excluded_tokens=attempted_tokens,
-                plan_type=plan_type,
-                source_type=source_type,
-                plan_types=plan_types,
-            )
-            attempted_tokens.add(access_token)
             try:
-                account = self.fetch_remote_info(access_token, "get_available_access_token")
-            except Exception:
+                access_token = self._acquire_next_candidate_token(
+                    excluded_tokens=attempted_tokens,
+                    plan_type=plan_type,
+                    source_type=source_type,
+                    plan_types=plan_types,
+                )
+            except RuntimeError:
+                if remote_errors:
+                    last_error, attempts = remote_errors[-1]
+                    raise RuntimeError(self._account_check_error_message(last_error, attempts)) from last_error
+                raise
+            attempted_tokens.add(access_token)
+
+            account = None
+            check_error: Exception | None = None
+            check_attempts = 0
+            for check_attempts in range(1, self._IMAGE_ACCOUNT_CHECK_RETRIES + 1):
+                try:
+                    account = self.fetch_remote_info(access_token, "get_available_access_token")
+                    check_error = None
+                    break
+                except Exception as exc:
+                    check_error = exc
+                    if (
+                            not self._is_transient_image_account_check_error(exc)
+                            or check_attempts >= self._IMAGE_ACCOUNT_CHECK_RETRIES
+                    ):
+                        break
+                    time.sleep(self._IMAGE_ACCOUNT_CHECK_RETRY_BACKOFF_SECONDS * (2 ** (check_attempts - 1)))
+
+            if check_error is not None:
+                if self._is_transient_image_account_check_error(check_error):
+                    cached_account = self.get_account(access_token) or {}
+                    if (
+                            self._is_image_account_available(cached_account)
+                            and self._account_matches_plan_type(cached_account, plan_type)
+                            and self._account_matches_any_plan_type(cached_account, plan_types)
+                            and self._account_matches_source_type(cached_account, source_type)
+                    ):
+                        cached_token = str(cached_account.get("access_token") or access_token)
+                        log_service.add(
+                            LOG_TYPE_ACCOUNT,
+                            "生图账号远程检查失败，使用缓存状态",
+                            {
+                                "source": "get_available_access_token",
+                                "token": anonymize_token(cached_token),
+                                "attempts": check_attempts,
+                                "error": str(check_error)[:500],
+                            },
+                        )
+                        return cached_token
+                remote_errors.append((check_error, check_attempts))
                 self.release_image_slot(access_token)
                 continue
+
             # fetch_remote_info 内部可能因 token rotation 导致 access_token 变化，
             # 把新 token 也加入排除列表，防止重复尝试
             resolved = str((account or {}).get("access_token") or "")
@@ -993,8 +1069,11 @@ class AccountService:
                 return str((account or {}).get("access_token") or access_token)
             self.release_image_slot(access_token)
         raise RuntimeError(
-            f"no available {plan_type or source_type or ''} image quota (tried {len(attempted_tokens)} tokens)".replace("  ", " ").strip()
-            if plan_type or source_type else f"no available image quota (tried {len(attempted_tokens)} tokens)"
+            self._account_check_error_message(*remote_errors[-1])
+            if remote_errors else (
+                f"no available {plan_type or source_type or ''} image quota (tried {len(attempted_tokens)} tokens)".replace("  ", " ").strip()
+                if plan_type or source_type else f"no available image quota (tried {len(attempted_tokens)} tokens)"
+            )
         )
 
     def get_text_access_token(self, excluded_tokens: set[str] | None = None) -> str:

--- a/services/openai_backend_api.py
+++ b/services/openai_backend_api.py
@@ -36,6 +36,12 @@ class ImagePollTimeoutError(RuntimeError):
     pass
 
 
+class ImageStreamTimeoutError(RuntimeError):
+    def __init__(self, timeout_secs: float) -> None:
+        self.timeout_secs = float(timeout_secs)
+        super().__init__(f"image generation stream timed out after {self.timeout_secs:g} seconds")
+
+
 class ImageContentPolicyError(RuntimeError):
     """Raised when image generation is blocked by content policy moderation."""
     pass
@@ -948,7 +954,8 @@ class OpenAIBackendAPI:
         }
 
     def _start_image_generation(self, prompt: str, requirements: ChatRequirements, conduit_token: str, model: str,
-                                references: Optional[list[Dict[str, Any]]] = None) -> requests.Response:
+                                references: Optional[list[Dict[str, Any]]] = None,
+                                timeout_secs: float = 300.0) -> requests.Response:
         """启动图片生成或编辑的 SSE 请求。"""
         references = references or []
         parts = [{
@@ -1014,7 +1021,7 @@ class OpenAIBackendAPI:
             self.base_url + path,
             headers=self._image_headers(path, requirements, conduit_token, "text/event-stream"),
             json=payload,
-            timeout=300,
+            timeout=timeout_secs,
             stream=True,
         )
         ensure_ok(response, path)
@@ -2587,10 +2594,29 @@ class OpenAIBackendAPI:
         self._report_progress("preparing_conversation")
         conduit_token = self._prepare_image_conversation(prompt, requirements, model)
         self._report_progress("starting_generation")
-        response = self._start_image_generation(prompt, requirements, conduit_token, model, references)
-        self._report_progress("generating")
+        stream_timeout_secs = float(config.image_poll_timeout_secs)
+        stream_started_at = time.monotonic()
         try:
-            yield from iter_sse_payloads(response)
+            response = self._start_image_generation(
+                prompt,
+                requirements,
+                conduit_token,
+                model,
+                references,
+                timeout_secs=stream_timeout_secs,
+            )
+        except (requests.exceptions.Timeout, TimeoutError) as exc:
+            raise ImageStreamTimeoutError(stream_timeout_secs) from exc
+        self._report_progress("generating")
+        remaining_secs = stream_timeout_secs - (time.monotonic() - stream_started_at)
+        if remaining_secs <= 0:
+            response.close()
+            raise ImageStreamTimeoutError(stream_timeout_secs)
+        try:
+            try:
+                yield from iter_sse_payloads(response, max_duration_secs=remaining_secs)
+            except TimeoutError as exc:
+                raise ImageStreamTimeoutError(stream_timeout_secs) from exc
         finally:
             response.close()
 

--- a/services/protocol/conversation.py
+++ b/services/protocol/conversation.py
@@ -14,7 +14,12 @@ import tiktoken
 from services.account_service import account_service
 from services.config import config
 from services.image_storage_service import image_storage_service
-from services.openai_backend_api import ImageContentPolicyError, ImagePollTimeoutError, OpenAIBackendAPI
+from services.openai_backend_api import (
+    ImageContentPolicyError,
+    ImagePollTimeoutError,
+    ImageStreamTimeoutError,
+    OpenAIBackendAPI,
+)
 from utils.helper import (
     IMAGE_MODELS,
     extract_image_from_message_content,
@@ -1339,6 +1344,23 @@ def _generate_single_image(
                 return outputs
             account_service.mark_image_result(token, True)
             return outputs
+        except ImageStreamTimeoutError as exc:
+            account_service.mark_image_result(token, False)
+            logger.warning({
+                "event": "image_stream_timeout",
+                "request_token": token,
+                "account_email": account_email,
+                "timeout_secs": exc.timeout_secs,
+                "index": index,
+            })
+            raise ImageGenerationError(
+                f"Upstream image stream timed out after {exc.timeout_secs:g} seconds; "
+                "the account slot has been released. Please try again.",
+                status_code=504,
+                error_type="server_error",
+                code="upstream_timeout",
+                account_email=account_email,
+            ) from exc
         except ImagePollTimeoutError as exc:
             account_service.mark_image_result(token, False)
             if account_email:

--- a/test/test_account_image_capabilities.py
+++ b/test/test_account_image_capabilities.py
@@ -4,7 +4,7 @@ import os
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 os.environ.setdefault("CHATGPT2API_AUTH_KEY", "test-auth")
 
@@ -95,6 +95,68 @@ class AccountCapabilityTests(unittest.TestCase):
 
             self.assertEqual(plus_token, "token-plus")
             self.assertEqual(pro_token, "token-pro")
+
+    def test_get_available_access_token_retries_transient_remote_check(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            service = AccountService(JSONStorageBackend(Path(tmp_dir) / "accounts.json"))
+            service.add_account_items(
+                [{"access_token": "token-pro", "type": "Pro", "status": "正常", "quota": 3}]
+            )
+            account = service.get_account("token-pro")
+            service.fetch_remote_info = Mock(side_effect=[
+                TimeoutError("connection timed out"),
+                TimeoutError("connection timed out"),
+                account,
+            ])
+
+            with patch("services.account_service.time.sleep") as sleep:
+                token = service.get_available_access_token()
+
+            service.release_image_slot(token)
+            self.assertEqual(token, "token-pro")
+            self.assertEqual(service.fetch_remote_info.call_count, 3)
+            self.assertEqual(sleep.call_count, 2)
+
+    def test_get_available_access_token_uses_cached_account_after_transient_failures(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            service = AccountService(JSONStorageBackend(Path(tmp_dir) / "accounts.json"))
+            service.add_account_items(
+                [{"access_token": "token-pro", "type": "Pro", "status": "正常", "quota": 3}]
+            )
+            service.fetch_remote_info = Mock(side_effect=TimeoutError("TLS connection closed"))
+
+            with patch("services.account_service.time.sleep"):
+                token = service.get_available_access_token()
+
+            service.release_image_slot(token)
+            self.assertEqual(token, "token-pro")
+            self.assertEqual(service.fetch_remote_info.call_count, 3)
+
+    def test_get_available_access_token_does_not_misreport_non_transient_check_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            service = AccountService(JSONStorageBackend(Path(tmp_dir) / "accounts.json"))
+            service.add_account_items(
+                [{"access_token": "token-pro", "type": "Pro", "status": "正常", "quota": 3}]
+            )
+            service.fetch_remote_info = Mock(side_effect=ValueError("invalid account response"))
+
+            with self.assertRaisesRegex(RuntimeError, "image account availability check failed after 1 attempt"):
+                service.get_available_access_token()
+
+            self.assertEqual(service.fetch_remote_info.call_count, 1)
+
+    def test_get_available_access_token_preserves_real_quota_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            service = AccountService(JSONStorageBackend(Path(tmp_dir) / "accounts.json"))
+            service.add_account_items(
+                [{"access_token": "token-pro", "type": "Pro", "status": "限流", "quota": 0}]
+            )
+            service.fetch_remote_info = Mock()
+
+            with self.assertRaisesRegex(RuntimeError, "no available image quota"):
+                service.get_available_access_token()
+
+            service.fetch_remote_info.assert_not_called()
 
     def test_refresh_accounts_can_remove_invalid_token_without_confirmation_delay(self) -> None:
         original_value = config.data.get("auto_remove_invalid_accounts")

--- a/test/test_multi_image_results.py
+++ b/test/test_multi_image_results.py
@@ -5,9 +5,16 @@ import unittest
 from unittest import mock
 
 from services.config import config
-from services.openai_backend_api import OpenAIBackendAPI
-from services.protocol.conversation import ImageOutput, extract_conversation_ids
+from services.openai_backend_api import ImageStreamTimeoutError, OpenAIBackendAPI
+from services.protocol.conversation import (
+    ConversationRequest,
+    ImageGenerationError,
+    ImageOutput,
+    _generate_single_image,
+    extract_conversation_ids,
+)
 from services.protocol.openai_v1_response import stream_image_response
+from utils.helper import iter_sse_payloads
 
 
 def _conversation(file_ids: list[str], sediment_ids: list[str] | None = None) -> dict:
@@ -50,6 +57,71 @@ class FakeBackend(OpenAIBackendAPI):
 
 
 class MultiImageResultTests(unittest.TestCase):
+    def test_sse_reader_stops_when_heartbeats_exceed_total_duration(self) -> None:
+        response = mock.Mock()
+        response.iter_lines.return_value = iter([b": heartbeat", b": heartbeat"])
+
+        with mock.patch("utils.helper.time.monotonic", side_effect=[0.0, 0.2, 1.1]):
+            with self.assertRaisesRegex(TimeoutError, "SSE stream exceeded"):
+                list(iter_sse_payloads(response, max_duration_secs=1.0))
+
+    def test_image_stream_timeout_is_not_retried_as_a_connection_failure(self) -> None:
+        backend = mock.Mock()
+        request = ConversationRequest(model="gpt-image-2", prompt="draw a circle")
+
+        with (
+            mock.patch(
+                "services.protocol.conversation.account_service.get_available_access_token",
+                return_value="token-1",
+            ) as get_token,
+            mock.patch(
+                "services.protocol.conversation.account_service.get_account",
+                return_value={"email": "owner@example.test"},
+            ),
+            mock.patch("services.protocol.conversation.account_service.mark_image_result") as mark_result,
+            mock.patch("services.protocol.conversation.OpenAIBackendAPI", return_value=backend),
+            mock.patch(
+                "services.protocol.conversation.stream_image_outputs",
+                side_effect=ImageStreamTimeoutError(1.0),
+            ),
+        ):
+            with self.assertRaises(ImageGenerationError) as raised:
+                _generate_single_image(request, 1, 1)
+
+        self.assertEqual(raised.exception.status_code, 504)
+        self.assertEqual(raised.exception.code, "upstream_timeout")
+        get_token.assert_called_once()
+        mark_result.assert_called_once_with("token-1", False)
+        backend.close.assert_called_once()
+
+    def test_picture_stream_wraps_total_duration_timeout_and_closes_response(self) -> None:
+        backend = object.__new__(OpenAIBackendAPI)
+        backend.access_token = "token-1"
+        backend.progress_callback = None
+        backend._bootstrap = mock.Mock()
+        backend._get_chat_requirements = mock.Mock(return_value=mock.sentinel.requirements)
+        backend._prepare_image_conversation = mock.Mock(return_value="conduit-token")
+        response = mock.Mock()
+        response.iter_lines.return_value = iter([b": heartbeat", b": heartbeat"])
+        backend._start_image_generation = mock.Mock(return_value=response)
+
+        with (
+            mock.patch.dict(config.data, {"image_poll_timeout_secs": 1}),
+            mock.patch("time.monotonic", side_effect=[0.0, 0.1, 0.1, 0.2, 1.2]),
+        ):
+            with self.assertRaises(ImageStreamTimeoutError):
+                list(backend._stream_picture_conversation("draw a circle", "gpt-image-2", []))
+
+        backend._start_image_generation.assert_called_once_with(
+            "draw a circle",
+            mock.sentinel.requirements,
+            "conduit-token",
+            "gpt-image-2",
+            [],
+            timeout_secs=1.0,
+        )
+        response.close.assert_called_once()
+
     def test_stream_id_extractor_keeps_full_file_ids(self) -> None:
         payload = (
             '{"conversation_id":"conv-1"} '

--- a/utils/helper.py
+++ b/utils/helper.py
@@ -226,8 +226,17 @@ def anthropic_sse_stream(items) -> Iterator[str]:
         yield f"data: {json.dumps(error, ensure_ascii=False)}\n\n"
 
 
-def iter_sse_payloads(response: requests.Response) -> Iterator[str]:
+def iter_sse_payloads(
+        response: requests.Response,
+        *,
+        max_duration_secs: float | None = None,
+) -> Iterator[str]:
+    deadline = None
+    if max_duration_secs is not None:
+        deadline = time.monotonic() + max(0.0, float(max_duration_secs))
     for raw_line in response.iter_lines():
+        if deadline is not None and time.monotonic() >= deadline:
+            raise TimeoutError(f"SSE stream exceeded {max_duration_secs:g} seconds")
         if not raw_line:
             continue
         line = raw_line.decode("utf-8", errors="ignore") if isinstance(raw_line, bytes) else str(raw_line)


### PR DESCRIPTION
## Summary

- enforce a wall-clock deadline for image-generation SSE streams, including heartbeat-only streams
- return a structured 504 `upstream_timeout` error and release the image account slot when that deadline expires
- retry transient image-account availability checks and fall back to an eligible cached account instead of reporting false quota exhaustion
- add regression coverage and ignore local frontend/runtime artifacts

## Why

The existing HTTP timeout only covered socket inactivity, so upstream SSE heartbeats could keep a failed image request alive indefinitely. Transient TLS or connection failures during the remote account check could also be misreported as "no available image quota."

## Impact

Image requests now terminate predictably, account slots are released on stream timeout, and transient remote-check failures are less likely to surface as false quota errors.

## Validation

- `.venv\Scripts\python.exe -m unittest test.test_multi_image_results test.test_account_image_capabilities` - 26 tests passed
- `.venv\Scripts\python.exe -m py_compile ...` - passed for all changed Python modules and tests
- staged diff whitespace and credential-pattern checks - passed

The repository-wide discovery suite was also attempted; unrelated integration tests still require a matching live localhost service credential and missing `assets/*.png` fixtures.
