### PR TITLE
Add option to remove local conversation when no image is generated

### DIFF
--- a/services/config.py
+++ b/services/config.py
@@ -454,6 +454,11 @@ class ConfigStore:
         return bool(value)
 
     @property
+    def image_remove_conversation_always(self) -> bool:
+        """无论是否出图，画图请求结束后都异步隐藏 ChatGPT 本地对话记录。"""
+        return _normalize_bool(self.data.get("image_remove_conversation_always"), False)
+
+    @property
     def image_settle_secs(self) -> float:
         """二次确认等待时间（秒）。"""
         try:
@@ -556,6 +561,7 @@ class ConfigStore:
         data["image_account_concurrency"] = self.image_account_concurrency
         data["image_parallel_generation"] = self.image_parallel_generation
         data["image_remove_conversation_after_result"] = self.image_remove_conversation_after_result
+        data["image_remove_conversation_always"] = self.image_remove_conversation_always
         data["auto_remove_invalid_accounts"] = self.auto_remove_invalid_accounts
         data["auto_remove_rate_limited_accounts"] = self.auto_remove_rate_limited_accounts
         data["auto_relogin_after_refresh"] = self.auto_relogin_after_refresh

--- a/services/openai_backend_api.py
+++ b/services/openai_backend_api.py
@@ -32,11 +32,19 @@ class InvalidAccessTokenError(RuntimeError):
     pass
 
 
-class ImagePollTimeoutError(RuntimeError):
+class ImageTaskError(RuntimeError):
+    """图片生成异常基类，携带上游会话 ID 供调用方清理对话。"""
+
+    def __init__(self, message: str = "", conversation_id: str = "") -> None:
+        super().__init__(message)
+        self.conversation_id = conversation_id
+
+
+class ImagePollTimeoutError(ImageTaskError):
     pass
 
 
-class ImageContentPolicyError(RuntimeError):
+class ImageContentPolicyError(ImageTaskError):
     """Raised when image generation is blocked by content policy moderation."""
     pass
 
@@ -2238,7 +2246,7 @@ class OpenAIBackendAPI:
                         "attempt": attempt,
                         "error_msg": policy_msg[:200],
                     })
-                    raise ImageContentPolicyError(policy_msg)
+                    raise ImageContentPolicyError(policy_msg, conversation_id or "")
 
             logger.debug({"event": "image_poll_check", "conversation_id": conversation_id, "attempt": attempt,
                           "file_ids": file_ids, "sediment_ids": sediment_ids})
@@ -2284,11 +2292,11 @@ class OpenAIBackendAPI:
         exc = ImagePollTimeoutError(
             f"ChatGPT 生图超时（已等待 {timeout_secs} 秒）。"
             f"当前超时阈值可在 config.json 中调大 image_poll_timeout_secs，"
-            f"也可能是账号被限流或生图队列拥堵导致。"
+            f"也可能是账号被限流或生图队列拥堵导致。",
+            conversation_id or "",
         )
         if last_task_error:
             setattr(exc, "task_error", last_task_error)
-        setattr(exc, "conversation_id", conversation_id or "")
         raise exc
 
     def _get_file_download_url(self, file_id: str) -> str:
@@ -2498,7 +2506,7 @@ class OpenAIBackendAPI:
                 task_error = getattr(exc, "task_error", "")
                 if not file_ids and not sediment_ids:
                     if task_error:
-                        raise ImageContentPolicyError(task_error) from exc
+                        raise ImageContentPolicyError(task_error, conversation_id or "") from exc
                     raise
                 logger.warning({
                     "event": "image_resolve_poll_partial_timeout",

--- a/services/protocol/conversation.py
+++ b/services/protocol/conversation.py
@@ -776,8 +776,15 @@ def _get_detailed_error_from_tasks(
         return ""
 
 
-def _remove_image_conversation_later(backend: OpenAIBackendAPI, conversation_id: str) -> None:
-    if not config.image_remove_conversation_after_result or not conversation_id:
+def _remove_image_conversation_later(
+        backend: OpenAIBackendAPI,
+        conversation_id: str,
+        *,
+        success: bool,
+) -> None:
+    if not conversation_id:
+        return
+    if not (config.image_remove_conversation_always or (success and config.image_remove_conversation_after_result)):
         return
 
     def _run() -> None:
@@ -818,6 +825,7 @@ def stream_image_outputs(
                 total=total,
                 text=str(event.get("delta") or ""),
                 upstream_event_type="conversation.delta",
+                conversation_id=str(event.get("conversation_id") or ""),
             )
             continue
         if event.get("type") == "conversation.event":
@@ -829,6 +837,7 @@ def stream_image_outputs(
                 index=index,
                 total=total,
                 upstream_event_type=raw_type,
+                conversation_id=str(event.get("conversation_id") or ""),
             )
 
     conversation_id = str(last.get("conversation_id") or "")
@@ -970,7 +979,6 @@ def stream_image_outputs(
             int(time.time()),
         )["data"]
         if data:
-            _remove_image_conversation_later(backend, conversation_id)
             yield ImageOutput(kind="result", model=request.model, index=index, total=total, data=data, conversation_id=conversation_id)
         return
 
@@ -1068,7 +1076,6 @@ def stream_image_outputs(
                         int(time.time()),
                     )["data"]
                     if data:
-                        _remove_image_conversation_later(backend, conversation_id)
                         yield ImageOutput(kind="result", model=request.model, index=index, total=total, data=data, conversation_id=conversation_id)
                         return
         elif is_text_reply:
@@ -1181,7 +1188,6 @@ def stream_image_outputs(
                     int(time.time()),
                 )["data"]
                 if data:
-                    _remove_image_conversation_later(backend, conversation_id)
                     yield ImageOutput(kind="result", model=request.model, index=index, total=total, data=data, conversation_id=conversation_id)
                     return
         
@@ -1305,22 +1311,31 @@ def _generate_single_image(
                 backend.progress_callback = request.progress_callback
             stream_fn = stream_codex_image_outputs if is_codex_image_model(request.model) else stream_image_outputs
             outputs: list[ImageOutput] = []
-            for output in stream_fn(backend, request, index, total):
-                if account_email and not output.account_email:
-                    output.account_email = account_email
-                if output.kind == "message" and request.message_as_error:
-                    raise ImageGenerationError(
-                        output.text or "Image generation was rejected by upstream policy.",
-                        status_code=400,
-                        error_type="invalid_request_error",
-                        code="content_policy_violation",
-                        account_email=account_email,
-                        conversation_id=output.conversation_id,
-                    )
-                emitted_for_token = True
-                returned_message = output.kind == "message"
-                returned_result = returned_result or output.kind == "result"
-                outputs.append(output)
+            last_conversation_id = ""
+            try:
+                for output in stream_fn(backend, request, index, total):
+                    last_conversation_id = output.conversation_id or last_conversation_id
+                    if account_email and not output.account_email:
+                        output.account_email = account_email
+                    if output.kind == "message" and request.message_as_error:
+                        raise ImageGenerationError(
+                            output.text or "Image generation was rejected by upstream policy.",
+                            status_code=400,
+                            error_type="invalid_request_error",
+                            code="content_policy_violation",
+                            account_email=account_email,
+                            conversation_id=output.conversation_id,
+                        )
+                    emitted_for_token = True
+                    returned_message = output.kind == "message"
+                    returned_result = returned_result or output.kind == "result"
+                    outputs.append(output)
+            except Exception as exc:
+                # 异常路径（内容政策拒绝、轮询超时等）会话 ID 只挂在异常上
+                last_conversation_id = last_conversation_id or str(getattr(exc, "conversation_id", "") or "")
+                raise
+            finally:
+                _remove_image_conversation_later(backend, last_conversation_id, success=returned_result)
             if returned_message:
                 account_service.mark_image_result(token, False)
                 return outputs

--- a/test/test_image_remove_conversation.py
+++ b/test/test_image_remove_conversation.py
@@ -1,0 +1,54 @@
+import threading
+import unittest
+
+from services.config import config
+from services.protocol.conversation import _remove_image_conversation_later
+
+
+class FakeBackend:
+    def __init__(self) -> None:
+        self.called = threading.Event()
+
+    def delete_conversation(self, conversation_id: str) -> dict:
+        self.called.set()
+        return {}
+
+
+class RemoveImageConversationGateTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._saved = dict(config.data)
+
+    def tearDown(self) -> None:
+        config.data = self._saved
+
+    def _removed(self, *, after_result: bool, always: bool, success: bool) -> bool:
+        config.data = dict(
+            self._saved,
+            image_remove_conversation_after_result=after_result,
+            image_remove_conversation_always=always,
+        )
+        backend = FakeBackend()
+        _remove_image_conversation_later(backend, "conv-1", success=success)
+        return backend.called.wait(2.0)
+
+    def test_both_off_never_removes(self) -> None:
+        self.assertFalse(self._removed(after_result=False, always=False, success=True))
+        self.assertFalse(self._removed(after_result=False, always=False, success=False))
+
+    def test_after_result_only_removes_on_success(self) -> None:
+        self.assertTrue(self._removed(after_result=True, always=False, success=True))
+        self.assertFalse(self._removed(after_result=True, always=False, success=False))
+
+    def test_always_removes_regardless_of_success(self) -> None:
+        self.assertTrue(self._removed(after_result=False, always=True, success=True))
+        self.assertTrue(self._removed(after_result=False, always=True, success=False))
+
+    def test_empty_conversation_id_is_noop(self) -> None:
+        config.data = dict(self._saved, image_remove_conversation_always=True)
+        backend = FakeBackend()
+        _remove_image_conversation_later(backend, "", success=False)
+        self.assertFalse(backend.called.wait(0.2))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/src/app/settings/components/config-card.tsx
+++ b/web/src/app/settings/components/config-card.tsx
@@ -28,6 +28,7 @@ export function ConfigCard() {
   const setImageAccountConcurrency = useSettingsStore((state) => state.setImageAccountConcurrency);
   const setImageSettleEnabled = useSettingsStore((state) => state.setImageSettleEnabled);
   const setImageRemoveConversationAfterResult = useSettingsStore((state) => state.setImageRemoveConversationAfterResult);
+  const setImageRemoveConversationAlways = useSettingsStore((state) => state.setImageRemoveConversationAlways);
   const setImageSettleSecs = useSettingsStore((state) => state.setImageSettleSecs);
   const setImageTimeoutRetrySecs = useSettingsStore((state) => state.setImageTimeoutRetrySecs);
   const setAutoRemoveInvalidAccounts = useSettingsStore((state) => state.setAutoRemoveInvalidAccounts);
@@ -205,6 +206,16 @@ export function ConfigCard() {
               <span className="text-sm text-stone-700">出图后移除本地对话</span>
             </div>
             <p className="text-xs text-stone-500">成功拿到图片后，异步隐藏 ChatGPT 侧对应的本地对话记录。</p>
+          </div>
+          <div className="space-y-2">
+            <div className="flex items-center gap-3 rounded-xl border border-stone-200 bg-white px-4 py-3">
+              <Checkbox
+                checked={Boolean(config?.image_remove_conversation_always)}
+                onCheckedChange={(checked) => setImageRemoveConversationAlways(Boolean(checked))}
+              />
+              <span className="text-sm text-stone-700">没出图也移除本地对话</span>
+            </div>
+            <p className="text-xs text-stone-500">失败、超时或只返回文本时也一并隐藏对话记录（打开后包含出图成功的情况）。</p>
           </div>
           <div className="space-y-2">
             <label className="text-sm text-stone-700">图片超时继续等待时间</label>

--- a/web/src/app/settings/store.ts
+++ b/web/src/app/settings/store.ts
@@ -172,6 +172,7 @@ function normalizeConfig(config: SettingsConfig): SettingsConfig {
     image_settle_enabled: Boolean(config.image_settle_enabled !== false),
     image_check_before_hit_enabled: Boolean(config.image_check_before_hit_enabled !== false),
     image_remove_conversation_after_result: Boolean(config.image_remove_conversation_after_result),
+    image_remove_conversation_always: Boolean(config.image_remove_conversation_always),
     image_settle_secs: Number(config.image_settle_secs || 2.0),
     image_timeout_retry_secs: Number(config.image_timeout_retry_secs || 30),
     auto_remove_invalid_accounts: Boolean(config.auto_remove_invalid_accounts),
@@ -292,6 +293,7 @@ type SettingsStore = {
   setImageSettleEnabled: (value: boolean) => void;
   setImageCheckBeforeHitEnabled: (value: boolean) => void;
   setImageRemoveConversationAfterResult: (value: boolean) => void;
+  setImageRemoveConversationAlways: (value: boolean) => void;
   setImageSettleSecs: (value: string) => void;
   setImageTimeoutRetrySecs: (value: string) => void;
   setAutoRemoveInvalidAccounts: (value: boolean) => void;
@@ -417,6 +419,7 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
         image_settle_enabled: Boolean(config.image_settle_enabled !== false),
         image_check_before_hit_enabled: Boolean(config.image_check_before_hit_enabled !== false),
         image_remove_conversation_after_result: Boolean(config.image_remove_conversation_after_result),
+        image_remove_conversation_always: Boolean(config.image_remove_conversation_always),
         image_settle_secs: Math.max(0.5, Number(config.image_settle_secs) || 2.0),
         image_timeout_retry_secs: Math.max(1, Number(config.image_timeout_retry_secs) || 30),
         auto_remove_invalid_accounts: Boolean(config.auto_remove_invalid_accounts),
@@ -530,6 +533,10 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
 
   setImageRemoveConversationAfterResult: (value) => {
     set((state) => state.config ? { config: { ...state.config, image_remove_conversation_after_result: value } } : {});
+  },
+
+  setImageRemoveConversationAlways: (value) => {
+    set((state) => state.config ? { config: { ...state.config, image_remove_conversation_always: value } } : {});
   },
 
   setImageSettleSecs: (value) => {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -171,6 +171,7 @@ export type SettingsConfig = {
   image_settle_enabled?: boolean;
   image_check_before_hit_enabled?: boolean;
   image_remove_conversation_after_result?: boolean;
+  image_remove_conversation_always?: boolean;
   image_settle_secs?: number | string;
   image_timeout_retry_secs?: number | string;
   auto_remove_invalid_accounts?: boolean;


### PR DESCRIPTION
Today the local ChatGPT conversation is only hidden after a successful image result, so failed, timed out or text-only requests leave conversations behind.

This adds an `image_remove_conversation_always` flag that hides the conversation after every image request regardless of outcome. The existing after-result option is unchanged and both flags are off by default. The new switch is exposed in the settings page.