### PR TITLE
fix: deduplicate imported accounts after token rotation

### DIFF
--- a/services/account_service.py
+++ b/services/account_service.py
@@ -1107,6 +1107,102 @@ class AccountService:
         return str(item.get("access_token") or item.get("accessToken") or "").strip()
 
     @staticmethod
+    def _first_nonempty_text(*values: object) -> str:
+        for value in values:
+            text = str(value or "").strip()
+            if text:
+                return text
+        return ""
+
+    @classmethod
+    def _account_identity_key(cls, item: dict) -> tuple[str, str] | None:
+        if not isinstance(item, dict):
+            return None
+
+        access_payload = cls._decode_jwt_payload(cls._account_payload_token(item))
+        id_payload = cls._decode_jwt_payload(str(item.get("id_token") or "").strip())
+        access_auth = access_payload.get("https://api.openai.com/auth")
+        access_auth = access_auth if isinstance(access_auth, dict) else {}
+        id_auth = id_payload.get("https://api.openai.com/auth")
+        id_auth = id_auth if isinstance(id_auth, dict) else {}
+        access_profile = access_payload.get("https://api.openai.com/profile")
+        access_profile = access_profile if isinstance(access_profile, dict) else {}
+        id_profile = id_payload.get("https://api.openai.com/profile")
+        id_profile = id_profile if isinstance(id_profile, dict) else {}
+
+        # Account IDs identify workspaces; subject and email are fallbacks only.
+        account_id = cls._first_nonempty_text(
+            access_auth.get("chatgpt_account_id"),
+            id_auth.get("chatgpt_account_id"),
+            item.get("account_id"),
+            item.get("chatgpt_account_id"),
+        )
+        if account_id:
+            return "account_id", account_id
+
+        subject = cls._first_nonempty_text(
+            access_payload.get("sub"),
+            id_payload.get("sub"),
+            access_auth.get("user_id"),
+            id_auth.get("user_id"),
+            item.get("user_id"),
+        )
+        if subject:
+            return "subject", subject
+
+        email = cls._first_nonempty_text(
+            access_profile.get("email"),
+            id_profile.get("email"),
+            access_payload.get("email"),
+            id_payload.get("email"),
+            item.get("email"),
+        )
+        return ("email", email.casefold()) if email else None
+
+    @classmethod
+    def _access_token_rank(cls, token: str) -> tuple[int, int]:
+        payload = cls._decode_jwt_payload(token)
+
+        def as_int(value: object) -> int:
+            try:
+                return int(value or 0)
+            except (TypeError, ValueError):
+                return 0
+
+        return as_int(payload.get("exp")), as_int(payload.get("iat"))
+
+    @staticmethod
+    def _has_import_value(value: object) -> bool:
+        return value is not None and (not isinstance(value, str) or bool(value.strip()))
+
+    @classmethod
+    def _merge_duplicate_payloads(cls, current: dict, incoming: dict) -> dict:
+        current_token = cls._account_payload_token(current)
+        incoming_token = cls._account_payload_token(incoming)
+        incoming_wins = (
+            incoming_token == current_token
+            or cls._access_token_rank(incoming_token) >= cls._access_token_rank(current_token)
+        )
+        preferred, fallback = (incoming, current) if incoming_wins else (current, incoming)
+        merged = dict(fallback)
+        for key, value in preferred.items():
+            if key not in merged or cls._has_import_value(value):
+                merged[key] = value
+
+        preferred_token = cls._account_payload_token(preferred)
+        merged["access_token"] = preferred_token
+        merged.pop("accessToken", None)
+
+        dated_values = [
+            (parsed, str(item.get("created_at") or "").strip())
+            for item in (current, incoming)
+            if (parsed := cls._parse_time(item.get("created_at"))) is not None
+        ]
+        if dated_values:
+            merged["created_at"] = min(dated_values, key=lambda value: value[0])[1]
+        return merged
+
+    @staticmethod
     def _prepare_account_payload(item: dict) -> dict | None:
         if not isinstance(item, dict):
             return None
@@ -1145,24 +1241,52 @@ class AccountService:
         ])
 
     def _add_account_payloads(self, payloads: list[dict]) -> dict:
-        deduped: dict[str, dict] = {}
+        deduped: dict[tuple[str, str], dict] = {}
+        batch_tokens: dict[tuple[str, str], set[str]] = {}
+        valid_payloads = 0
         for payload in payloads:
             if not isinstance(payload, dict):
                 continue
             access_token = self._account_payload_token(payload)
             if not access_token:
                 continue
-            current = deduped.get(access_token, {})
-            deduped[access_token] = {**current, **payload, "access_token": access_token}
+            valid_payloads += 1
+            prepared = {**payload, "access_token": access_token}
+            identity_key = self._account_identity_key(prepared)
+            dedupe_key = identity_key or ("access_token", access_token)
+            batch_tokens.setdefault(dedupe_key, set()).add(access_token)
+            current = deduped.get(dedupe_key)
+            if current is None:
+                deduped[dedupe_key] = prepared
+                continue
+
+            deduped[dedupe_key] = self._merge_duplicate_payloads(current, prepared)
 
         if not deduped:
             return {"added": 0, "skipped": 0, "items": self.list_accounts()}
 
         with self._lock:
             added = 0
-            skipped = 0
-            for access_token, payload in deduped.items():
-                current = self._accounts.get(access_token)
+            skipped = max(0, valid_payloads - len(deduped))
+            identity_index: dict[tuple[str, str], str] = {}
+            for existing_token, existing_account in self._accounts.items():
+                identity_key = self._account_identity_key(existing_account)
+                if identity_key is None:
+                    continue
+                indexed_token = identity_index.get(identity_key)
+                if (
+                    indexed_token is None
+                    or self._access_token_rank(existing_token) >= self._access_token_rank(indexed_token)
+                ):
+                    identity_index[identity_key] = existing_token
+
+            for dedupe_key, payload in deduped.items():
+                incoming_token = self._account_payload_token(payload)
+                identity_key = self._account_identity_key(payload)
+                current_token = incoming_token if incoming_token in self._accounts else None
+                if current_token is None and identity_key is not None:
+                    current_token = identity_index.get(identity_key)
+                current = self._accounts.get(current_token) if current_token else None
                 if current is None:
                     added += 1
                     self._cumulative_total += 1
@@ -1170,19 +1294,34 @@ class AccountService:
                     current = {"created_at": self._now()}
                 else:
                     skipped += 1
-                incoming = dict(payload)
+
+                incoming = self._merge_duplicate_payloads(current, payload)
+                access_token = self._account_payload_token(incoming)
                 if not incoming.get("created_at"):
                     incoming.pop("created_at", None)
                 account = self._normalize_account(
                     {
-                        **current,
                         **incoming,
                         "access_token": access_token,
-                        "type": str(incoming.get("type") or current.get("type") or "free"),
+                        "type": str(incoming.get("type") or "free"),
                     }
                 )
                 if account is not None:
+                    if current_token and current_token != access_token:
+                        self._accounts.pop(current_token, None)
+                        self._token_aliases[current_token] = access_token
+                        old_inflight = int(self._image_inflight.pop(current_token, 0))
+                        if old_inflight:
+                            current_inflight = int(self._image_inflight.get(access_token, 0))
+                            self._image_inflight[access_token] = current_inflight + old_inflight
                     self._accounts[access_token] = account
+                    if incoming_token != access_token:
+                        self._token_aliases[incoming_token] = access_token
+                    for duplicate_token in batch_tokens[dedupe_key]:
+                        if duplicate_token != access_token:
+                            self._token_aliases[duplicate_token] = access_token
+                    if identity_key is not None:
+                        identity_index[identity_key] = access_token
             self._save_accounts()
             items = [dict(item) for item in self._accounts.values()]
             log_service.add(LOG_TYPE_ACCOUNT, f"新增 {added} 个账号，跳过 {skipped} 个",
@@ -1486,7 +1625,12 @@ class AccountService:
         progress_id: str | None = None,
         defer_invalid_removal: bool = True,
     ) -> dict[str, Any]:
-        access_tokens = list(dict.fromkeys(token for token in access_tokens if token))
+        with self._lock:
+            access_tokens = list(dict.fromkeys(
+                self._resolve_access_token_locked(token)
+                for token in access_tokens
+                if token
+            ))
         if not access_tokens:
             items = self.list_accounts()
             result = {"refreshed": 0, "errors": [], "items": items, "relogined": 0}

--- a/test/test_account_deduplication.py
+++ b/test/test_account_deduplication.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import base64
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+from services.account_service import AccountService
+from services.storage.database_storage import DatabaseStorageBackend
+from services.storage.json_storage import JSONStorageBackend
+
+
+class MemoryStorage:
+    def __init__(self, accounts: list[dict[str, Any]] | None = None) -> None:
+        self.accounts = [dict(item) for item in accounts or []]
+
+    def load_accounts(self) -> list[dict[str, Any]]:
+        return [dict(item) for item in self.accounts]
+
+    def save_accounts(self, accounts: list[dict[str, Any]]) -> None:
+        self.accounts = [dict(item) for item in accounts]
+
+    def load_auth_keys(self) -> list[dict[str, Any]]:
+        return []
+
+    def save_auth_keys(self, auth_keys: list[dict[str, Any]]) -> None:
+        pass
+
+    def health_check(self) -> dict[str, Any]:
+        return {"ok": True}
+
+    def get_backend_info(self) -> dict[str, Any]:
+        return {"type": "memory"}
+
+
+class IsolatedAccountService(AccountService):
+    def _load_cumulative_total(self) -> int:
+        return len(self._accounts)
+
+    def _save_cumulative_total(self) -> None:
+        pass
+
+
+def make_jwt(payload: dict[str, Any]) -> str:
+    def encode(value: dict[str, Any]) -> str:
+        raw = json.dumps(value, separators=(",", ":")).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+    return f'{encode({"alg": "none", "typ": "JWT"})}.{encode(payload)}.sig'
+
+
+def make_access_token(
+    *,
+    account_id: str = "",
+    subject: str = "",
+    email: str = "",
+    exp: int = 0,
+    iat: int = 0,
+) -> str:
+    payload: dict[str, Any] = {"exp": exp, "iat": iat}
+    if account_id:
+        payload["https://api.openai.com/auth"] = {"chatgpt_account_id": account_id}
+    if subject:
+        payload["sub"] = subject
+    if email:
+        payload["https://api.openai.com/profile"] = {"email": email}
+    return make_jwt(payload)
+
+
+class AccountDeduplicationTests(unittest.TestCase):
+    def test_cpa_batch_keeps_only_the_token_with_the_latest_expiry(self) -> None:
+        old_token = make_access_token(
+            account_id="acct-1",
+            subject="user-1",
+            email="same@example.com",
+            exp=100,
+            iat=10,
+        )
+        new_token = make_access_token(
+            account_id="acct-1",
+            subject="user-1",
+            email="same@example.com",
+            exp=200,
+            iat=20,
+        )
+        service = IsolatedAccountService(MemoryStorage())
+
+        result = service.add_accounts([old_token, new_token], source_type="codex")
+
+        self.assertEqual(result["added"], 1)
+        self.assertEqual(result["skipped"], 1)
+        self.assertEqual(service.list_tokens(), [new_token])
+        self.assertEqual(service.get_account(old_token)["access_token"], new_token)
+
+    def test_newer_token_replaces_existing_identity_and_preserves_metadata(self) -> None:
+        old_token = make_access_token(account_id="acct-1", exp=100, iat=10)
+        new_token = make_access_token(account_id="acct-1", exp=200, iat=20)
+        service = IsolatedAccountService(
+            MemoryStorage(
+                [
+                    {
+                        "access_token": old_token,
+                        "created_at": "2026-01-01 00:00:00",
+                        "success": 3,
+                        "fail": 1,
+                        "password": "preserved-password",
+                        "status": "正常",
+                    }
+                ]
+            )
+        )
+
+        result = service.add_accounts([new_token], source_type="codex")
+
+        self.assertEqual(result["added"], 0)
+        self.assertEqual(result["skipped"], 1)
+        self.assertEqual(service.list_tokens(), [new_token])
+        account = service.get_account(new_token)
+        self.assertEqual(account["created_at"], "2026-01-01 00:00:00")
+        self.assertEqual(account["success"], 3)
+        self.assertEqual(account["fail"], 1)
+        self.assertEqual(account["password"], "preserved-password")
+        self.assertEqual(service.get_account(old_token)["access_token"], new_token)
+
+    def test_older_import_does_not_replace_a_newer_existing_token(self) -> None:
+        old_token = make_access_token(account_id="acct-1", exp=100, iat=10)
+        new_token = make_access_token(account_id="acct-1", exp=200, iat=20)
+        service = IsolatedAccountService(MemoryStorage([{"access_token": new_token, "success": 4}]))
+
+        result = service.add_accounts([old_token], source_type="codex")
+
+        self.assertEqual(result["added"], 0)
+        self.assertEqual(result["skipped"], 1)
+        self.assertEqual(service.list_tokens(), [new_token])
+        self.assertEqual(service.get_account(old_token)["access_token"], new_token)
+        self.assertEqual(service.get_account(new_token)["success"], 4)
+
+    def test_account_id_keeps_workspaces_separate_even_when_user_and_email_match(self) -> None:
+        personal = make_access_token(
+            account_id="acct-personal",
+            subject="user-1",
+            email="same@example.com",
+            exp=100,
+        )
+        team = make_access_token(
+            account_id="acct-team",
+            subject="user-1",
+            email="same@example.com",
+            exp=200,
+        )
+        service = IsolatedAccountService(MemoryStorage())
+
+        result = service.add_accounts([personal, team], source_type="codex")
+
+        self.assertEqual(result["added"], 2)
+        self.assertEqual(result["skipped"], 0)
+        self.assertCountEqual(service.list_tokens(), [personal, team])
+
+    def test_subject_and_then_email_are_used_when_account_id_is_missing(self) -> None:
+        old_subject_token = make_access_token(subject="user-1", exp=100)
+        new_subject_token = make_access_token(subject="user-1", exp=200)
+        service = IsolatedAccountService(MemoryStorage())
+
+        subject_result = service.add_accounts([old_subject_token, new_subject_token])
+        first_email_token = "opaque-token-1"
+        second_email_token = "opaque-token-2"
+        email_result = service.add_account_items(
+            [
+                {"access_token": first_email_token, "email": " User@Example.com "},
+                {"access_token": second_email_token, "email": "user@example.com"},
+            ]
+        )
+
+        self.assertEqual(subject_result["added"], 1)
+        self.assertEqual(subject_result["skipped"], 1)
+        self.assertEqual(email_result["added"], 1)
+        self.assertEqual(email_result["skipped"], 1)
+        self.assertEqual(len(service.list_tokens()), 2)
+        self.assertIn(new_subject_token, service.list_tokens())
+        self.assertIn(second_email_token, service.list_tokens())
+
+    def test_repeated_opaque_tokens_do_not_create_an_alias_cycle(self) -> None:
+        service = IsolatedAccountService(MemoryStorage())
+
+        result = service.add_account_items(
+            [
+                {"access_token": "opaque-a", "email": "same@example.com"},
+                {"access_token": "opaque-b", "email": "same@example.com"},
+                {"access_token": "opaque-a", "email": "same@example.com"},
+            ]
+        )
+
+        self.assertEqual(result["added"], 1)
+        self.assertEqual(result["skipped"], 2)
+        self.assertEqual(service.list_tokens(), ["opaque-a"])
+        self.assertEqual(service.resolve_access_token("opaque-b"), "opaque-a")
+
+    def test_token_account_id_takes_precedence_over_stale_import_metadata(self) -> None:
+        old_token = make_access_token(account_id="acct-1", exp=100)
+        new_token = make_access_token(account_id="acct-1", exp=200)
+        service = IsolatedAccountService(MemoryStorage())
+
+        result = service.add_account_items(
+            [
+                {"access_token": old_token, "account_id": "stale-old"},
+                {"access_token": new_token, "account_id": "stale-new"},
+            ]
+        )
+
+        self.assertEqual(result["added"], 1)
+        self.assertEqual(result["skipped"], 1)
+        self.assertEqual(service.list_tokens(), [new_token])
+
+    def test_refresh_accounts_resolves_aliases_before_deduplicating(self) -> None:
+        old_token = make_access_token(account_id="acct-1", exp=100)
+        new_token = make_access_token(account_id="acct-1", exp=200)
+        service = IsolatedAccountService(MemoryStorage())
+        service.add_accounts([old_token, new_token], source_type="codex")
+
+        with mock.patch.object(
+            service,
+            "fetch_remote_info",
+            side_effect=lambda token, *_args: service.get_account(token),
+        ) as fetch_remote_info:
+            result = service.refresh_accounts([old_token, new_token])
+
+        self.assertEqual(result["refreshed"], 1)
+        fetch_remote_info.assert_called_once()
+        self.assertEqual(fetch_remote_info.call_args.args[0], new_token)
+
+    def test_replaced_token_is_persisted_by_json_and_database_backends(self) -> None:
+        old_token = make_access_token(account_id="acct-1", exp=100, iat=10)
+        new_token = make_access_token(account_id="acct-1", exp=200, iat=20)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            backends = [
+                JSONStorageBackend(root / "accounts.json"),
+                DatabaseStorageBackend(f"sqlite:///{root / 'accounts.db'}"),
+            ]
+            try:
+                for backend in backends:
+                    service = IsolatedAccountService(backend)
+                    service.add_accounts([old_token], source_type="codex")
+                    service.add_accounts([new_token], source_type="codex")
+
+                    reloaded = IsolatedAccountService(backend)
+                    self.assertEqual(reloaded.list_tokens(), [new_token])
+            finally:
+                for backend in backends:
+                    if isinstance(backend, DatabaseStorageBackend):
+                        backend.engine.dispose()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- deduplicate account imports by stable identity instead of the full access-token string
- prefer `chatgpt_account_id` so separate workspaces remain separate, with subject/email fallbacks only when the account ID is absent
- keep the longest-lived token, preserve existing account metadata and creation time, and migrate token aliases plus image in-flight state
- resolve token aliases before batch refresh so one imported account is not refreshed multiple times

## Root cause

All account import paths converge on `AccountService._add_account_payloads`:

- CPA
- Sub2API
- manual token/JSON import
- OAuth login

The shared method only deduplicated exact access-token strings. A refreshed token therefore created a second pool entry for the same ChatGPT account, and the subsequent refresh phase also requested that account twice.

## Tests

- regression-first check on upstream `main`: 7 of 8 new behavior tests failed before the fix
- 25 focused account/export/capability tests pass
- JSON and SQLite persistence both retain only the replacement token after reload
- 140 offline tests across 21 isolated modules pass
- a 1,577-token synthetic import matching the reported pool shape produces 1,507 unique accounts and 70 skipped duplicates

Baseline note: five unrelated image tests fail identically on unmodified upstream commit `e55aef2` and this branch; they were excluded from the isolated 140-test pass set.