### PR TITLE
fix: harden model routing and request handling

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,7 +10,29 @@ env:
   IMAGE_NAME: chatgpt2api
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up uv and Python
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: "3.13"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --frozen --group dev
+
+      - name: Run offline tests
+        run: uv run --frozen pytest -m "not live" -q
+
   docker:
+    needs: test
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -18,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,100 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up uv and Python
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: "3.13"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --frozen --group dev
+
+      - name: Run offline tests
+        run: uv run --frozen pytest -m "not live" -q
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build frontend
+        run: bun run build
+
+  docker:
+    needs: [backend, frontend]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build application image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          target: app
+          platforms: linux/amd64
+          load: true
+          push: false
+          tags: chatgpt2api:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test application image
+        shell: bash
+        run: |
+          set -euo pipefail
+          container="chatgpt2api-smoke-${GITHUB_RUN_ID}"
+          cleanup() {
+            status=$?
+            if [ "$status" -ne 0 ]; then
+              docker logs "$container" || true
+            fi
+            docker rm -f "$container" >/dev/null 2>&1 || true
+            return "$status"
+          }
+          trap cleanup EXIT
+
+          docker run -d --name "$container" \
+            -e CHATGPT2API_AUTH_KEY=ci-smoke-test \
+            chatgpt2api:test
+
+          for _ in $(seq 1 30); do
+            if docker exec "$container" /app/.venv/bin/python -c \
+              'import urllib.request; urllib.request.urlopen("http://127.0.0.1/openapi.json", timeout=2).read(1)'; then
+              exit 0
+            fi
+            sleep 1
+          done
+          exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,17 @@ ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETARCH
 
-FROM --platform=$BUILDPLATFORM node:22-alpine AS web-build
+FROM --platform=$BUILDPLATFORM oven/bun:1.3.14-alpine AS web-build
 
 WORKDIR /app/web
 
 COPY web/package.json web/bun.lock ./
-RUN npm install
+RUN bun install --frozen-lockfile
 
 COPY VERSION /app/VERSION
 COPY CHANGELOG.md /app/CHANGELOG.md
 COPY web ./
-RUN NEXT_PUBLIC_APP_VERSION="$(cat /app/VERSION)" npm run build
+RUN NEXT_PUBLIC_APP_VERSION="$(cat /app/VERSION)" bun run build
 
 
 FROM --platform=$TARGETPLATFORM python:3.13-slim AS app
@@ -53,4 +53,4 @@ COPY --from=web-build /app/web/out ./web_dist
 
 EXPOSE 80
 
-CMD ["uv", "run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "80", "--access-log"]
+CMD ["/app/.venv/bin/uvicorn", "main:app", "--host", "0.0.0.0", "--port", "80", "--access-log"]

--- a/api/image_inputs.py
+++ b/api/image_inputs.py
@@ -3,18 +3,16 @@ from __future__ import annotations
 import base64
 import binascii
 import json
-import mimetypes
 import re
 from pathlib import PurePosixPath
 from typing import Any, TypeGuard
-from urllib.parse import unquote, unquote_to_bytes, urlparse
+from urllib.parse import unquote, unquote_to_bytes
 
-from curl_cffi import requests
 from fastapi import HTTPException, Request
 from fastapi.concurrency import run_in_threadpool
 from starlette.datastructures import UploadFile
 
-from services.proxy_service import proxy_settings
+from utils.remote_image import download_public_image
 
 ImageInput = tuple[bytes, str, str]
 ImageSource = str | UploadFile | ImageInput
@@ -215,7 +213,7 @@ def _safe_filename(name: str, mime_type: str, fallback: str) -> str:
     return cleaned
 
 
-def _decode_data_url(url: str) -> ImageInput:
+def _decode_data_url(url: str, fallback_name: str = "image_url") -> ImageInput:
     """解码 data URL：把内联图片转成标准图片输入元组。"""
     header, separator, payload = url.partition(",")
     if not separator:
@@ -231,66 +229,33 @@ def _decode_data_url(url: str) -> ImageInput:
         raise HTTPException(status_code=400, detail={"error": "image URL is empty"})
     if len(data) > MAX_IMAGE_REFERENCE_BYTES:
         raise HTTPException(status_code=400, detail={"error": "image URL exceeds 50MB limit"})
-    return data, f"image_url.{_extension_from_mime(mime_type)}", mime_type
+    return data, _safe_filename(fallback_name, mime_type, "image_url"), mime_type
 
 
-def _response_mime_type(response: requests.Response, parsed_path: str) -> str:
-    """识别下载图片类型：优先响应头，必要时按 URL 后缀推断。"""
-    header_type = str(response.headers.get("content-type") or "").split(";", 1)[0].strip().lower()
-    guessed_type = mimetypes.guess_type(parsed_path)[0] or ""
-    if header_type.startswith("image/"):
-        return header_type
-    if header_type and header_type not in {"application/octet-stream", "binary/octet-stream"}:
-        raise HTTPException(status_code=400, detail={"error": "image_url must point to an image"})
-    if guessed_type.startswith("image/"):
-        return guessed_type
-    if not header_type or header_type in {"application/octet-stream", "binary/octet-stream"}:
-        return "image/png"
-    raise HTTPException(status_code=400, detail={"error": "image_url must point to an image"})
-
-
-def _filename_from_url(parsed_path: str, mime_type: str) -> str:
+def _filename_from_url(parsed_path: str, mime_type: str, fallback_name: str = "image_url") -> str:
     """生成 URL 图片文件名：从链接路径提取名称并做安全化。"""
     raw_name = PurePosixPath(unquote(parsed_path)).name
-    return _safe_filename(raw_name, mime_type, "image_url")
+    return _safe_filename(raw_name, mime_type, fallback_name)
 
 
-def _download_image_url(url: str) -> ImageInput:
+def _download_image_url(url: str, fallback_name: str = "image_url") -> ImageInput:
     """下载远程图片：把 http/https 图片链接转成标准图片输入元组。"""
     source = _clean(url)
     if source.startswith("data:"):
-        return _decode_data_url(source)
-    parsed = urlparse(source)
-    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-        raise HTTPException(status_code=400, detail={"error": "image_url must be an http or https URL"})
-    try:
-        response = requests.get(
-            source,
-            headers={"Accept": "image/*,*/*;q=0.8", "User-Agent": "chatgpt2api image fetcher"},
-            timeout=60,
-            allow_redirects=True,
-            **proxy_settings.build_session_kwargs(),
-        )
-    except Exception as exc:
-        raise HTTPException(status_code=400, detail={"error": f"image_url fetch failed: {exc}"}) from exc
-    if not 200 <= response.status_code < 300:
-        raise HTTPException(status_code=400, detail={"error": f"image_url fetch failed: HTTP {response.status_code}"})
-    content_length = _clean(response.headers.get("content-length"))
-    if content_length and content_length.isdigit() and int(content_length) > MAX_IMAGE_REFERENCE_BYTES:
-        raise HTTPException(status_code=400, detail={"error": "image_url exceeds 50MB limit"})
-    data = response.content
-    if not data:
-        raise HTTPException(status_code=400, detail={"error": "image_url returned empty content"})
-    if len(data) > MAX_IMAGE_REFERENCE_BYTES:
-        raise HTTPException(status_code=400, detail={"error": "image_url exceeds 50MB limit"})
-    mime_type = _response_mime_type(response, parsed.path)
-    return data, _filename_from_url(parsed.path, mime_type), mime_type
+        return _decode_data_url(source, fallback_name)
+    data, parsed_path, mime_type = download_public_image(
+        source,
+        max_bytes=MAX_IMAGE_REFERENCE_BYTES,
+        timeout_seconds=60,
+        user_agent="chatgpt2api image fetcher",
+    )
+    return data, _filename_from_url(parsed_path, mime_type, fallback_name), mime_type
 
 
 async def read_image_sources(sources: list[ImageSource]) -> list[ImageInput]:
     """读取图片来源：上传文件直接读取，URL 下载后统一返回图片元组。"""
     images: list[ImageInput] = []
-    for source in sources:
+    for index, source in enumerate(sources, start=1):
         if isinstance(source, tuple):
             images.append(source)
             continue
@@ -303,7 +268,7 @@ async def read_image_sources(sources: list[ImageSource]) -> list[ImageInput]:
                 raise HTTPException(status_code=400, detail={"error": "image file is empty"})
             images.append((image_data, source.filename or "image.png", source.content_type or "image/png"))
             continue
-        images.append(await run_in_threadpool(_download_image_url, source))
+        images.append(await run_in_threadpool(_download_image_url, source, f"image_{index}"))
     if not images:
         raise HTTPException(status_code=400, detail={"error": "image file or image_url is required"})
     return images

--- a/config.json
+++ b/config.json
@@ -88,10 +88,7 @@
     "ttl_seconds": 60,
     "max_entries": 256,
     "dedupe_inflight": true,
-    "stream_cache": true,
-    "normalize_messages": true,
-    "drop_adjacent_duplicates": true,
-    "drop_assistant_history": false
+    "stream_cache": true
   },
   "image_settle_enabled": false,
   "image_check_before_hit_enabled": false,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
 [dependency-groups]
 dev = [
     "httpx>=0.28.1",
+    "pytest>=8.3.0",
 ]
 
 [[tool.uv.index]]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+testpaths = test
+addopts = --strict-markers
+markers =
+    live: requires a running ChatGPT2API service and real upstream credentials

--- a/services/account_service.py
+++ b/services/account_service.py
@@ -356,7 +356,11 @@ class AccountService:
         from curl_cffi import requests
         from services.proxy_service import proxy_settings
 
-        session = requests.Session(**proxy_settings.build_session_kwargs(account=account, impersonate="chrome110", verify=True))
+        session = requests.Session(**proxy_settings.build_session_kwargs(
+            account=account,
+            impersonate="chrome110",
+            require_tls_verification=True,
+        ))
         try:
             response = session.post(
                 self._OAUTH_TOKEN_URL,
@@ -585,6 +589,7 @@ class AccountService:
     def _login_with_password(self, email: str, password: str) -> dict:
         """通过邮箱+密码登录，返回 {access_token, refresh_token, id_token, ...}"""
         from curl_cffi import requests
+        from services.proxy_service import proxy_settings
         
         # 常量
         auth_base = "https://auth.openai.com"
@@ -595,10 +600,11 @@ class AccountService:
         user_agent = self._OAUTH_USER_AGENT
         
         # 创建 session
-        session_kwargs = {"impersonate": "chrome110", "verify": False}
-        proxy = config.get_proxy_settings()
-        if proxy:
-            session_kwargs["proxy"] = proxy
+        session_kwargs = proxy_settings.build_session_kwargs(
+            proxy=config.get_proxy_settings(),
+            impersonate="chrome110",
+            require_tls_verification=True,
+        )
         session = requests.Session(**session_kwargs)
         
         try:
@@ -774,7 +780,6 @@ class AccountService:
                     "code": auth_code,
                     "redirect_uri": platform_oauth_redirect_uri,
                 },
-                verify=False,
                 timeout=60,
             )
             
@@ -1014,11 +1019,11 @@ class AccountService:
                 token
                 for account in self._accounts.values()
                 if account.get("status") not in {"禁用", "异常"}
+                   and (token := account.get("access_token") or "")
                    and (
                        route is None
-                       or self._normalize_account_type(account.get("type")) in route.account_types
+                       or token in route.access_tokens
                    )
-                   and (token := account.get("access_token") or "")
                    and token not in excluded
             ]
             if not candidates:
@@ -1026,9 +1031,7 @@ class AccountService:
                     return ""
                 from services.model_service import ModelUnavailableError
 
-                raise ModelUnavailableError(
-                    f"model {requested_model!r} is not available to any active account"
-                )
+                raise ModelUnavailableError(requested_model)
             access_token = candidates[self._index % len(candidates)]
             self._index += 1
         return self.refresh_access_token(access_token, event="get_text_access_token") or access_token

--- a/services/account_service.py
+++ b/services/account_service.py
@@ -359,7 +359,7 @@ class AccountService:
         session = requests.Session(**proxy_settings.build_session_kwargs(
             account=account,
             impersonate="chrome110",
-            require_tls_verification=True,
+            verify=True,
         ))
         try:
             response = session.post(
@@ -603,7 +603,7 @@ class AccountService:
         session_kwargs = proxy_settings.build_session_kwargs(
             proxy=config.get_proxy_settings(),
             impersonate="chrome110",
-            require_tls_verification=True,
+            verify=False,
         )
         session = requests.Session(**session_kwargs)
         

--- a/services/config.py
+++ b/services/config.py
@@ -43,9 +43,6 @@ DEFAULT_CHAT_COMPLETION_CACHE = {
     "max_entries": 256,
     "dedupe_inflight": True,
     "stream_cache": True,
-    "normalize_messages": True,
-    "drop_adjacent_duplicates": True,
-    "drop_assistant_history": False,
 }
 
 DEFAULT_PROXY_RUNTIME_USER_AGENT = (
@@ -182,18 +179,6 @@ def _normalize_chat_completion_cache_settings(value: object) -> dict[str, object
         "stream_cache": _normalize_bool(
             source.get("stream_cache"),
             bool(DEFAULT_CHAT_COMPLETION_CACHE["stream_cache"]),
-        ),
-        "normalize_messages": _normalize_bool(
-            source.get("normalize_messages"),
-            bool(DEFAULT_CHAT_COMPLETION_CACHE["normalize_messages"]),
-        ),
-        "drop_adjacent_duplicates": _normalize_bool(
-            source.get("drop_adjacent_duplicates"),
-            bool(DEFAULT_CHAT_COMPLETION_CACHE["drop_adjacent_duplicates"]),
-        ),
-        "drop_assistant_history": _normalize_bool(
-            source.get("drop_assistant_history"),
-            bool(DEFAULT_CHAT_COMPLETION_CACHE["drop_assistant_history"]),
         ),
     }
 

--- a/services/log_service.py
+++ b/services/log_service.py
@@ -201,6 +201,16 @@ def _image_error_response(exc: Exception) -> JSONResponse:
 
 
 def _protocol_error_response(exc: Exception, status_code: int, sse: str) -> JSONResponse:
+    exception_status = getattr(exc, "status_code", status_code)
+    try:
+        status_code = int(exception_status)
+    except (TypeError, ValueError):
+        status_code = 502
+    if not 400 <= status_code <= 599:
+        status_code = 502
+    to_openai_error = getattr(exc, "to_openai_error", None)
+    if sse != "anthropic" and callable(to_openai_error):
+        return JSONResponse(status_code=status_code, content=to_openai_error())
     message = str(exc)
     if sse == "anthropic":
         return anthropic_error_response(message, status_code)

--- a/services/model_service.py
+++ b/services/model_service.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import time
 from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from dataclasses import dataclass
-from threading import RLock
+from threading import Condition, RLock, Thread
 from typing import Any
 
 from services.account_service import AccountService, account_service
@@ -14,16 +14,30 @@ from utils.log import logger
 
 @dataclass(frozen=True)
 class ModelRoute:
-    account_types: frozenset[str]
+    access_tokens: frozenset[str]
     allow_anonymous: bool = False
 
 
 class ModelUnavailableError(RuntimeError):
-    pass
+    status_code = 400
+
+    def __init__(self, model: str) -> None:
+        self.model = str(model or "").strip()
+        super().__init__(f"model {self.model!r} is not available to any active account")
+
+    def to_openai_error(self) -> dict[str, Any]:
+        return {
+            "error": {
+                "message": str(self),
+                "type": "invalid_request_error",
+                "param": "model",
+                "code": "model_not_available",
+            }
+        }
 
 
 class ModelCatalogService:
-    """Caches the model catalogs advertised to each active account type."""
+    """Caches the model catalog advertised by each active account."""
 
     def __init__(
         self,
@@ -32,16 +46,30 @@ class ModelCatalogService:
         backend_factory: Callable[..., Any] = OpenAIBackendAPI,
         cache_ttl_seconds: float = 300,
         clock: Callable[[], float] = time.monotonic,
+        max_workers: int = 4,
+        max_pending_requests: int = 32,
+        request_timeout_seconds: float = 10,
+        initial_wait_seconds: float = 15,
     ) -> None:
         self._accounts = accounts
         self._backend_factory = backend_factory
         self._cache_ttl_seconds = max(1.0, float(cache_ttl_seconds))
         self._clock = clock
+        self._max_workers = max(1, int(max_workers))
+        self._max_pending_requests = max(
+            self._max_workers,
+            int(max_pending_requests),
+        )
+        self._request_timeout_seconds = max(1.0, float(request_timeout_seconds))
+        self._initial_wait_seconds = max(0.0, float(initial_wait_seconds))
         self._lock = RLock()
+        self._condition = Condition(self._lock)
         self._expires_at = 0.0
-        self._account_signature: tuple[tuple[str, int], ...] = ()
+        self._account_signature: tuple[tuple[str, str], ...] = ()
         self._anonymous_models: dict[str, dict[str, Any]] = {}
-        self._models_by_account_type: dict[str, dict[str, dict[str, Any]]] = {}
+        self._models_by_access_token: dict[str, dict[str, dict[str, Any]]] = {}
+        self._initialized = False
+        self._refreshing = False
 
     @staticmethod
     def _model_map(result: object) -> dict[str, dict[str, Any]]:
@@ -68,96 +96,271 @@ class ModelCatalogService:
         return groups
 
     @staticmethod
-    def _signature(groups: dict[str, list[str]]) -> tuple[tuple[str, int], ...]:
+    def _signature(groups: dict[str, list[str]]) -> tuple[tuple[str, str], ...]:
         return tuple(
-            (account_type, len(tokens))
-            for account_type, tokens in sorted(groups.items())
+            sorted(
+                (account_type, access_token)
+                for account_type, access_tokens in groups.items()
+                for access_token in access_tokens
+            )
         )
 
-    def _fetch_models(self, access_token: str = "") -> dict[str, dict[str, Any]]:
-        backend = self._backend_factory(access_token=access_token)
-        try:
-            return self._model_map(backend.list_models())
-        finally:
-            backend.close()
-
-    def _fetch_account_type_models(
+    def _fetch_models(
         self,
-        account_type: str,
-        access_tokens: list[str],
-    ) -> dict[str, dict[str, Any]] | None:
-        attempted_tokens: set[str] = set()
-        last_error: Exception | None = None
-        for access_token in access_tokens:
-            try:
-                resolved_token = self._accounts.refresh_access_token(
-                    access_token,
-                    event="list_models",
-                ) or access_token
-                if resolved_token in attempted_tokens:
-                    continue
-                attempted_tokens.add(resolved_token)
-                return self._fetch_models(resolved_token)
-            except Exception as exc:  # noqa: BLE001 - try the next account for any upstream failure
-                last_error = exc
-        if last_error is not None:
-            logger.warning({
-                "event": "model_catalog_account_type_failed",
-                "account_type": account_type,
-                "error_type": type(last_error).__name__,
-            })
-        return None
-
-    def _refresh(self, groups: dict[str, list[str]], signature: tuple[tuple[str, int], ...]) -> None:
-        models_by_account_type: dict[str, dict[str, dict[str, Any]]] = {}
-        with ThreadPoolExecutor(max_workers=min(4, len(groups) + 1)) as executor:
-            anonymous_future = executor.submit(self._fetch_models)
-            account_futures = {
-                account_type: executor.submit(
-                    self._fetch_account_type_models,
-                    account_type,
-                    access_tokens,
+        access_token: str = "",
+    ) -> tuple[str, dict[str, dict[str, Any]] | None, str | None]:
+        resolved_token = access_token
+        try:
+            if access_token:
+                resolved_token = (
+                    self._accounts.refresh_access_token(
+                        access_token,
+                        event="model_catalog",
+                    )
+                    or access_token
                 )
-                for account_type, access_tokens in groups.items()
-            }
+            backend = self._backend_factory(access_token=resolved_token)
             try:
-                anonymous_models = anonymous_future.result()
-            except Exception as exc:  # noqa: BLE001 - retain cached models on upstream failure
-                logger.warning({
-                    "event": "model_catalog_anonymous_failed",
-                    "error_type": type(exc).__name__,
-                })
-                anonymous_models = self._anonymous_models
+                models = self._model_map(
+                    backend.list_models(timeout_secs=self._request_timeout_seconds)
+                )
+            finally:
+                backend.close()
+        except Exception as exc:  # noqa: BLE001 - report account failure to the worker
+            return resolved_token, None, type(exc).__name__
+        return resolved_token, models, None
 
-            for account_type, future in account_futures.items():
-                models = future.result()
-                if models is not None:
-                    models_by_account_type[account_type] = models
-                elif account_type in self._models_by_account_type:
-                    models_by_account_type[account_type] = self._models_by_account_type[account_type]
+    @staticmethod
+    def _accounts_for_refresh(groups: dict[str, list[str]]) -> list[tuple[str, str]]:
+        accounts: list[tuple[str, str]] = []
+        for account_type in sorted(groups):
+            accounts.extend(
+                (account_type, access_token)
+                for access_token in dict.fromkeys(groups[account_type])
+            )
+        return accounts
 
-        self._anonymous_models = anonymous_models
-        self._models_by_account_type = models_by_account_type
-        self._account_signature = signature
-        self._expires_at = self._clock() + self._cache_ttl_seconds
+    def _publish_partial_account(
+        self,
+        original_token: str,
+        resolved_token: str,
+        models: dict[str, dict[str, Any]] | None,
+    ) -> None:
+        with self._condition:
+            stale_models = None
+            if original_token != resolved_token:
+                stale_models = self._models_by_access_token.pop(original_token, None)
+            if models is not None:
+                self._models_by_access_token[resolved_token] = models
+            elif stale_models is not None:
+                self._models_by_access_token[resolved_token] = stale_models
+            self._condition.notify_all()
 
-    def _ensure_catalog(self) -> None:
+    def _resolved_access_token(self, access_token: str) -> str:
+        account = self._accounts.get_account(access_token)
+        if not account:
+            return access_token
+        return str(account.get("access_token") or access_token).strip() or access_token
+
+    def _refresh_worker(
+        self,
+        groups: dict[str, list[str]],
+        accounts_to_refresh: list[tuple[str, str]],
+    ) -> None:
+        active_tokens = {
+            access_token
+            for access_tokens in groups.values()
+            for access_token in access_tokens
+        }
+        with self._condition:
+            self._models_by_access_token = {
+                access_token: models
+                for access_token, models in self._models_by_access_token.items()
+                if access_token in active_tokens
+            }
+
+        pending: dict[
+            Future[tuple[str, dict[str, dict[str, Any]] | None, str | None]],
+            tuple[str | None, str],
+        ] = {}
+        processed_tokens: set[str] = set()
+        try:
+            jobs = iter([(None, ""), *accounts_to_refresh])
+            worker_count = min(self._max_workers, len(accounts_to_refresh) + 1)
+            with ThreadPoolExecutor(max_workers=max(1, worker_count)) as executor:
+                def fill_pending() -> None:
+                    while len(pending) < self._max_pending_requests:
+                        try:
+                            account_type, access_token = next(jobs)
+                        except StopIteration:
+                            return
+                        pending[executor.submit(self._fetch_models, access_token)] = (
+                            account_type,
+                            access_token,
+                        )
+
+                fill_pending()
+                while pending:
+                    completed, _ = wait(pending, return_when=FIRST_COMPLETED)
+                    for future in completed:
+                        account_type, access_token = pending.pop(future)
+                        try:
+                            resolved_token, models, error_type = future.result()
+                        except Exception as exc:  # noqa: BLE001 - retain the last good catalog
+                            if account_type is not None:
+                                resolved_token = self._resolved_access_token(access_token)
+                                processed_tokens.add(resolved_token)
+                                self._publish_partial_account(
+                                    access_token,
+                                    resolved_token,
+                                    None,
+                                )
+                            logger.warning({
+                                "event": (
+                                    "model_catalog_anonymous_failed"
+                                    if account_type is None
+                                    else "model_catalog_account_failed"
+                                ),
+                                **({"account_type": account_type} if account_type is not None else {}),
+                                "error_type": type(exc).__name__,
+                            })
+                            continue
+                        if error_type is not None:
+                            if account_type is not None:
+                                processed_tokens.add(resolved_token)
+                                self._publish_partial_account(
+                                    access_token,
+                                    resolved_token,
+                                    None,
+                                )
+                            logger.warning({
+                                "event": (
+                                    "model_catalog_anonymous_failed"
+                                    if account_type is None
+                                    else "model_catalog_account_failed"
+                                ),
+                                **({"account_type": account_type} if account_type is not None else {}),
+                                "error_type": error_type,
+                            })
+                            continue
+                        if account_type is None:
+                            assert models is not None
+                            with self._condition:
+                                self._anonymous_models = models
+                                self._condition.notify_all()
+                        else:
+                            assert models is not None
+                            processed_tokens.add(resolved_token)
+                            self._publish_partial_account(
+                                access_token,
+                                resolved_token,
+                                models,
+                            )
+                    fill_pending()
+        except Exception as exc:  # noqa: BLE001 - always release waiters after worker failure
+            logger.warning({
+                "event": "model_catalog_refresh_failed",
+                "error_type": type(exc).__name__,
+            })
+        finally:
+            current_groups = self._active_accounts_by_type()
+            current_signature = self._signature(current_groups)
+            current_tokens = {
+                access_token
+                for access_tokens in current_groups.values()
+                for access_token in access_tokens
+            }
+            with self._condition:
+                self._models_by_access_token = {
+                    access_token: models
+                    for access_token, models in self._models_by_access_token.items()
+                    if access_token in current_tokens
+                }
+                self._account_signature = current_signature
+                self._expires_at = (
+                    self._clock()
+                    if current_tokens - processed_tokens
+                    else self._clock() + self._cache_ttl_seconds
+                )
+                self._initialized = True
+                self._refreshing = False
+                self._condition.notify_all()
+
+    def _route_locked(self, model: str) -> ModelRoute:
+        return ModelRoute(
+            access_tokens=frozenset(
+                access_token
+                for access_token, models in self._models_by_access_token.items()
+                if model in models
+            ),
+            allow_anonymous=model in self._anonymous_models,
+        )
+
+    def _ensure_catalog(self, requested_model: str = "") -> None:
         groups = self._active_accounts_by_type()
         signature = self._signature(groups)
-        with self._lock:
-            if signature == self._account_signature and self._clock() < self._expires_at:
+        with self._condition:
+            active_tokens = {
+                access_token
+                for access_tokens in groups.values()
+                for access_token in access_tokens
+            }
+            if set(self._models_by_access_token) - active_tokens:
+                self._models_by_access_token = {
+                    access_token: models
+                    for access_token, models in self._models_by_access_token.items()
+                    if access_token in active_tokens
+                }
+            fresh = (
+                self._initialized
+                and signature == self._account_signature
+                and self._clock() < self._expires_at
+            )
+            if not fresh and not self._refreshing:
+                accounts_to_refresh = self._accounts_for_refresh(groups)
+                self._refreshing = True
+                worker = Thread(
+                    target=self._refresh_worker,
+                    args=(groups, accounts_to_refresh),
+                    name="model-catalog-refresh",
+                    daemon=True,
+                )
+                try:
+                    worker.start()
+                except Exception:
+                    self._refreshing = False
+                    self._condition.notify_all()
+                    raise
+
+            if self._initial_wait_seconds <= 0:
                 return
-            self._refresh(groups, signature)
+            route_available = lambda: (
+                bool(self._route_locked(requested_model).access_tokens)
+                or self._route_locked(requested_model).allow_anonymous
+            )
+            if not self._initialized:
+                self._condition.wait_for(
+                    lambda: self._initialized or (bool(requested_model) and route_available()),
+                    timeout=self._initial_wait_seconds,
+                )
+            elif requested_model and self._refreshing and not route_available():
+                self._condition.wait_for(
+                    lambda: (
+                        route_available()
+                        or not self._refreshing
+                    ),
+                    timeout=self._initial_wait_seconds,
+                )
 
     def list_models(self) -> dict[str, Any]:
         self._ensure_catalog()
-        with self._lock:
+        with self._condition:
             union: dict[str, dict[str, Any]] = {
                 model_id: dict(item)
                 for model_id, item in self._anonymous_models.items()
             }
-            for account_type in sorted(self._models_by_account_type):
-                for model_id, item in self._models_by_account_type[account_type].items():
+            for access_token in sorted(self._models_by_access_token):
+                for model_id, item in self._models_by_access_token[access_token].items():
                     union.setdefault(model_id, dict(item))
         return {
             "object": "list",
@@ -166,17 +369,9 @@ class ModelCatalogService:
 
     def route_for_model(self, model: str) -> ModelRoute:
         model = str(model or "").strip()
-        self._ensure_catalog()
-        with self._lock:
-            account_types = frozenset(
-                account_type
-                for account_type, models in self._models_by_account_type.items()
-                if model in models
-            )
-            return ModelRoute(
-                account_types=account_types,
-                allow_anonymous=model in self._anonymous_models,
-            )
+        self._ensure_catalog(model)
+        with self._condition:
+            return self._route_locked(model)
 
 
 model_catalog_service = ModelCatalogService(account_service)

--- a/services/oauth_login_service.py
+++ b/services/oauth_login_service.py
@@ -195,7 +195,7 @@ class OAuthLoginService:
         """调用 /api/accounts/oauth/token 用 code+verifier 换 token 三件套。"""
         kwargs = proxy_settings.build_session_kwargs(
             impersonate="chrome",
-            require_tls_verification=True,
+            verify=False,
         )
         session = requests.Session(**kwargs)
         try:

--- a/services/oauth_login_service.py
+++ b/services/oauth_login_service.py
@@ -193,7 +193,10 @@ class OAuthLoginService:
     @staticmethod
     def _exchange_code(code: str, code_verifier: str, redirect_uri: str) -> dict[str, str]:
         """调用 /api/accounts/oauth/token 用 code+verifier 换 token 三件套。"""
-        kwargs = proxy_settings.build_session_kwargs(impersonate="chrome", verify=False)
+        kwargs = proxy_settings.build_session_kwargs(
+            impersonate="chrome",
+            require_tls_verification=True,
+        )
         session = requests.Session(**kwargs)
         try:
             response = session.post(

--- a/services/openai_backend_api.py
+++ b/services/openai_backend_api.py
@@ -2649,12 +2649,13 @@ class OpenAIBackendAPI:
             except Exception:
                 pass
 
-    def _bootstrap(self) -> None:
+    def _bootstrap(self, timeout_secs: float = 30) -> None:
         """预热首页，并提取 PoW 相关脚本引用。"""
+        timeout = max(1.0, float(timeout_secs))
         response = self.session.get(
             self.base_url + "/",
             headers=self._bootstrap_headers(),
-            timeout=30,
+            timeout=timeout,
         )
         ensure_ok(response, "bootstrap")
         self.pow_script_sources, self.pow_data_build = parse_pow_resources(response.text)
@@ -2727,9 +2728,10 @@ class OpenAIBackendAPI:
             return "/backend-api/conversation", "Asia/Shanghai"
         return "/backend-anon/conversation", "America/Los_Angeles"
 
-    def list_models(self) -> Dict[str, Any]:
+    def list_models(self, timeout_secs: float = 30) -> Dict[str, Any]:
         """返回当前模式下可用模型，格式对齐 OpenAI `/v1/models`。"""
-        self._bootstrap()
+        timeout = max(1.0, float(timeout_secs))
+        self._bootstrap(timeout_secs=timeout)
         path = "/backend-api/models?history_and_training_disabled=false" if self.access_token else (
             "/backend-anon/models?iim=false&is_gizmo=false"
         )
@@ -2738,7 +2740,7 @@ class OpenAIBackendAPI:
         response = self.session.get(
             self.base_url + path,
             headers=self._headers(route),
-            timeout=30,
+            timeout=timeout,
         )
         ensure_ok(response, context)
         data = []

--- a/services/protocol/chat_completion_cache.py
+++ b/services/protocol/chat_completion_cache.py
@@ -75,28 +75,6 @@ def cache_key(body: dict[str, Any], messages: list[dict[str, Any]], *, stream: b
     return hashlib.sha256(encoded).hexdigest()
 
 
-def _message_signature(message: dict[str, Any]) -> str:
-    return json.dumps(_json_safe(message), ensure_ascii=False, sort_keys=True, separators=(",", ":"))
-
-
-def normalize_text_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    settings = config.get_chat_completion_cache_settings()
-    if not settings.get("normalize_messages"):
-        return messages
-
-    normalized: list[dict[str, Any]] = []
-    previous_signature = ""
-    for message in messages:
-        if settings.get("drop_assistant_history") and str(message.get("role") or "") == "assistant":
-            continue
-        signature = _message_signature(message)
-        if settings.get("drop_adjacent_duplicates") and signature == previous_signature:
-            continue
-        normalized.append(message)
-        previous_signature = signature
-    return normalized
-
-
 class ChatCompletionCache:
     def __init__(self) -> None:
         self._lock = threading.RLock()

--- a/services/protocol/conversation.py
+++ b/services/protocol/conversation.py
@@ -749,8 +749,8 @@ def stream_text_deltas(backend: OpenAIBackendAPI, request: ConversationRequest) 
                         excluded_tokens=set(attempted_tokens),
                         model=request.model,
                     )
-                if token:
-                    continue
+                # An empty token is the valid anonymous backend, not a failed selection.
+                continue
             raise
         finally:
             if active_backend is not None:

--- a/services/protocol/openai_v1_chat_complete.py
+++ b/services/protocol/openai_v1_chat_complete.py
@@ -6,7 +6,7 @@ from typing import Any, Iterable, Iterator
 
 from fastapi import HTTPException
 
-from services.protocol.chat_completion_cache import cache_key, chat_completion_cache, normalize_text_messages
+from services.protocol.chat_completion_cache import cache_key, chat_completion_cache
 from services.protocol.conversation import (
     ConversationRequest,
     ImageOutput,
@@ -175,7 +175,7 @@ def chat_image_args(body: dict[str, Any]) -> tuple[str, str, int, list[tuple[byt
 
 def text_chat_parts(body: dict[str, Any]) -> tuple[str, list[dict[str, Any]]]:
     model = str(body.get("model") or "auto").strip() or "auto"
-    messages = normalize_text_messages(normalize_messages(chat_messages_from_body(body)))
+    messages = normalize_messages(chat_messages_from_body(body))
     if has_unsupported_tools(body, WEB_SEARCH_TOOL_TYPES):
         messages.insert(0, {"role": "system", "content": TOOL_UNAVAILABLE_SYSTEM_MESSAGE})
     return model, messages

--- a/services/protocol/openai_v1_response.py
+++ b/services/protocol/openai_v1_response.py
@@ -6,7 +6,7 @@ from typing import Any, Iterable, Iterator
 
 from fastapi import HTTPException
 
-from services.protocol.chat_completion_cache import cache_key, chat_completion_cache, normalize_text_messages
+from services.protocol.chat_completion_cache import cache_key, chat_completion_cache
 from services.protocol.conversation import (
     ConversationRequest,
     ImageOutput,
@@ -290,7 +290,7 @@ def response_completed(
 
 def text_response_parts(body: dict[str, Any]) -> tuple[str, list[dict[str, Any]]]:
     model = str(body.get("model") or "auto").strip() or "auto"
-    messages = normalize_text_messages(normalize_messages(messages_from_input(body.get("input"), body.get("instructions"))))
+    messages = normalize_messages(messages_from_input(body.get("input"), body.get("instructions")))
     if has_unsupported_response_tools(body):
         messages.insert(0, {"role": "system", "content": TOOL_UNAVAILABLE_SYSTEM_MESSAGE})
     return model, messages

--- a/services/proxy_service.py
+++ b/services/proxy_service.py
@@ -223,15 +223,12 @@ class ProxySettingsStore:
         proxy: str = "",
         resource: bool = False,
         upstream: bool = False,
-        require_tls_verification: bool = False,
         **session_kwargs,
     ) -> dict[str, object]:
         profile = self.get_profile(account=account, proxy=proxy, resource=resource, upstream=upstream)
         if profile.proxy_url:
             session_kwargs["proxy"] = profile.proxy_url
-        if require_tls_verification:
-            session_kwargs["verify"] = True
-        elif profile.runtime_enabled and profile.skip_ssl_verify:
+        if profile.runtime_enabled and profile.skip_ssl_verify:
             session_kwargs["verify"] = False
         return session_kwargs
 

--- a/services/proxy_service.py
+++ b/services/proxy_service.py
@@ -223,12 +223,15 @@ class ProxySettingsStore:
         proxy: str = "",
         resource: bool = False,
         upstream: bool = False,
+        require_tls_verification: bool = False,
         **session_kwargs,
     ) -> dict[str, object]:
         profile = self.get_profile(account=account, proxy=proxy, resource=resource, upstream=upstream)
         if profile.proxy_url:
             session_kwargs["proxy"] = profile.proxy_url
-        if profile.runtime_enabled and profile.skip_ssl_verify:
+        if require_tls_verification:
+            session_kwargs["verify"] = True
+        elif profile.runtime_enabled and profile.skip_ssl_verify:
             session_kwargs["verify"] = False
         return session_kwargs
 

--- a/services/storage/database_storage.py
+++ b/services/storage/database_storage.py
@@ -4,8 +4,7 @@ import json
 from typing import Any
 
 from sqlalchemy import Column, String, Text, create_engine, Integer, text
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import declarative_base, sessionmaker
 
 from services.storage.base import StorageBackend
 

--- a/test/test_account_tls.py
+++ b/test/test_account_tls.py
@@ -9,6 +9,7 @@ from services.account_service import AccountService
 from services.oauth_login_service import OAuthLoginService
 from services.proxy_service import ProxyRuntimeProfile, proxy_settings
 from services.storage.json_storage import JSONStorageBackend
+from utils.sentinel import SentinelTokenGenerator, build_sentinel_token
 
 
 class FakeTokenResponse:
@@ -38,26 +39,49 @@ class FakeTokenSession:
 
 
 class AccountTLSVerificationTests(unittest.TestCase):
-    def test_required_tls_overrides_proxy_skip_verify(self) -> None:
+    def test_proxy_skip_verify_overrides_caller_default(self) -> None:
         profile = ProxyRuntimeProfile(
             proxy_url="http://proxy.example:8080",
             runtime_enabled=True,
             skip_ssl_verify=True,
         )
         with mock.patch.object(proxy_settings, "get_profile", return_value=profile):
-            kwargs = proxy_settings.build_session_kwargs(require_tls_verification=True)
+            kwargs = proxy_settings.build_session_kwargs(verify=True)
 
         self.assertEqual(kwargs["proxy"], "http://proxy.example:8080")
-        self.assertIs(kwargs["verify"], True)
-        self.assertNotIn("require_tls_verification", kwargs)
+        self.assertIs(kwargs["verify"], False)
 
-    def test_oauth_code_exchange_uses_verified_session(self) -> None:
+    def test_access_token_refresh_keeps_original_verified_default(self) -> None:
+        session = FakeTokenSession()
+        account = {"access_token": "old-access"}
+        with tempfile.TemporaryDirectory() as directory:
+            service = AccountService(JSONStorageBackend(Path(directory) / "accounts.json"))
+            with (
+                mock.patch.object(
+                    proxy_settings,
+                    "build_session_kwargs",
+                    return_value={"verify": True},
+                ) as kwargs_builder,
+                mock.patch("curl_cffi.requests.Session", return_value=session) as session_factory,
+            ):
+                result = service._request_access_token_refresh("old-refresh", account)
+
+        kwargs_builder.assert_called_once_with(
+            account=account,
+            impersonate="chrome110",
+            verify=True,
+        )
+        session_factory.assert_called_once_with(verify=True)
+        self.assertTrue(session.closed)
+        self.assertEqual(result["access_token"], "access")
+
+    def test_oauth_code_exchange_keeps_original_unverified_default(self) -> None:
         session = FakeTokenSession()
         with (
             mock.patch.object(
                 proxy_settings,
                 "build_session_kwargs",
-                return_value={"verify": True},
+                return_value={"verify": False},
             ) as kwargs_builder,
             mock.patch("services.oauth_login_service.requests.Session", return_value=session) as session_factory,
         ):
@@ -65,21 +89,21 @@ class AccountTLSVerificationTests(unittest.TestCase):
 
         kwargs_builder.assert_called_once_with(
             impersonate="chrome",
-            require_tls_verification=True,
+            verify=False,
         )
-        session_factory.assert_called_once_with(verify=True)
+        session_factory.assert_called_once_with(verify=False)
         self.assertNotIn("verify", session.post_kwargs or {})
         self.assertTrue(session.closed)
         self.assertEqual(result["access_token"], "access")
 
-    def test_password_login_constructs_a_verified_proxy_session(self) -> None:
+    def test_password_login_keeps_original_unverified_default(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             service = AccountService(JSONStorageBackend(Path(directory) / "accounts.json"))
             with (
                 mock.patch.object(
                     proxy_settings,
                     "build_session_kwargs",
-                    return_value={"impersonate": "chrome110", "verify": True},
+                    return_value={"impersonate": "chrome110", "verify": False},
                 ) as kwargs_builder,
                 mock.patch("services.account_service.config.get_proxy_settings", return_value=""),
                 mock.patch("curl_cffi.requests.Session", side_effect=RuntimeError("session-created")) as session_factory,
@@ -90,9 +114,22 @@ class AccountTLSVerificationTests(unittest.TestCase):
         kwargs_builder.assert_called_once_with(
             proxy="",
             impersonate="chrome110",
-            require_tls_verification=True,
+            verify=False,
         )
-        session_factory.assert_called_once_with(impersonate="chrome110", verify=True)
+        session_factory.assert_called_once_with(impersonate="chrome110", verify=False)
+
+    def test_sentinel_request_keeps_original_unverified_override(self) -> None:
+        response = mock.Mock(status_code=200, text="token response")
+        response.json.return_value = {"token": "challenge", "proofofwork": {"required": False}}
+        session = mock.Mock()
+        session.post.return_value = response
+
+        with mock.patch.object(SentinelTokenGenerator, "generate_requirements_token", return_value="proof"):
+            sentinel_value, cookie_value = build_sentinel_token(session, "device", "password_verify")
+
+        self.assertIn('"c":"challenge"', sentinel_value)
+        self.assertEqual(cookie_value, "0challenge")
+        self.assertIs(session.post.call_args.kwargs["verify"], False)
 
 
 if __name__ == "__main__":

--- a/test/test_account_tls.py
+++ b/test/test_account_tls.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from services.account_service import AccountService
+from services.oauth_login_service import OAuthLoginService
+from services.proxy_service import ProxyRuntimeProfile, proxy_settings
+from services.storage.json_storage import JSONStorageBackend
+
+
+class FakeTokenResponse:
+    status_code = 200
+    text = "token response"
+
+    @staticmethod
+    def json() -> dict[str, str]:
+        return {
+            "access_token": "access",
+            "refresh_token": "refresh",
+            "id_token": "id",
+        }
+
+
+class FakeTokenSession:
+    def __init__(self) -> None:
+        self.post_kwargs: dict | None = None
+        self.closed = False
+
+    def post(self, _url: str, **kwargs):
+        self.post_kwargs = kwargs
+        return FakeTokenResponse()
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class AccountTLSVerificationTests(unittest.TestCase):
+    def test_required_tls_overrides_proxy_skip_verify(self) -> None:
+        profile = ProxyRuntimeProfile(
+            proxy_url="http://proxy.example:8080",
+            runtime_enabled=True,
+            skip_ssl_verify=True,
+        )
+        with mock.patch.object(proxy_settings, "get_profile", return_value=profile):
+            kwargs = proxy_settings.build_session_kwargs(require_tls_verification=True)
+
+        self.assertEqual(kwargs["proxy"], "http://proxy.example:8080")
+        self.assertIs(kwargs["verify"], True)
+        self.assertNotIn("require_tls_verification", kwargs)
+
+    def test_oauth_code_exchange_uses_verified_session(self) -> None:
+        session = FakeTokenSession()
+        with (
+            mock.patch.object(
+                proxy_settings,
+                "build_session_kwargs",
+                return_value={"verify": True},
+            ) as kwargs_builder,
+            mock.patch("services.oauth_login_service.requests.Session", return_value=session) as session_factory,
+        ):
+            result = OAuthLoginService._exchange_code("code", "verifier", "https://example.test/callback")
+
+        kwargs_builder.assert_called_once_with(
+            impersonate="chrome",
+            require_tls_verification=True,
+        )
+        session_factory.assert_called_once_with(verify=True)
+        self.assertNotIn("verify", session.post_kwargs or {})
+        self.assertTrue(session.closed)
+        self.assertEqual(result["access_token"], "access")
+
+    def test_password_login_constructs_a_verified_proxy_session(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            service = AccountService(JSONStorageBackend(Path(directory) / "accounts.json"))
+            with (
+                mock.patch.object(
+                    proxy_settings,
+                    "build_session_kwargs",
+                    return_value={"impersonate": "chrome110", "verify": True},
+                ) as kwargs_builder,
+                mock.patch("services.account_service.config.get_proxy_settings", return_value=""),
+                mock.patch("curl_cffi.requests.Session", side_effect=RuntimeError("session-created")) as session_factory,
+                self.assertRaisesRegex(RuntimeError, "session-created"),
+            ):
+                service._login_with_password("user@example.test", "secret")
+
+        kwargs_builder.assert_called_once_with(
+            proxy="",
+            impersonate="chrome110",
+            require_tls_verification=True,
+        )
+        session_factory.assert_called_once_with(impersonate="chrome110", verify=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_chat_completion_cache.py
+++ b/test/test_chat_completion_cache.py
@@ -27,9 +27,6 @@ class ChatCompletionCacheTests(unittest.TestCase):
             "max_entries": 32,
             "dedupe_inflight": True,
             "stream_cache": True,
-            "normalize_messages": True,
-            "drop_adjacent_duplicates": True,
-            "drop_assistant_history": False,
         }
         chat_completion_cache.clear()
 
@@ -150,7 +147,7 @@ class ChatCompletionCacheTests(unittest.TestCase):
         content = "".join(str(chunk["choices"][0]["delta"].get("content") or "") for chunk in second)
         self.assertEqual(content, "streamed answer")
 
-    def test_adjacent_duplicate_messages_are_removed_before_upstream_call(self) -> None:
+    def test_adjacent_duplicate_messages_are_preserved_before_upstream_call(self) -> None:
         captured_messages = []
 
         def fake_collect_text(_backend, request):
@@ -176,6 +173,7 @@ class ChatCompletionCacheTests(unittest.TestCase):
         self.assertEqual(
             captured_messages,
             [
+                {"role": "user", "content": "repeat me"},
                 {"role": "user", "content": "repeat me"},
                 {"role": "assistant", "content": "old answer"},
                 {"role": "user", "content": "next prompt"},
@@ -545,12 +543,10 @@ class ChatCompletionCacheTests(unittest.TestCase):
         self.assertIn("plain text answer", response["choices"][0]["message"]["content"])
 
     def test_chat_completions_accepts_remote_image_url(self) -> None:
-        class FakeImageResponse:
-            status_code = 200
-            headers = {"content-type": "image/png", "content-length": str(len(PNG_1X1))}
-            content = PNG_1X1
-
-        with mock.patch("utils.helper.requests.get", return_value=FakeImageResponse()) as request_get:
+        with mock.patch(
+            "utils.helper.download_public_image",
+            return_value=(PNG_1X1, "/image.png", "image/png"),
+        ) as image_download:
             model, messages = openai_v1_chat_complete.text_chat_parts({
                 "model": "auto",
                 "messages": [{
@@ -562,7 +558,7 @@ class ChatCompletionCacheTests(unittest.TestCase):
                 }],
             })
 
-        request_get.assert_called_once()
+        image_download.assert_called_once()
         self.assertEqual(model, "auto")
         content = messages[0]["content"]
         self.assertEqual(content[0], {"type": "text", "text": "Describe this"})
@@ -600,12 +596,10 @@ class ChatCompletionCacheTests(unittest.TestCase):
         self.assertGreater(response["usage"]["input_tokens_details"]["image_tokens"], 0)
 
     def test_responses_text_request_accepts_remote_input_image_url(self) -> None:
-        class FakeImageResponse:
-            status_code = 200
-            headers = {"content-type": "image/png", "content-length": str(len(PNG_1X1))}
-            content = PNG_1X1
-
-        with mock.patch("utils.helper.requests.get", return_value=FakeImageResponse()) as request_get:
+        with mock.patch(
+            "utils.helper.download_public_image",
+            return_value=(PNG_1X1, "/image.png", "image/png"),
+        ) as image_download:
             _model, messages = openai_v1_response.text_response_parts({
                 "model": "auto",
                 "input": [{
@@ -618,7 +612,7 @@ class ChatCompletionCacheTests(unittest.TestCase):
                 }],
             })
 
-        request_get.assert_called_once()
+        image_download.assert_called_once()
         content = messages[0]["content"]
         self.assertEqual(content[0], {"type": "text", "text": "Describe this"})
         self.assertEqual(content[1]["type"], "image")

--- a/test/test_image_inputs_security.py
+++ b/test/test_image_inputs_security.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import socket
+import unittest
+from unittest import mock
+
+from fastapi import HTTPException
+
+from api import image_inputs
+from utils import helper
+from utils import remote_image
+
+
+PUBLIC_DNS_RESULT = [
+    (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", ("93.184.216.34", 443)),
+]
+
+
+class FakeResponse:
+    def __init__(
+        self,
+        *,
+        status_code: int = 200,
+        headers: dict[str, str] | None = None,
+        chunks: list[bytes] | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self.headers = headers or {"content-type": "image/png"}
+        self._chunks = chunks or []
+        self.content = b"".join(self._chunks)
+        self.read_count = 0
+        self.closed = False
+
+    def iter_content(self, chunk_size: int):
+        self.chunk_size = chunk_size
+        for chunk in self._chunks:
+            self.read_count += 1
+            yield chunk
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakeSession:
+    def __init__(self, response: FakeResponse) -> None:
+        self.response = response
+        self.calls: list[tuple[str, dict]] = []
+        self.closed = False
+
+    def get(self, url: str, **kwargs):
+        self.calls.append((url, kwargs))
+        return self.response
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class ImageInputSecurityTests(unittest.TestCase):
+    def test_message_image_urls_use_the_shared_secure_downloader(self) -> None:
+        with mock.patch.object(
+            helper,
+            "download_public_image",
+            return_value=(b"image", "/image.png", "image/png"),
+        ) as download:
+            result = helper._decode_message_image_url("https://public.example/image.png")
+
+        self.assertEqual(result, (b"image", "image/png"))
+        download.assert_called_once_with(
+            "https://public.example/image.png",
+            max_bytes=helper.MAX_JSON_IMAGE_BYTES,
+            timeout_seconds=helper.REMOTE_IMAGE_TIMEOUT_SECONDS,
+            user_agent="chatgpt2api vision fetcher",
+        )
+
+    def test_loopback_literal_is_rejected_before_network_access(self) -> None:
+        with mock.patch.object(remote_image.requests, "get") as legacy_get:
+            with self.assertRaises(HTTPException) as raised:
+                image_inputs._download_image_url("http://127.0.0.1/private.png")
+
+        self.assertEqual(raised.exception.status_code, 400)
+        legacy_get.assert_not_called()
+
+    def test_hostname_resolving_to_private_address_is_rejected(self) -> None:
+        private_dns = [
+            (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", ("10.0.0.8", 80)),
+        ]
+        with (
+            mock.patch.object(remote_image.socket, "getaddrinfo", return_value=private_dns),
+            mock.patch.object(remote_image.requests, "get") as legacy_get,
+        ):
+            with self.assertRaises(HTTPException):
+                image_inputs._download_image_url("http://internal.example/image.png")
+
+        legacy_get.assert_not_called()
+
+    def test_redirect_target_is_validated_before_following(self) -> None:
+        response = FakeResponse(
+            status_code=302,
+            headers={"location": "http://127.0.0.1/private.png"},
+        )
+        session = FakeSession(response)
+        with (
+            mock.patch.object(remote_image.socket, "getaddrinfo", return_value=PUBLIC_DNS_RESULT),
+            mock.patch.object(remote_image.requests, "Session", return_value=session),
+            mock.patch.object(remote_image.requests, "get", return_value=response) as legacy_get,
+        ):
+            with self.assertRaises(HTTPException):
+                image_inputs._download_image_url("https://public.example/image.png")
+
+        legacy_get.assert_not_called()
+        self.assertEqual(len(session.calls), 1)
+        self.assertFalse(session.calls[0][1]["allow_redirects"])
+
+    def test_streaming_limit_stops_before_the_remaining_body(self) -> None:
+        response = FakeResponse(chunks=[b"12345", b"67890", b"not-read"])
+        session = FakeSession(response)
+        with (
+            mock.patch.object(image_inputs, "MAX_IMAGE_REFERENCE_BYTES", 8),
+            mock.patch.object(remote_image.socket, "getaddrinfo", return_value=PUBLIC_DNS_RESULT),
+            mock.patch.object(remote_image.requests, "Session", return_value=session),
+            mock.patch.object(remote_image.requests, "get", return_value=response) as legacy_get,
+        ):
+            with self.assertRaises(HTTPException):
+                image_inputs._download_image_url("https://public.example/image.png")
+
+        legacy_get.assert_not_called()
+        self.assertEqual(response.read_count, 2)
+        self.assertTrue(response.closed)
+        self.assertTrue(session.closed)
+
+    def test_public_image_is_streamed_with_redirects_disabled(self) -> None:
+        response = FakeResponse(chunks=[b"png-", b"bytes"])
+        session = FakeSession(response)
+        with (
+            mock.patch.object(remote_image.socket, "getaddrinfo", return_value=PUBLIC_DNS_RESULT),
+            mock.patch.object(remote_image.requests, "Session", return_value=session) as session_factory,
+            mock.patch.object(remote_image.proxy_settings, "build_session_kwargs", return_value={}) as session_kwargs,
+            mock.patch.object(remote_image.requests, "get", return_value=response) as legacy_get,
+        ):
+            data, filename, mime_type = image_inputs._download_image_url(
+                "https://public.example/path/photo.png"
+            )
+
+        self.assertEqual(data, b"png-bytes")
+        self.assertEqual(filename, "photo.png")
+        self.assertEqual(mime_type, "image/png")
+        legacy_get.assert_not_called()
+        session_kwargs.assert_called_once_with(require_tls_verification=True)
+        session_factory.assert_called_once()
+        self.assertTrue(session.calls[0][1]["stream"])
+        self.assertFalse(session.calls[0][1]["allow_redirects"])
+        self.assertTrue(response.closed)
+        self.assertTrue(session.closed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_image_inputs_security.py
+++ b/test/test_image_inputs_security.py
@@ -134,7 +134,11 @@ class ImageInputSecurityTests(unittest.TestCase):
         with (
             mock.patch.object(remote_image.socket, "getaddrinfo", return_value=PUBLIC_DNS_RESULT),
             mock.patch.object(remote_image.requests, "Session", return_value=session) as session_factory,
-            mock.patch.object(remote_image.proxy_settings, "build_session_kwargs", return_value={}) as session_kwargs,
+            mock.patch.object(
+                remote_image.proxy_settings,
+                "build_session_kwargs",
+                return_value={"verify": False},
+            ) as session_kwargs,
             mock.patch.object(remote_image.requests, "get", return_value=response) as legacy_get,
         ):
             data, filename, mime_type = image_inputs._download_image_url(
@@ -145,8 +149,10 @@ class ImageInputSecurityTests(unittest.TestCase):
         self.assertEqual(filename, "photo.png")
         self.assertEqual(mime_type, "image/png")
         legacy_get.assert_not_called()
-        session_kwargs.assert_called_once_with(require_tls_verification=True)
+        session_kwargs.assert_called_once_with(resource=True, upstream=True, verify=True)
         session_factory.assert_called_once()
+        self.assertIs(session_factory.call_args.kwargs["verify"], False)
+        self.assertIn(remote_image.CurlOpt.RESOLVE, session_factory.call_args.kwargs["curl_options"])
         self.assertTrue(session.calls[0][1]["stream"])
         self.assertFalse(session.calls[0][1]["allow_redirects"])
         self.assertTrue(response.closed)

--- a/test/test_image_tasks_api.py
+++ b/test/test_image_tasks_api.py
@@ -62,9 +62,18 @@ class FakeImageTaskService:
 class ImageTasksApiTests(unittest.TestCase):
     def setUp(self):
         self.fake_service = FakeImageTaskService()
-        self.service_patcher = mock.patch.object(image_tasks_module, "image_task_service", self.fake_service)
-        self.service_patcher.start()
-        self.addCleanup(self.service_patcher.stop)
+        self.patchers = [
+            mock.patch.object(image_tasks_module, "image_task_service", self.fake_service),
+            mock.patch.object(
+                image_tasks_module,
+                "require_identity",
+                return_value={"id": "test-user", "name": "Test User", "role": "user"},
+            ),
+            mock.patch.object(image_tasks_module, "filter_or_log", mock.AsyncMock()),
+        ]
+        for patcher in self.patchers:
+            patcher.start()
+            self.addCleanup(patcher.stop)
         app = FastAPI()
         app.include_router(image_tasks_module.create_router())
         self.client = TestClient(app)
@@ -116,7 +125,7 @@ class ImageTasksApiTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200, response.text)
         self.assertEqual(len(self.fake_service.edit_calls), 1)
         images = self.fake_service.edit_calls[0][1]["images"]
-        self.assertEqual(images, [(PNG_BYTES, "image_url.png", "image/png")])
+        self.assertEqual(images, [(PNG_BYTES, "image_1.png", "image/png")])
 
     def test_list_tasks_reports_missing_ids(self):
         response = self.client.get("/api/image-tasks?ids=task-1,missing", headers=AUTH_HEADERS)

--- a/test/test_model_catalog_service.py
+++ b/test/test_model_catalog_service.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import tempfile
+import time
 import unittest
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from threading import Event, Lock
 
 from services.account_service import AccountService
 from services.model_service import ModelCatalogService
@@ -35,9 +37,12 @@ class FakeBackend:
         self._calls = calls
         self._closed = closed
 
-    def list_models(self) -> dict:
+    def list_models(self, timeout_secs: float = 30) -> dict:
+        del timeout_secs
         self._calls.append(self.access_token)
         outcome = self._outcomes[self.access_token]
+        if callable(outcome):
+            outcome = outcome()
         if isinstance(outcome, Exception):
             raise outcome
         return outcome
@@ -94,12 +99,56 @@ class ModelCatalogServiceTests(unittest.TestCase):
         self.assertNotIn("team-disabled", self.calls)
 
         pro_route = self.catalog.route_for_model("pro-only")
-        self.assertEqual(pro_route.account_types, frozenset({"Pro"}))
+        self.assertEqual(pro_route.access_tokens, frozenset({"pro"}))
         self.assertFalse(pro_route.allow_anonymous)
 
         shared_route = self.catalog.route_for_model("shared")
-        self.assertEqual(shared_route.account_types, frozenset({"free", "Plus"}))
+        self.assertEqual(shared_route.access_tokens, frozenset({"free-good", "plus"}))
         self.assertTrue(shared_route.allow_anonymous)
+
+    def test_same_type_accounts_keep_distinct_model_capabilities(self) -> None:
+        self.accounts.add_account_items([
+            {"access_token": "pro-alt", "type": "Pro", "status": "正常"},
+        ])
+        self.outcomes["pro-alt"] = model_list("pro-alt-only")
+
+        result = self.catalog.list_models()
+
+        self.assertIn("pro-alt-only", {item["id"] for item in result["data"]})
+        self.assertEqual(
+            self.catalog.route_for_model("pro-only").access_tokens,
+            frozenset({"pro"}),
+        )
+        self.assertEqual(
+            self.catalog.route_for_model("pro-alt-only").access_tokens,
+            frozenset({"pro-alt"}),
+        )
+
+    def test_model_discovery_refreshes_and_routes_a_rotated_token(self) -> None:
+        refresh_calls: list[str] = []
+
+        def rotate_token(token: str, **_kwargs) -> str:
+            refresh_calls.append(token)
+            if token != "pro":
+                return token
+            self.accounts.delete_accounts(["pro"])
+            self.accounts.add_account_items([
+                {"access_token": "pro-rotated", "type": "Pro", "status": "正常"},
+            ])
+            return "pro-rotated"
+
+        self.accounts.refresh_access_token = rotate_token
+        self.outcomes["pro-rotated"] = model_list("pro-rotated-only")
+
+        result = self.catalog.list_models()
+
+        self.assertIn("pro", refresh_calls)
+        self.assertIn("pro-rotated-only", {item["id"] for item in result["data"]})
+        self.assertNotIn("pro", self.calls)
+        self.assertEqual(
+            self.catalog.route_for_model("pro-rotated-only").access_tokens,
+            frozenset({"pro-rotated"}),
+        )
 
     def test_catalog_is_cached_until_ttl_expires(self) -> None:
         self.catalog.list_models()
@@ -127,11 +176,33 @@ class ModelCatalogServiceTests(unittest.TestCase):
         result = self.catalog.list_models()
 
         self.assertIn("pro-only", {item["id"] for item in result["data"]})
+        deadline = time.monotonic() + 1
+        while self.calls.count("pro") < 2 and time.monotonic() < deadline:
+            time.sleep(0.01)
         self.assertEqual(
-            self.catalog.route_for_model("pro-only").account_types,
-            frozenset({"Pro"}),
+            self.catalog.route_for_model("pro-only").access_tokens,
+            frozenset({"pro"}),
         )
         self.assertEqual(self.calls.count("pro"), 2)
+
+    def test_stale_catalog_is_served_while_refresh_runs_in_background(self) -> None:
+        self.catalog.list_models()
+        release = Event()
+
+        def blocked_models() -> dict:
+            release.wait(timeout=1)
+            return model_list("pro-new")
+
+        self.outcomes["pro"] = blocked_models
+        self.now += 301
+
+        started = time.monotonic()
+        result = self.catalog.list_models()
+        elapsed = time.monotonic() - started
+
+        self.assertLess(elapsed, 0.2)
+        self.assertIn("pro-only", {item["id"] for item in result["data"]})
+        release.set()
 
     def test_removed_account_type_drops_its_stale_capabilities(self) -> None:
         self.catalog.list_models()
@@ -141,8 +212,142 @@ class ModelCatalogServiceTests(unittest.TestCase):
 
         self.assertNotIn("pro-only", {item["id"] for item in result["data"]})
         self.assertEqual(
-            self.catalog.route_for_model("pro-only").account_types,
+            self.catalog.route_for_model("pro-only").access_tokens,
             frozenset(),
+        )
+
+    def test_refresh_queries_every_active_account_with_bounded_concurrency(self) -> None:
+        extra_accounts = [
+            {"access_token": f"business-{index}", "type": "Business", "status": "正常"}
+            for index in range(6)
+        ]
+        self.accounts.add_account_items(extra_accounts)
+        concurrency_lock = Lock()
+        active = 0
+        peak_active = 0
+
+        def unavailable() -> dict:
+            nonlocal active, peak_active
+            with concurrency_lock:
+                active += 1
+                peak_active = max(peak_active, active)
+            try:
+                time.sleep(0.02)
+                raise RuntimeError("upstream unavailable")
+            finally:
+                with concurrency_lock:
+                    active -= 1
+
+        for account in extra_accounts:
+            self.outcomes[account["access_token"]] = unavailable
+        catalog = ModelCatalogService(
+            self.accounts,
+            backend_factory=lambda access_token="": FakeBackend(
+                access_token, self.outcomes, self.calls, self.closed
+            ),
+            cache_ttl_seconds=300,
+            max_workers=2,
+            max_pending_requests=2,
+            clock=lambda: self.now,
+        )
+
+        catalog.list_models()
+
+        business_calls = [token for token in self.calls if token.startswith("business-")]
+        self.assertCountEqual(
+            business_calls,
+            [account["access_token"] for account in extra_accounts],
+        )
+        self.assertLessEqual(peak_active, 2)
+
+    def test_account_result_is_published_before_slow_anonymous_result(self) -> None:
+        release = Event()
+
+        def slow_anonymous() -> dict:
+            release.wait(timeout=1)
+            return model_list("anon")
+
+        self.outcomes[""] = slow_anonymous
+        catalog = ModelCatalogService(
+            self.accounts,
+            backend_factory=lambda access_token="": FakeBackend(
+                access_token, self.outcomes, self.calls, self.closed
+            ),
+            initial_wait_seconds=0.5,
+            clock=lambda: self.now,
+        )
+
+        try:
+            started = time.monotonic()
+            route = catalog.route_for_model("pro-only")
+            elapsed = time.monotonic() - started
+        finally:
+            release.set()
+
+        self.assertLess(elapsed, 0.2)
+        self.assertEqual(route.access_tokens, frozenset({"pro"}))
+
+    def test_token_rotation_waits_for_replacement_account_capabilities(self) -> None:
+        self.catalog.list_models()
+        self.accounts.delete_accounts(["pro"])
+        self.accounts.add_account_items([
+            {"access_token": "pro-rotated", "type": "Pro", "status": "正常"},
+        ])
+        self.outcomes["pro-rotated"] = model_list("pro-only")
+
+        route = self.catalog.route_for_model("pro-only")
+
+        self.assertEqual(route.access_tokens, frozenset({"pro-rotated"}))
+
+    def test_account_added_during_refresh_is_discovered_before_routing(self) -> None:
+        refresh_started = Event()
+        release_refresh = Event()
+
+        def blocked_pro_models() -> dict:
+            refresh_started.set()
+            release_refresh.wait(timeout=1)
+            return model_list("pro-only")
+
+        self.outcomes["pro"] = blocked_pro_models
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            initial_refresh = executor.submit(self.catalog.list_models)
+            self.assertTrue(refresh_started.wait(timeout=1))
+            self.accounts.add_account_items([
+                {"access_token": "late-pro", "type": "Pro", "status": "正常"},
+            ])
+            self.outcomes["late-pro"] = model_list("late-pro-only")
+            release_refresh.set()
+            initial_refresh.result(timeout=1)
+
+        route = self.catalog.route_for_model("late-pro-only")
+
+        self.assertEqual(route.access_tokens, frozenset({"late-pro"}))
+
+    def test_failed_discovery_keeps_stale_models_on_a_rotated_token(self) -> None:
+        self.catalog.list_models()
+
+        def rotate_token(token: str, **_kwargs) -> str:
+            if token != "pro":
+                return token
+            self.accounts.delete_accounts(["pro"])
+            self.accounts.add_account_items([
+                {"access_token": "pro-rotated", "type": "Pro", "status": "正常"},
+            ])
+            return "pro-rotated"
+
+        self.accounts.refresh_access_token = rotate_token
+        self.outcomes["pro-rotated"] = RuntimeError("temporary upstream failure")
+        self.now += 301
+
+        self.catalog.list_models()
+        deadline = time.monotonic() + 1
+        while "pro-rotated" not in self.calls and time.monotonic() < deadline:
+            time.sleep(0.01)
+
+        self.assertIn("pro-rotated", self.calls)
+        self.assertEqual(
+            self.catalog.route_for_model("pro-only").access_tokens,
+            frozenset({"pro-rotated"}),
         )
 
 

--- a/test/test_model_error_response.py
+++ b/test/test_model_error_response.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+import unittest
+from unittest import mock
+
+from services.log_service import LoggedCall
+from services.model_service import ModelUnavailableError
+
+
+class ModelErrorResponseTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.call = LoggedCall(
+            {"id": "test", "name": "test", "role": "user"},
+            "/v1/responses",
+            "missing-model",
+            "Responses",
+        )
+
+    async def test_unavailable_model_is_a_client_error(self) -> None:
+        def handler():
+            raise ModelUnavailableError("missing-model")
+
+        with mock.patch.object(self.call, "log"):
+            response = await self.call.run(handler)
+
+        payload = json.loads(response.body)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(payload["error"]["type"], "invalid_request_error")
+        self.assertEqual(payload["error"]["code"], "model_not_available")
+        self.assertEqual(payload["error"]["param"], "model")
+
+    async def test_stream_setup_uses_the_same_model_error(self) -> None:
+        def events():
+            raise ModelUnavailableError("missing-model")
+            yield
+
+        with mock.patch.object(self.call, "log"):
+            response = await self.call.run(events)
+
+        payload = json.loads(response.body)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(payload["error"]["code"], "model_not_available")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_multi_image_results.py
+++ b/test/test_multi_image_results.py
@@ -119,7 +119,15 @@ class MultiImageResultTests(unittest.TestCase):
         ])
 
         with (
-            mock.patch.dict(config.data, {"image_poll_initial_wait_secs": 0, "image_poll_interval_secs": 0.5}),
+            mock.patch.dict(
+                config.data,
+                {
+                    "image_poll_initial_wait_secs": 0,
+                    "image_poll_interval_secs": 0.5,
+                    "image_settle_enabled": True,
+                    "image_check_before_hit_enabled": True,
+                },
+            ),
             mock.patch("services.openai_backend_api.time.sleep", lambda _seconds: None),
         ):
             file_ids, sediment_ids = backend._poll_image_results("conv-1", timeout_secs=10)

--- a/test/test_text_model_routing.py
+++ b/test/test_text_model_routing.py
@@ -34,8 +34,11 @@ class TextAccountRoutingTests(unittest.TestCase):
         )
         self.service.refresh_access_token = lambda token, **_kwargs: token
 
-    def test_explicit_model_selects_only_advertising_account_type(self) -> None:
-        route = ModelRoute(account_types=frozenset({"Pro"}), allow_anonymous=False)
+    def test_explicit_model_selects_only_advertising_account(self) -> None:
+        self.service.add_account_items([
+            {"access_token": "pro-alt", "type": "Pro", "status": "正常"},
+        ])
+        route = ModelRoute(access_tokens=frozenset({"pro"}), allow_anonymous=False)
         with mock.patch(
             "services.model_service.model_catalog_service.route_for_model",
             return_value=route,
@@ -58,7 +61,7 @@ class TextAccountRoutingTests(unittest.TestCase):
         self.assertEqual(tokens, {"free", "plus", "pro"})
 
     def test_anonymous_model_uses_anonymous_backend(self) -> None:
-        route = ModelRoute(account_types=frozenset(), allow_anonymous=True)
+        route = ModelRoute(access_tokens=frozenset(), allow_anonymous=True)
         with mock.patch(
             "services.model_service.model_catalog_service.route_for_model",
             return_value=route,
@@ -68,7 +71,7 @@ class TextAccountRoutingTests(unittest.TestCase):
         self.assertEqual(token, "")
 
     def test_model_without_eligible_account_fails_closed(self) -> None:
-        route = ModelRoute(account_types=frozenset({"Team"}), allow_anonymous=False)
+        route = ModelRoute(access_tokens=frozenset(), allow_anonymous=False)
         with mock.patch(
             "services.model_service.model_catalog_service.route_for_model",
             return_value=route,
@@ -170,6 +173,36 @@ class TextProtocolRoutingTests(unittest.TestCase):
             excluded_tokens={"bad"},
             model="pro-only",
         )
+
+    def test_invalid_token_can_fall_back_to_anonymous_backend(self) -> None:
+        initial_backend = SimpleNamespace(access_token="bad")
+        request = conversation.ConversationRequest(
+            model="shared-model",
+            messages=[{"role": "user", "content": "hello"}],
+        )
+        attempted: list[str] = []
+
+        def backend_factory(access_token: str):
+            attempted.append(access_token)
+            return SimpleNamespace(access_token=access_token, close=lambda: None)
+
+        def fake_events(backend, **_kwargs):
+            if backend.access_token == "bad":
+                raise RuntimeError("token_invalidated")
+            yield {"type": "conversation.delta", "delta": "anonymous-ok"}
+
+        with (
+            mock.patch.object(conversation, "OpenAIBackendAPI", side_effect=backend_factory),
+            mock.patch.object(conversation, "conversation_events", side_effect=fake_events),
+            mock.patch.object(conversation.account_service, "refresh_access_token", return_value="bad"),
+            mock.patch.object(conversation.account_service, "remove_invalid_token"),
+            mock.patch.object(conversation.account_service, "get_text_access_token", return_value=""),
+            mock.patch.object(conversation.account_service, "mark_text_used"),
+        ):
+            result = list(conversation.stream_text_deltas(initial_backend, request))
+
+        self.assertEqual(result, ["anonymous-ok"])
+        self.assertEqual(attempted, ["bad", ""])
 
 
 if __name__ == "__main__":

--- a/test/test_v1_chat_completions.py
+++ b/test/test_v1_chat_completions.py
@@ -5,11 +5,13 @@ import time
 import unittest
 
 import requests
+import pytest
 
 from utils.helper import save_images_from_text
 
 AUTH_KEY = "chatgpt2api"
 BASE_URL = "http://localhost:8000"
+pytestmark = pytest.mark.live
 
 
 class ChatCompletionsTests(unittest.TestCase):

--- a/test/test_v1_images_edits.py
+++ b/test/test_v1_images_edits.py
@@ -6,12 +6,14 @@ import unittest
 from pathlib import Path
 
 import requests
+import pytest
 
 from test.utils import save_image
 from utils.log import logger
 
 AUTH_KEY = "chatgpt2api"
 BASE_URL = "http://localhost:8000"
+pytestmark = pytest.mark.live
 ASSETS_DIR = Path(__file__).resolve().parents[1] / "assets"
 
 

--- a/test/test_v1_images_edits_api.py
+++ b/test/test_v1_images_edits_api.py
@@ -23,9 +23,18 @@ class ImagesEditsApiTests(unittest.TestCase):
             self.handle_calls.append(payload)
             return {"created": 1, "data": [{"b64_json": base64.b64encode(b"out").decode("ascii")}]}
 
-        self.handler_patcher = mock.patch.object(ai_module.openai_v1_image_edit, "handle", fake_handle)
-        self.handler_patcher.start()
-        self.addCleanup(self.handler_patcher.stop)
+        self.patchers = [
+            mock.patch.object(ai_module.openai_v1_image_edit, "handle", fake_handle),
+            mock.patch.object(
+                ai_module,
+                "require_identity",
+                return_value={"id": "test-user", "name": "Test User", "role": "user"},
+            ),
+            mock.patch.object(ai_module, "filter_or_log", mock.AsyncMock()),
+        ]
+        for patcher in self.patchers:
+            patcher.start()
+            self.addCleanup(patcher.stop)
         app = FastAPI()
         app.include_router(ai_module.create_router())
         self.client = TestClient(app)
@@ -49,7 +58,7 @@ class ImagesEditsApiTests(unittest.TestCase):
         payload = self.handle_calls[0]
         self.assertEqual(payload["prompt"], "edit")
         self.assertEqual(payload["n"], 1)
-        self.assertEqual(payload["images"], [(PNG_BYTES, "image_url.png", "image/png")])
+        self.assertEqual(payload["images"], [(PNG_BYTES, "image_1.png", "image/png")])
 
     def test_edit_rejects_file_id_reference(self):
         """测试图片编辑接口对暂不支持的 file_id 返回明确错误。"""

--- a/test/test_v1_images_edits_json.py
+++ b/test/test_v1_images_edits_json.py
@@ -27,10 +27,17 @@ class ImageEditsJsonApiTests(unittest.TestCase):
 
         self.handle_patcher = mock.patch.object(ai_module.openai_v1_image_edit, "handle", fake_handle)
         self.filter_patcher = mock.patch.object(ai_module, "filter_or_log", mock.AsyncMock())
+        self.identity_patcher = mock.patch.object(
+            ai_module,
+            "require_identity",
+            return_value={"id": "test-user", "name": "Test User", "role": "user"},
+        )
         self.handle_patcher.start()
         self.filter_patcher.start()
+        self.identity_patcher.start()
         self.addCleanup(self.handle_patcher.stop)
         self.addCleanup(self.filter_patcher.stop)
+        self.addCleanup(self.identity_patcher.stop)
 
         app = FastAPI()
         app.include_router(ai_module.create_router())
@@ -109,16 +116,22 @@ class ImageEditsJsonApiTests(unittest.TestCase):
     def test_image_edit_rejects_json_without_image(self):
         response = self.client.post("/v1/images/edits", headers=AUTH_HEADERS, json={"prompt": "缺少图片"})
         self.assertEqual(response.status_code, 400, response.text)
-        self.assertIn("image file is required", response.text)
+        self.assertIn("image file or image_url is required", response.text)
 
-    def test_image_edit_rejects_remote_json_url(self):
-        response = self.client.post(
-            "/v1/images/edits",
-            headers=AUTH_HEADERS,
-            json={"prompt": "不允许远程拉图", "images": [{"image_url": "https://example.com/a.png"}]},
-        )
-        self.assertEqual(response.status_code, 400, response.text)
-        self.assertIn("remote image URLs are not supported", response.text)
+    def test_image_edit_accepts_remote_json_url_via_safe_downloader(self):
+        with mock.patch(
+            "api.image_inputs.download_public_image",
+            return_value=(b"remote-png", "/a.png", "image/png"),
+        ) as downloader:
+            response = self.client.post(
+                "/v1/images/edits",
+                headers=AUTH_HEADERS,
+                json={"prompt": "远程拉图", "images": [{"image_url": "https://example.com/a.png"}]},
+            )
+
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(self.calls[0]["images"], [(b"remote-png", "a.png", "image/png")])
+        downloader.assert_called_once()
 
     def test_image_edit_rejects_json_n_out_of_range(self):
         response = self.client.post("/v1/images/edits", headers=AUTH_HEADERS, json={"prompt": "n 越界", "n": 5, "image": PNG_DATA_URL})

--- a/test/test_v1_images_generations.py
+++ b/test/test_v1_images_generations.py
@@ -5,11 +5,13 @@ import time
 import unittest
 
 import requests
+import pytest
 
 from test.utils import save_image
 
 AUTH_KEY = "chatgpt2api"
 BASE_URL = "http://localhost:8000"
+pytestmark = pytest.mark.live
 
 
 class ImageGenerationsTests(unittest.TestCase):

--- a/test/test_v1_messages.py
+++ b/test/test_v1_messages.py
@@ -5,10 +5,12 @@ import time
 import unittest
 
 import requests
+import pytest
 
 AUTH_KEY = "chatgpt2api"
 BASE_URL = "http://localhost:8000"
 MODEL = "auto"
+pytestmark = pytest.mark.live
 
 
 class AnthropicMessagesTests(unittest.TestCase):

--- a/test/test_v1_models.py
+++ b/test/test_v1_models.py
@@ -5,6 +5,7 @@ import unittest
 from unittest import mock
 
 import requests
+import pytest
 
 from services.protocol import openai_v1_models
 
@@ -62,12 +63,14 @@ class ModelListTests(unittest.TestCase):
         self.assertNotIn("codex-gpt-image-2", ids)
         self.assertNotIn("plus-codex-gpt-image-2", ids)
 
+    @pytest.mark.live
     def test_list_models_function(self):
         """测试直接调用服务层获取模型列表。"""
         result = openai_v1_models.list_models()
         print("function result:")
         print(json.dumps(result, ensure_ascii=False, indent=2))
 
+    @pytest.mark.live
     def test_list_models_http(self):
         """测试通过 HTTP 接口获取模型列表。"""
         response = requests.get(

--- a/test/test_v1_responses.py
+++ b/test/test_v1_responses.py
@@ -5,6 +5,7 @@ import time
 import unittest
 
 import requests
+import pytest
 
 from test.utils import save_image
 
@@ -13,6 +14,7 @@ BASE_URL = "http://localhost:8000"
 TEXT_MODEL = "auto"
 IMAGE_MODEL = "gpt-image-2"
 CODEX_IMAGE_MODEL = "codex-gpt-image-2"
+pytestmark = pytest.mark.live
 
 
 class ResponsesTests(unittest.TestCase):

--- a/utils/helper.py
+++ b/utils/helper.py
@@ -1,18 +1,16 @@
 import base64
 import hashlib
 import json
-import mimetypes
 import re
 import time
 import uuid
 from pathlib import Path
 from typing import Any, Iterator
-from urllib.parse import urlparse
 
 from curl_cffi import requests
 from fastapi import HTTPException
-from services.proxy_service import proxy_settings
 from utils.log import logger
+from utils.remote_image import download_public_image
 
 BASE_IMAGE_MODELS = {"gpt-image-2", "codex-gpt-image-2"}
 IMAGE_MODEL_PLAN_TYPES = ("plus", "team", "pro")
@@ -334,38 +332,12 @@ def _decode_message_image_url(value: object) -> tuple[bytes, str] | None:
         return base64.b64decode(data), mime
     if not source.startswith(("http://", "https://")):
         return None
-    parsed = urlparse(source)
-    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-        return None
-
-    try:
-        response = requests.get(
-            source,
-            headers={"Accept": "image/*,*/*;q=0.8", "User-Agent": "chatgpt2api vision fetcher"},
-            timeout=REMOTE_IMAGE_TIMEOUT_SECONDS,
-            allow_redirects=True,
-            **proxy_settings.build_session_kwargs(),
-        )
-    except Exception as exc:
-        raise HTTPException(status_code=400, detail={"error": f"image_url fetch failed: {exc}"}) from exc
-    if not 200 <= response.status_code < 300:
-        raise HTTPException(status_code=400, detail={"error": f"image_url fetch failed: HTTP {response.status_code}"})
-    content_length = str(response.headers.get("content-length") or "").strip()
-    if content_length.isdigit() and int(content_length) > MAX_JSON_IMAGE_BYTES:
-        raise HTTPException(status_code=400, detail={"error": "image_url exceeds 10MB limit"})
-    image_data = response.content
-    if not image_data:
-        raise HTTPException(status_code=400, detail={"error": "image_url returned empty content"})
-    if len(image_data) > MAX_JSON_IMAGE_BYTES:
-        raise HTTPException(status_code=400, detail={"error": "image_url exceeds 10MB limit"})
-    mime = str(response.headers.get("content-type") or "image/png").split(";", 1)[0].lower()
-    guessed_mime = mimetypes.guess_type(parsed.path)[0] or ""
-    if mime and not mime.startswith("image/") and mime not in {"application/octet-stream", "binary/octet-stream"}:
-        raise HTTPException(status_code=400, detail={"error": "image_url must point to an image"})
-    if not mime.startswith("image/") and guessed_mime.startswith("image/"):
-        mime = guessed_mime
-    if not mime.startswith("image/"):
-        mime = "image/png"
+    image_data, _parsed_path, mime = download_public_image(
+        source,
+        max_bytes=MAX_JSON_IMAGE_BYTES,
+        timeout_seconds=REMOTE_IMAGE_TIMEOUT_SECONDS,
+        user_agent="chatgpt2api vision fetcher",
+    )
     return image_data, mime
 
 

--- a/utils/remote_image.py
+++ b/utils/remote_image.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import ipaddress
+import mimetypes
+import socket
+from urllib.parse import ParseResult, urljoin, urlparse
+
+from curl_cffi import requests
+from curl_cffi.const import CurlOpt
+from fastapi import HTTPException
+
+from services.proxy_service import proxy_settings
+
+DOWNLOAD_CHUNK_BYTES = 64 * 1024
+MAX_REDIRECTS = 5
+
+
+def _limit_label(max_bytes: int) -> str:
+    return f"{max(1, max_bytes // (1024 * 1024))}MB"
+
+
+def _public_target(url: str) -> tuple[ParseResult, list[str]]:
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc or not parsed.hostname:
+        raise HTTPException(status_code=400, detail={"error": "image_url must be an http or https URL"})
+    if parsed.username is not None or parsed.password is not None:
+        raise HTTPException(status_code=400, detail={"error": "image_url credentials are not allowed"})
+    try:
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail={"error": "image_url has an invalid port"}) from exc
+
+    host = parsed.hostname
+    literal_address = False
+    try:
+        literal = ipaddress.ip_address(host)
+    except ValueError:
+        try:
+            resolved = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+        except OSError as exc:
+            raise HTTPException(status_code=400, detail={"error": "image_url host could not be resolved"}) from exc
+        addresses = []
+        for family, _socktype, _protocol, _canonical_name, sockaddr in resolved:
+            if family not in {socket.AF_INET, socket.AF_INET6} or not sockaddr:
+                continue
+            try:
+                address = ipaddress.ip_address(sockaddr[0])
+            except ValueError:
+                continue
+            if address not in addresses:
+                addresses.append(address)
+    else:
+        literal_address = True
+        addresses = [literal]
+
+    if not addresses or any(not address.is_global for address in addresses):
+        raise HTTPException(status_code=400, detail={"error": "image_url target must use a public IP address"})
+    if literal_address:
+        return parsed, []
+
+    resolved_addresses = ",".join(
+        f"[{address}]" if address.version == 6 else str(address)
+        for address in addresses
+    )
+    return parsed, [f"{host}:{port}:{resolved_addresses}"]
+
+
+def _response_mime_type(response: requests.Response, parsed_path: str) -> str:
+    header_type = str(response.headers.get("content-type") or "").split(";", 1)[0].strip().lower()
+    guessed_type = mimetypes.guess_type(parsed_path)[0] or ""
+    if header_type.startswith("image/"):
+        return header_type
+    if header_type and header_type not in {"application/octet-stream", "binary/octet-stream"}:
+        raise HTTPException(status_code=400, detail={"error": "image_url must point to an image"})
+    if guessed_type.startswith("image/"):
+        return guessed_type
+    if not header_type or header_type in {"application/octet-stream", "binary/octet-stream"}:
+        return "image/png"
+    raise HTTPException(status_code=400, detail={"error": "image_url must point to an image"})
+
+
+def _read_limited(response: requests.Response, max_bytes: int) -> bytes:
+    limit_label = _limit_label(max_bytes)
+    content_length = str(response.headers.get("content-length") or "").strip()
+    if content_length.isdigit() and int(content_length) > max_bytes:
+        raise HTTPException(status_code=400, detail={"error": f"image_url exceeds {limit_label} limit"})
+
+    chunks: list[bytes] = []
+    total = 0
+    for chunk in response.iter_content(chunk_size=DOWNLOAD_CHUNK_BYTES):
+        if not chunk:
+            continue
+        total += len(chunk)
+        if total > max_bytes:
+            raise HTTPException(status_code=400, detail={"error": f"image_url exceeds {limit_label} limit"})
+        chunks.append(bytes(chunk))
+    data = b"".join(chunks)
+    if not data:
+        raise HTTPException(status_code=400, detail={"error": "image_url returned empty content"})
+    return data
+
+
+def download_public_image(
+    url: str,
+    *,
+    max_bytes: int,
+    timeout_seconds: float,
+    user_agent: str,
+) -> tuple[bytes, str, str]:
+    current_url = str(url or "").strip()
+    for redirect_count in range(MAX_REDIRECTS + 1):
+        parsed, resolve_entries = _public_target(current_url)
+        session_kwargs = proxy_settings.build_session_kwargs(
+            require_tls_verification=True,
+        )
+        if resolve_entries:
+            curl_options = dict(session_kwargs.pop("curl_options", {}) or {})
+            curl_options[CurlOpt.RESOLVE] = resolve_entries
+            session_kwargs["curl_options"] = curl_options
+        session = requests.Session(**session_kwargs)
+        response = None
+        try:
+            response = session.get(
+                current_url,
+                headers={"Accept": "image/*,*/*;q=0.8", "User-Agent": user_agent},
+                timeout=timeout_seconds,
+                allow_redirects=False,
+                stream=True,
+            )
+            if response.status_code in {301, 302, 303, 307, 308}:
+                if redirect_count >= MAX_REDIRECTS:
+                    raise HTTPException(status_code=400, detail={"error": "image_url has too many redirects"})
+                location = str(response.headers.get("location") or "").strip()
+                if not location:
+                    raise HTTPException(status_code=400, detail={"error": "image_url redirect has no location"})
+                current_url = urljoin(current_url, location)
+                continue
+            if not 200 <= response.status_code < 300:
+                raise HTTPException(
+                    status_code=400,
+                    detail={"error": f"image_url fetch failed: HTTP {response.status_code}"},
+                )
+            data = _read_limited(response, max(1, int(max_bytes)))
+            return data, parsed.path, _response_mime_type(response, parsed.path)
+        except HTTPException:
+            raise
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail={"error": f"image_url fetch failed: {exc}"}) from exc
+        finally:
+            if response is not None:
+                try:
+                    response.close()
+                except Exception:
+                    pass
+            try:
+                session.close()
+            except Exception:
+                pass
+    raise HTTPException(status_code=400, detail={"error": "image_url has too many redirects"})

--- a/utils/remote_image.py
+++ b/utils/remote_image.py
@@ -111,7 +111,9 @@ def download_public_image(
     for redirect_count in range(MAX_REDIRECTS + 1):
         parsed, resolve_entries = _public_target(current_url)
         session_kwargs = proxy_settings.build_session_kwargs(
-            require_tls_verification=True,
+            resource=True,
+            upstream=True,
+            verify=True,
         )
         if resolve_entries:
             curl_options = dict(session_kwargs.pop("curl_options", {}) or {})

--- a/utils/sentinel.py
+++ b/utils/sentinel.py
@@ -132,7 +132,6 @@ def build_sentinel_token(
             "sec-ch-ua-platform": '"Windows"',
         },
         timeout=20,
-        verify=False,
     )
 
     try:

--- a/utils/sentinel.py
+++ b/utils/sentinel.py
@@ -132,6 +132,7 @@ def build_sentinel_token(
             "sec-ch-ua-platform": '"Windows"',
         },
         timeout=20,
+        verify=False,
     )
 
     try:

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -163,6 +163,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "httpx" },
+    { name = "pytest" },
 ]
 
 [package.metadata]
@@ -180,7 +181,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "httpx", specifier = ">=0.28.1" }]
+dev = [
+    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "pytest", specifier = ">=8.3.0" },
+]
 
 [[package]]
 name = "click"
@@ -285,9 +289,7 @@ wheels = [
     { url = "https://mirrors.aliyun.com/pypi/packages/7a/75/7e9cd1126a1e1f0cd67b0eda02e5221b28488d352684704a78ed505bd719/greenlet-3.4.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:43748988b097f9c6f09364f260741aa73c80747f63389824435c7a50bfdfd5c1" },
     { url = "https://mirrors.aliyun.com/pypi/packages/9d/c4/3e2df392e5cb199527c4d9dbcaa75c14edcc394b45040f0189f649631e3c/greenlet-3.4.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5566e4e2cd7a880e8c27618e3eab20f3494452d12fd5129edef7b2f7aa9a36d1" },
     { url = "https://mirrors.aliyun.com/pypi/packages/da/af/750cdfda1d1bd30a6c28080245be8d0346e669a98fdbae7f4102aa95fff3/greenlet-3.4.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1054c5a3c78e2ab599d452f23f7adafef55062a783a8e241d24f3b633ba6ff82" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/e0/93/c8c508d68ba93232784bbc1b5474d92371f2897dfc6bc281b419f2e0d492/greenlet-3.4.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:98eedd1803353daf1cd9ef23eef23eda5a4d22f99b1f998d273a8b78b70dd47f" },
     { url = "https://mirrors.aliyun.com/pypi/packages/54/78/0cbc693622cd54ebe25207efbb3a0eb07c2639cb8594f6e3aaaa0bb077a8/greenlet-3.4.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f82cb6cddc27dd81c96b1506f4aa7def15070c3b2a67d4e46fd19016aacce6cf" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/7f/46/cfaaa0ade435a60550fd83d07dfd5c41f873a01da17ede5c4cade0b9bab8/greenlet-3.4.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:b7857e2202aae67bc5725e0c1f6403c20a8ff46094ece015e7d474f5f7020b55" },
     { url = "https://mirrors.aliyun.com/pypi/packages/ba/c0/8966767de01343c1ff47e8b855dc78e7d1a8ed2b7b9c83576a57e289f81d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:227a46251ecba4ff46ae742bc5ce95c91d5aceb4b02f885487aff269c127a729" },
     { url = "https://mirrors.aliyun.com/pypi/packages/b8/38/bcdc71ba05e9a5fda87f63ffc2abcd1f15693b659346df994a48c968003d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5b99e87be7eba788dd5b75ba1cde5639edffdec5f91fe0d734a249535ec3408c" },
     { url = "https://mirrors.aliyun.com/pypi/packages/a1/c2/19b664b7173b9e4ef5f77e8cef9f14c20ec7fce7920dc1ccd7afd955d093/greenlet-3.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:849f8bc17acd6295fcb5de8e46d55cc0e52381c56eaf50a2afd258e97bc65940" },
@@ -295,9 +297,7 @@ wheels = [
     { url = "https://mirrors.aliyun.com/pypi/packages/78/02/bde66806e8f169cf90b14d02c500c44cdbe02c8e224c9c67bafd1b8cadd1/greenlet-3.4.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:10a07aca6babdd18c16a3f4f8880acfffc2b88dfe431ad6aa5f5740759d7d75e" },
     { url = "https://mirrors.aliyun.com/pypi/packages/05/1f/39da1c336a87d47c58352fb8a78541ce63d63ae57c5b9dae1fe02801bbc2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:076e21040b3a917d3ce4ad68fb5c3c6b32f1405616c4a57aa83120979649bd3d" },
     { url = "https://mirrors.aliyun.com/pypi/packages/d3/6c/90ee29a4ee27af7aa2e2ec408799eeb69ee3fcc5abcecac6ddd07a5cd0f2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e82689eea4a237e530bb5cb41b180ef81fa2160e1f89422a67be7d90da67f615" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/d2/4a/74078d3936712cff6d3c91a930016f476ce4198d84e224fe6d81d3e02880/greenlet-3.4.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:06c2d3b89e0c62ba50bd7adf491b14f39da9e7e701647cb7b9ff4c99bee04b19" },
     { url = "https://mirrors.aliyun.com/pypi/packages/07/49/d4cad6e5381a50947bb973d2f6cf6592621451b09368b8c20d9b8af49c5b/greenlet-3.4.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4df3b0b2289ec686d3c821a5fee44259c05cfe824dd5e6e12c8e5f5df23085cf" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/79/3e/df8a83ab894751bc31e1106fdfaa80ca9753222f106b04de93faaa55feb7/greenlet-3.4.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:070b8bac2ff3b4d9e0ff36a0d19e42103331d9737e8504747cd1e659f76297bd" },
     { url = "https://mirrors.aliyun.com/pypi/packages/37/31/d1edd54f424761b5d47718822f506b435b6aab2f3f93b465441143ea5119/greenlet-3.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8bff29d586ea415688f4cec96a591fcc3bf762d046a796cdadc1fdb6e7f2d5bf" },
     { url = "https://mirrors.aliyun.com/pypi/packages/b0/c6/6d3f9cdcb21c4e12a79cb332579f1c6aa1af78eb68059c5a957c7812d95e/greenlet-3.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8a569c2fb840c53c13a2b8967c63621fafbd1a0e015b9c82f408c33d626a2fda" },
     { url = "https://mirrors.aliyun.com/pypi/packages/63/45/c1ca4a1ad975de4727e52d3ffe641ae23e1d7a8ffaa8ff7a0477e1827b92/greenlet-3.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:207ba5b97ea8b0b60eb43ffcacf26969dd83726095161d676aac03ff913ee50d" },
@@ -305,9 +305,7 @@ wheels = [
     { url = "https://mirrors.aliyun.com/pypi/packages/d4/8f/18d72b629783f5e8d045a76f5325c1e938e659a9e4da79c7dcd10169a48d/greenlet-3.4.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d70012e51df2dbbccfaf63a40aaf9b40c8bed37c3e3a38751c926301ce538ece" },
     { url = "https://mirrors.aliyun.com/pypi/packages/9e/ad/5fa86ec46769c4153820d58a04062285b3b9e10ba3d461ee257b68dcbf53/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a58bec0751f43068cd40cff31bb3ca02ad6000b3a51ca81367af4eb5abc480c8" },
     { url = "https://mirrors.aliyun.com/pypi/packages/43/f0/4e8174ca0e87ae748c409f055a1ba161038c43cc0a5a6f1433a26ac2e5bf/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05fa0803561028f4b2e3b490ee41216a842eaee11aed004cc343a996d9523aa2" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/ef/92/466b0d9afd44b8af623139a3599d651c7564fa4152f25f117e1ee5949ffb/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c4cd56a9eb7a6444edbc19062f7b6fbc8f287c663b946e3171d899693b1c19fa" },
     { url = "https://mirrors.aliyun.com/pypi/packages/19/da/991cf7cd33662e2df92a1274b7eb4d61769294d38a1bba8a45f31364845e/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e60d38719cb80b3ab5e85f9f1aed4960acfde09868af6762ccb27b260d68f4ed" },
-    { url = "https://mirrors.aliyun.com/pypi/packages/0d/14/3395a7ef3e260de0325152ddfe19dffb3e49fe10873b94654352b53ad48e/greenlet-3.4.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:1f85f204c4d54134ae850d401fa435c89cd667d5ce9dc567571776b45941af72" },
     { url = "https://mirrors.aliyun.com/pypi/packages/36/c5/6c2c708e14db3d9caea4b459d8464f58c32047451142fe2cfd90e7458f41/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f" },
     { url = "https://mirrors.aliyun.com/pypi/packages/7a/4c/50c5fed19378e11a29fabab1f6be39ea95358f4a0a07e115a51ca93385d8/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a" },
     { url = "https://mirrors.aliyun.com/pypi/packages/db/72/85ae954d734703ab48e622c59d4ce35d77ce840c265814af9c078cacc7aa/greenlet-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705" },
@@ -360,6 +358,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
@@ -378,6 +385,15 @@ source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
 sdist = { url = "https://mirrors.aliyun.com/pypi/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba" }
 wheels = [
     { url = "https://mirrors.aliyun.com/pypi/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e" },
 ]
 
 [[package]]
@@ -436,6 +452,15 @@ wheels = [
     { url = "https://mirrors.aliyun.com/pypi/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354" },
     { url = "https://mirrors.aliyun.com/pypi/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1" },
     { url = "https://mirrors.aliyun.com/pypi/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746" },
 ]
 
 [[package]]
@@ -649,6 +674,22 @@ source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
 sdist = { url = "https://mirrors.aliyun.com/pypi/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f" }
 wheels = [
     { url = "https://mirrors.aliyun.com/pypi/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c" },
 ]
 
 [[package]]

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -32,9 +32,6 @@ const nextConfig: NextConfig = {
     images: {
         unoptimized: true,
     },
-    typescript: {
-        ignoreBuildErrors: true,
-    },
 }
 
 export default nextConfig


### PR DESCRIPTION
## Summary

- Discover models per active account and route requests only to the exact accounts that advertise the requested model.
- Refresh expiring access tokens before discovery, migrate cached capabilities across token rotation, retain stale capabilities on transient failures, and bound background refresh concurrency.
- Return a typed OpenAI-compatible `400 model_not_available` error when no authenticated or anonymous route exists.
- Preserve caller message history instead of deleting duplicate or assistant messages during cache normalization; keep invalid-token fallback to the anonymous backend.
- Secure remote image loading with public-address validation on every redirect, DNS pinning, streaming byte limits, and credential rejection.
- Preserve the existing TLS contract: access-token and remote-image requests verify by default, OAuth/password/Sentinel keep their original per-flow behavior, and the explicit `skip_ssl_verify` setting remains authoritative.
- Add repeatable offline tests, deterministic Bun/Docker builds, PR CI, release test gates, and a container startup smoke test.

## Validation

- `python -m pytest -m "not live" -q`: **160 passed, 18 deselected**
- Focused TLS, proxy-runtime, and remote-image suite: **34 passed**
- Focused model routing/error suite: **25 passed**
- `python -m compileall -q main.py api services utils test`
- `uv lock --check`
- `actionlint`
- Bun 1.3.14 frozen install, Next.js production build, and TypeScript check
- Browser smoke test against an isolated local instance:
  - login and all seven shipped application routes rendered
  - `skip_ssl_verify` saved, survived reload, and was restored to its initial value
  - no browser console errors
- Earlier isolated real-account routing canary with refresh credentials removed:
  - two Free accounts advertised 7 models each; one Pro account advertised 19
  - Pro-only models were absent from Free capability sets
  - `/v1/models` returned the 23-model union
  - unknown model returned `400 / model_not_available`
  - `gpt-5-5-pro` `/v1/responses` returned 200
  - `/v1/chat/completions` preserved duplicate user messages and assistant history
  - public image download succeeded; loopback, private redirect, and URL credentials were rejected

## Remaining external limitation

The current WARP egress can list anonymous models, but the upstream anonymous conversation endpoint returns 403. Anonymous fallback behavior is covered offline; anonymous conversation success is not claimed by this PR.