### PR TITLE
fix: preserve Workbench account and conversation bindings

### DIFF
--- a/api/ai.py
+++ b/api/ai.py
@@ -8,6 +8,10 @@ from pydantic import BaseModel, ConfigDict, Field
 from api.image_inputs import parse_image_edit_request, read_image_sources
 from api.support import require_identity, resolve_image_base_url
 from services.content_filter import check_request, request_shape, request_text
+from services.conversation_binding_service import (
+    ConversationBindingError,
+    conversation_binding_service,
+)
 from services.editable_file_task_service import editable_file_task_service
 from services.log_service import LoggedCall
 from services.protocol import (
@@ -49,6 +53,17 @@ class ResponseCreateRequest(BaseModel):
     tools: list[dict[str, object]] | None = None
     tool_choice: object | None = None
     stream: bool | None = None
+
+
+class ConversationBindingTextRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    model: str = "auto"
+    image_model: str = "gpt-image-2"
+    messages: list[dict[str, object]]
+    thinking_effort: str = "standard"
+    provider_binding_id: str | None = None
+    conversation_id: str | None = None
+    parent_message_id: str | None = None
 
 
 class AnthropicMessageRequest(BaseModel):
@@ -151,6 +166,32 @@ def create_router() -> APIRouter:
         )
         await filter_or_log(call, request_preview)
         return await call.run(openai_v1_response.handle, payload)
+
+    @router.post("/api/conversation-bindings/text")
+    async def continue_bound_text(
+            body: ConversationBindingTextRequest,
+            authorization: str | None = Header(default=None),
+    ):
+        identity = require_identity(authorization)
+        payload = body.model_dump(mode="python")
+        request_preview = request_text(payload.get("messages"))
+        await filter_or_log(
+            LoggedCall(
+                identity,
+                "/api/conversation-bindings/text",
+                body.model,
+                "绑定会话文本",
+                request_text=request_preview,
+            ),
+            request_preview,
+        )
+        try:
+            return await run_in_threadpool(conversation_binding_service.complete_text, payload)
+        except ConversationBindingError as exc:
+            raise HTTPException(
+                status_code=409,
+                detail={"code": exc.code, "error": str(exc)},
+            ) from exc
 
     @router.post("/v1/messages")
     async def create_message(

--- a/api/ai.py
+++ b/api/ai.py
@@ -62,6 +62,8 @@ class ConversationBindingTextRequest(BaseModel):
     messages: list[dict[str, object]]
     thinking_effort: str = "standard"
     provider_binding_id: str | None = None
+    provider_account_identity: str | None = None
+    client_conversation_id: str
     conversation_id: str | None = None
     parent_message_id: str | None = None
 
@@ -188,9 +190,22 @@ def create_router() -> APIRouter:
         try:
             return await run_in_threadpool(conversation_binding_service.complete_text, payload)
         except ConversationBindingError as exc:
+            detail = {"code": exc.code, "error": str(exc)}
+            for key in (
+                "provider_binding_id",
+                "provider_account_identity",
+                "conversation_id",
+                "parent_message_id",
+            ):
+                value = str(getattr(exc, key, "") or "").strip()
+                if value:
+                    detail[key] = value
+            detail["binding_status"] = (
+                "unknown" if exc.code == "CONVERSATION_OUTCOME_UNKNOWN" else "unavailable"
+            )
             raise HTTPException(
                 status_code=409,
-                detail={"code": exc.code, "error": str(exc)},
+                detail=detail,
             ) from exc
 
     @router.post("/v1/messages")

--- a/api/image_inputs.py
+++ b/api/image_inputs.py
@@ -76,7 +76,13 @@ def _payload_from_fields(fields: dict[str, Any]) -> dict[str, Any]:
     }
     if "client_task_id" in fields:
         payload["client_task_id"] = _clean(fields.get("client_task_id"))
-    for field in ("provider_binding_id", "conversation_id", "parent_message_id"):
+    for field in (
+        "provider_binding_id",
+        "provider_account_identity",
+        "client_conversation_id",
+        "conversation_id",
+        "parent_message_id",
+    ):
         if field in fields:
             payload[field] = _clean(fields.get(field))
     if "retain_conversation" in fields:

--- a/api/image_inputs.py
+++ b/api/image_inputs.py
@@ -76,6 +76,11 @@ def _payload_from_fields(fields: dict[str, Any]) -> dict[str, Any]:
     }
     if "client_task_id" in fields:
         payload["client_task_id"] = _clean(fields.get("client_task_id"))
+    for field in ("provider_binding_id", "conversation_id", "parent_message_id"):
+        if field in fields:
+            payload[field] = _clean(fields.get(field))
+    if "retain_conversation" in fields:
+        payload["retain_conversation"] = bool(_parse_bool(fields.get("retain_conversation")))
     return payload
 
 

--- a/api/image_tasks.py
+++ b/api/image_tasks.py
@@ -18,6 +18,8 @@ class ImageGenerationTaskRequest(BaseModel):
     size: str | None = None
     quality: str = "auto"
     provider_binding_id: str = ""
+    provider_account_identity: str = ""
+    client_conversation_id: str = ""
     conversation_id: str = ""
     parent_message_id: str = ""
     retain_conversation: bool = False
@@ -69,6 +71,8 @@ def create_router() -> APIRouter:
                 quality=body.quality,
                 base_url=resolve_image_base_url(request),
                 provider_binding_id=body.provider_binding_id,
+                provider_account_identity=body.provider_account_identity,
+                client_conversation_id=body.client_conversation_id,
                 conversation_id=body.conversation_id,
                 parent_message_id=body.parent_message_id,
                 retain_conversation=body.retain_conversation,
@@ -104,6 +108,8 @@ def create_router() -> APIRouter:
                 images=images,
                 masks=masks,
                 provider_binding_id=str(payload.get("provider_binding_id") or ""),
+                provider_account_identity=str(payload.get("provider_account_identity") or ""),
+                client_conversation_id=str(payload.get("client_conversation_id") or ""),
                 conversation_id=str(payload.get("conversation_id") or ""),
                 parent_message_id=str(payload.get("parent_message_id") or ""),
                 retain_conversation=bool(payload.get("retain_conversation")),

--- a/api/image_tasks.py
+++ b/api/image_tasks.py
@@ -17,6 +17,10 @@ class ImageGenerationTaskRequest(BaseModel):
     model: str = "gpt-image-2"
     size: str | None = None
     quality: str = "auto"
+    provider_binding_id: str = ""
+    conversation_id: str = ""
+    parent_message_id: str = ""
+    retain_conversation: bool = False
 
 
 class ResumePollRequest(BaseModel):
@@ -64,6 +68,10 @@ def create_router() -> APIRouter:
                 size=body.size,
                 quality=body.quality,
                 base_url=resolve_image_base_url(request),
+                provider_binding_id=body.provider_binding_id,
+                conversation_id=body.conversation_id,
+                parent_message_id=body.parent_message_id,
+                retain_conversation=body.retain_conversation,
             )
         except ValueError as exc:
             raise HTTPException(status_code=400, detail={"error": str(exc)}) from exc
@@ -95,6 +103,10 @@ def create_router() -> APIRouter:
                 base_url=resolve_image_base_url(request),
                 images=images,
                 masks=masks,
+                provider_binding_id=str(payload.get("provider_binding_id") or ""),
+                conversation_id=str(payload.get("conversation_id") or ""),
+                parent_message_id=str(payload.get("parent_message_id") or ""),
+                retain_conversation=bool(payload.get("retain_conversation")),
             )
         except ValueError as exc:
             raise HTTPException(status_code=400, detail={"error": str(exc)}) from exc

--- a/services/account_service.py
+++ b/services/account_service.py
@@ -58,12 +58,14 @@ class AccountService:
         self._token_aliases: dict[str, str] = {}
         self._cumulative_total = self._load_cumulative_total()
 
-    def conversation_binding_lock(self, binding_id: str) -> Lock:
+    def conversation_binding_lock(self, binding_id: str, client_conversation_id: str = "") -> Lock:
         expected = str(binding_id or "").strip()
         if not expected:
             raise RuntimeError("conversation binding unavailable: binding id is required")
+        conversation_key = str(client_conversation_id or "").strip()
+        lock_key = f"{expected}:{conversation_key}" if conversation_key else expected
         with self._lock:
-            return self._conversation_binding_locks.setdefault(expected, Lock())
+            return self._conversation_binding_locks.setdefault(lock_key, Lock())
 
     def _get_cumulative_file(self) -> Path:
         from services.config import DATA_DIR
@@ -1027,6 +1029,21 @@ class AccountService:
         self._save_accounts()
         return binding_id
 
+    def _provider_account_identity_for_token_locked(self, access_token: str) -> str:
+        resolved = self._resolve_access_token_locked(access_token)
+        account = self._accounts.get(resolved)
+        if account is None:
+            raise RuntimeError("conversation binding unavailable: account missing")
+        identity = str(account.get("provider_account_identity") or "").strip()
+        if identity:
+            return identity
+        identity = f"account_{uuid.uuid4().hex}"
+        account = dict(account)
+        account["provider_account_identity"] = identity
+        self._accounts[resolved] = account
+        self._save_accounts()
+        return identity
+
     def _bound_token_locked(self, binding_id: str) -> str:
         expected = str(binding_id or "").strip()
         if not expected:
@@ -1057,7 +1074,7 @@ class AccountService:
             ("plus", "team", "pro") if codex_model and not plan_type else None,
         )
 
-    def create_conversation_binding(self, *, image_model: str) -> tuple[str, str]:
+    def create_conversation_binding(self, *, image_model: str) -> tuple[str, str, str]:
         plan_type, source_type, plan_types = self._image_route(image_model)
         access_token = self.get_available_access_token(
             plan_type=plan_type,
@@ -1066,7 +1083,13 @@ class AccountService:
         )
         with self._lock:
             binding_id = self._conversation_binding_for_token_locked(access_token)
-        return binding_id, access_token
+            account_identity = self._provider_account_identity_for_token_locked(access_token)
+        return binding_id, account_identity, access_token
+
+    def get_bound_account_identity(self, binding_id: str) -> str:
+        with self._lock:
+            access_token = self._bound_token_locked(binding_id)
+            return self._provider_account_identity_for_token_locked(access_token)
 
     def acquire_bound_image_access_token(
             self,

--- a/services/account_service.py
+++ b/services/account_service.py
@@ -18,7 +18,7 @@ from services.log_service import (
     log_service,
 )
 from services.storage.base import StorageBackend
-from utils.helper import anonymize_token
+from utils.helper import anonymize_token, is_codex_image_model, split_image_model
 
 
 class AccountService:
@@ -54,8 +54,16 @@ class AccountService:
         self._index = 0
         self._accounts = self._load_accounts()
         self._image_inflight: dict[str, int] = {}
+        self._conversation_binding_locks: dict[str, Lock] = {}
         self._token_aliases: dict[str, str] = {}
         self._cumulative_total = self._load_cumulative_total()
+
+    def conversation_binding_lock(self, binding_id: str) -> Lock:
+        expected = str(binding_id or "").strip()
+        if not expected:
+            raise RuntimeError("conversation binding unavailable: binding id is required")
+        with self._lock:
+            return self._conversation_binding_locks.setdefault(expected, Lock())
 
     def _get_cumulative_file(self) -> Path:
         from services.config import DATA_DIR
@@ -996,6 +1004,110 @@ class AccountService:
             f"no available {plan_type or source_type or ''} image quota (tried {len(attempted_tokens)} tokens)".replace("  ", " ").strip()
             if plan_type or source_type else f"no available image quota (tried {len(attempted_tokens)} tokens)"
         )
+
+    def _conversation_binding_for_token_locked(self, access_token: str) -> str:
+        resolved = self._resolve_access_token_locked(access_token)
+        account = self._accounts.get(resolved)
+        if account is None:
+            raise RuntimeError("conversation binding unavailable: account missing")
+        binding_id = f"cb_{uuid.uuid4().hex}"
+        account = dict(account)
+        bindings = {
+            str(item).strip()
+            for item in account.get("conversation_binding_ids") or []
+            if str(item).strip()
+        }
+        legacy = str(account.get("conversation_binding_id") or "").strip()
+        if legacy:
+            bindings.add(legacy)
+        bindings.add(binding_id)
+        account["conversation_binding_ids"] = sorted(bindings)
+        account.pop("conversation_binding_id", None)
+        self._accounts[resolved] = account
+        self._save_accounts()
+        return binding_id
+
+    def _bound_token_locked(self, binding_id: str) -> str:
+        expected = str(binding_id or "").strip()
+        if not expected:
+            raise RuntimeError("conversation binding unavailable: binding id is required")
+        matches = [
+            token
+            for token, account in self._accounts.items()
+            if (
+                str(account.get("conversation_binding_id") or "").strip() == expected
+                or expected
+                in {
+                    str(item).strip()
+                    for item in account.get("conversation_binding_ids") or []
+                }
+            )
+        ]
+        if len(matches) != 1:
+            raise RuntimeError("conversation binding unavailable: bound account missing")
+        return matches[0]
+
+    @staticmethod
+    def _image_route(model: str) -> tuple[str | None, str | None, tuple[str, ...] | None]:
+        plan_type, _ = split_image_model(model)
+        codex_model = is_codex_image_model(model)
+        return (
+            plan_type,
+            "codex" if codex_model else None,
+            ("plus", "team", "pro") if codex_model and not plan_type else None,
+        )
+
+    def create_conversation_binding(self, *, image_model: str) -> tuple[str, str]:
+        plan_type, source_type, plan_types = self._image_route(image_model)
+        access_token = self.get_available_access_token(
+            plan_type=plan_type,
+            source_type=source_type,
+            plan_types=plan_types,
+        )
+        with self._lock:
+            binding_id = self._conversation_binding_for_token_locked(access_token)
+        return binding_id, access_token
+
+    def acquire_bound_image_access_token(
+            self,
+            binding_id: str,
+            *,
+            image_model: str,
+    ) -> str:
+        plan_type, source_type, plan_types = self._image_route(image_model)
+        max_concurrency = max(1, int(config.image_account_concurrency or 1))
+        with self._image_slot_condition:
+            while True:
+                access_token = self._bound_token_locked(binding_id)
+                account = self._accounts.get(access_token) or {}
+                if (
+                        not self._is_image_account_available(account)
+                        or not self._account_matches_plan_type(account, plan_type)
+                        or not self._account_matches_any_plan_type(account, plan_types)
+                        or not self._account_matches_source_type(account, source_type)
+                ):
+                    raise RuntimeError("conversation binding unavailable: bound account cannot generate images")
+                if int(self._image_inflight.get(access_token, 0)) < max_concurrency:
+                    self._image_inflight[access_token] = int(self._image_inflight.get(access_token, 0)) + 1
+                    return access_token
+                self._image_slot_condition.wait(timeout=1.0)
+
+    def get_bound_text_access_token(self, binding_id: str, *, model: str) -> str:
+        with self._lock:
+            access_token = self._bound_token_locked(binding_id)
+            account = self._accounts.get(access_token) or {}
+            if account.get("status") in {"禁用", "异常"}:
+                raise RuntimeError("conversation binding unavailable: bound account cannot serve text")
+            if model and model != "auto":
+                from services.model_service import model_catalog_service
+
+                route = model_catalog_service.route_for_model(model)
+                if self._normalize_account_type(account.get("type")) not in route.account_types:
+                    raise RuntimeError("conversation binding unavailable: bound account cannot serve model")
+        refreshed = self.refresh_access_token(access_token, event="conversation_binding_text")
+        if not refreshed:
+            raise RuntimeError("conversation binding unavailable: bound account token refresh failed")
+        return refreshed
 
     def get_text_access_token(
             self,

--- a/services/conversation_binding_service.py
+++ b/services/conversation_binding_service.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from typing import Any
+
+from services.account_service import account_service
+from services.openai_backend_api import OpenAIBackendAPI
+from services.protocol.conversation import conversation_events
+
+
+class ConversationBindingError(RuntimeError):
+    def __init__(self, message: str, *, code: str = "CONVERSATION_BINDING_UNAVAILABLE") -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class ConversationBindingService:
+    def complete_text(self, body: dict[str, Any]) -> dict[str, Any]:
+        binding_id = str(body.get("provider_binding_id") or "").strip()
+        conversation_id = str(body.get("conversation_id") or "").strip()
+        parent_message_id = str(body.get("parent_message_id") or "").strip()
+        model = str(body.get("model") or "auto").strip() or "auto"
+        image_model = str(body.get("image_model") or "gpt-image-2").strip() or "gpt-image-2"
+        messages = body.get("messages")
+        if not isinstance(messages, list) or not messages:
+            raise ConversationBindingError(
+                "conversation messages are required",
+                code="CONVERSATION_BINDING_CONTRACT_INVALID",
+            )
+        if binding_id:
+            if not conversation_id or not parent_message_id:
+                raise ConversationBindingError(
+                    "bound conversation requires conversation_id and parent_message_id",
+                    code="CONVERSATION_BINDING_CONTRACT_INVALID",
+                )
+        elif conversation_id or parent_message_id:
+            raise ConversationBindingError(
+                "upstream cursor requires provider_binding_id",
+                code="CONVERSATION_BINDING_CONTRACT_INVALID",
+            )
+        else:
+            try:
+                binding_id, image_token = account_service.create_conversation_binding(
+                    image_model=image_model
+                )
+                account_service.release_image_slot(image_token)
+            except RuntimeError as exc:
+                raise ConversationBindingError(str(exc)) from exc
+
+        try:
+            access_token = account_service.get_bound_text_access_token(
+                binding_id,
+                model=model,
+            )
+        except RuntimeError as exc:
+            raise ConversationBindingError(str(exc)) from exc
+
+        with account_service.conversation_binding_lock(binding_id):
+            backend = OpenAIBackendAPI(access_token=access_token)
+            try:
+                parts: list[str] = []
+                returned_conversation_id = ""
+                for event in conversation_events(
+                    backend,
+                    messages=messages,
+                    model=model,
+                    thinking_effort=str(body.get("thinking_effort") or ""),
+                    conversation_id=conversation_id,
+                    parent_message_id=parent_message_id,
+                ):
+                    returned_conversation_id = str(
+                        event.get("conversation_id") or returned_conversation_id
+                    )
+                    if event.get("type") == "conversation.delta":
+                        delta = str(event.get("delta") or "")
+                        if delta:
+                            parts.append(delta)
+                if not returned_conversation_id:
+                    raise ConversationBindingError(
+                        "upstream response has no conversation_id",
+                        code="CONVERSATION_OUTCOME_UNKNOWN",
+                    )
+                if conversation_id and returned_conversation_id != conversation_id:
+                    raise ConversationBindingError(
+                        "upstream conversation identity changed",
+                        code="CONVERSATION_BINDING_MISMATCH",
+                    )
+                content = "".join(parts).strip()
+                if not content:
+                    raise ConversationBindingError(
+                        "upstream response was empty",
+                        code="CONVERSATION_OUTCOME_UNKNOWN",
+                    )
+                next_parent_message_id = backend.get_conversation_parent_message_id(
+                    returned_conversation_id
+                )
+                account_service.mark_text_used(access_token)
+                return {
+                    "content": content,
+                    "provider_binding_id": binding_id,
+                    "conversation_id": returned_conversation_id,
+                    "parent_message_id": next_parent_message_id,
+                    "binding_status": "bound",
+                }
+            finally:
+                backend.close()
+
+
+conversation_binding_service = ConversationBindingService()

--- a/services/conversation_binding_service.py
+++ b/services/conversation_binding_service.py
@@ -8,14 +8,29 @@ from services.protocol.conversation import conversation_events
 
 
 class ConversationBindingError(RuntimeError):
-    def __init__(self, message: str, *, code: str = "CONVERSATION_BINDING_UNAVAILABLE") -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str = "CONVERSATION_BINDING_UNAVAILABLE",
+        provider_binding_id: str = "",
+        provider_account_identity: str = "",
+        conversation_id: str = "",
+        parent_message_id: str = "",
+    ) -> None:
         super().__init__(message)
         self.code = code
+        self.provider_binding_id = provider_binding_id
+        self.provider_account_identity = provider_account_identity
+        self.conversation_id = conversation_id
+        self.parent_message_id = parent_message_id
 
 
 class ConversationBindingService:
     def complete_text(self, body: dict[str, Any]) -> dict[str, Any]:
         binding_id = str(body.get("provider_binding_id") or "").strip()
+        account_identity = str(body.get("provider_account_identity") or "").strip()
+        client_conversation_id = str(body.get("client_conversation_id") or "").strip()
         conversation_id = str(body.get("conversation_id") or "").strip()
         parent_message_id = str(body.get("parent_message_id") or "").strip()
         model = str(body.get("model") or "auto").strip() or "auto"
@@ -26,11 +41,30 @@ class ConversationBindingService:
                 "conversation messages are required",
                 code="CONVERSATION_BINDING_CONTRACT_INVALID",
             )
+        if not client_conversation_id:
+            raise ConversationBindingError(
+                "client_conversation_id is required",
+                code="CONVERSATION_BINDING_CONTRACT_INVALID",
+            )
         if binding_id:
-            if not conversation_id or not parent_message_id:
+            if not account_identity:
                 raise ConversationBindingError(
-                    "bound conversation requires conversation_id and parent_message_id",
+                    "provider account identity is required for a bound account",
                     code="CONVERSATION_BINDING_CONTRACT_INVALID",
+                )
+            if bool(conversation_id) != bool(parent_message_id):
+                raise ConversationBindingError(
+                    "conversation continuation requires conversation_id and parent_message_id",
+                    code="CONVERSATION_BINDING_CONTRACT_INVALID",
+                )
+            try:
+                authoritative_identity = account_service.get_bound_account_identity(binding_id)
+            except RuntimeError as exc:
+                raise ConversationBindingError(str(exc)) from exc
+            if authoritative_identity != account_identity:
+                raise ConversationBindingError(
+                    "provider account identity changed",
+                    code="CONVERSATION_BINDING_MISMATCH",
                 )
         elif conversation_id or parent_message_id:
             raise ConversationBindingError(
@@ -39,7 +73,7 @@ class ConversationBindingService:
             )
         else:
             try:
-                binding_id, image_token = account_service.create_conversation_binding(
+                binding_id, account_identity, image_token = account_service.create_conversation_binding(
                     image_model=image_model
                 )
                 account_service.release_image_slot(image_token)
@@ -54,7 +88,7 @@ class ConversationBindingService:
         except RuntimeError as exc:
             raise ConversationBindingError(str(exc)) from exc
 
-        with account_service.conversation_binding_lock(binding_id):
+        with account_service.conversation_binding_lock(binding_id, client_conversation_id):
             backend = OpenAIBackendAPI(access_token=access_token)
             try:
                 parts: list[str] = []
@@ -78,17 +112,25 @@ class ConversationBindingService:
                     raise ConversationBindingError(
                         "upstream response has no conversation_id",
                         code="CONVERSATION_OUTCOME_UNKNOWN",
+                        provider_binding_id=binding_id,
+                        provider_account_identity=account_identity,
                     )
                 if conversation_id and returned_conversation_id != conversation_id:
                     raise ConversationBindingError(
                         "upstream conversation identity changed",
                         code="CONVERSATION_BINDING_MISMATCH",
+                        provider_binding_id=binding_id,
+                        provider_account_identity=account_identity,
+                        conversation_id=returned_conversation_id,
                     )
                 content = "".join(parts).strip()
                 if not content:
                     raise ConversationBindingError(
                         "upstream response was empty",
                         code="CONVERSATION_OUTCOME_UNKNOWN",
+                        provider_binding_id=binding_id,
+                        provider_account_identity=account_identity,
+                        conversation_id=returned_conversation_id,
                     )
                 next_parent_message_id = backend.get_conversation_parent_message_id(
                     returned_conversation_id
@@ -97,10 +139,30 @@ class ConversationBindingService:
                 return {
                     "content": content,
                     "provider_binding_id": binding_id,
+                    "provider_account_identity": account_identity,
                     "conversation_id": returned_conversation_id,
                     "parent_message_id": next_parent_message_id,
                     "binding_status": "bound",
                 }
+            except ConversationBindingError:
+                raise
+            except Exception as exc:
+                recovered_parent = ""
+                if returned_conversation_id:
+                    try:
+                        recovered_parent = backend.get_conversation_parent_message_id(
+                            returned_conversation_id
+                        )
+                    except Exception:
+                        pass
+                raise ConversationBindingError(
+                    str(exc) or "upstream conversation outcome is unknown",
+                    code="CONVERSATION_OUTCOME_UNKNOWN",
+                    provider_binding_id=binding_id,
+                    provider_account_identity=account_identity,
+                    conversation_id=returned_conversation_id,
+                    parent_message_id=recovered_parent,
+                ) from exc
             finally:
                 backend.close()
 

--- a/services/image_task_service.py
+++ b/services/image_task_service.py
@@ -74,6 +74,9 @@ def _public_task(task: dict[str, Any]) -> dict[str, Any]:
     }
     if task.get("conversation_id"):
         item["conversation_id"] = task.get("conversation_id")
+    for field in ("provider_binding_id", "parent_message_id", "binding_status", "error_code"):
+        if task.get(field):
+            item[field] = task.get(field)
     if task.get("data") is not None:
         item["data"] = task.get("data")
     if task.get("usage") is not None:
@@ -129,6 +132,10 @@ class ImageTaskService:
         size: str | None,
         quality: str = "auto",
         base_url: str = "",
+        provider_binding_id: str = "",
+        conversation_id: str = "",
+        parent_message_id: str = "",
+        retain_conversation: bool = False,
     ) -> dict[str, Any]:
         payload = {
             "prompt": prompt,
@@ -138,6 +145,10 @@ class ImageTaskService:
             "quality": quality,
             "response_format": "url",
             "base_url": base_url,
+            "provider_binding_id": provider_binding_id,
+            "conversation_id": conversation_id,
+            "parent_message_id": parent_message_id,
+            "retain_conversation": retain_conversation,
         }
         return self._submit(identity, client_task_id=client_task_id, mode="generate", payload=payload)
 
@@ -153,6 +164,10 @@ class ImageTaskService:
         base_url: str = "",
         images: list[tuple[bytes, str, str]] | None = None,
         masks: list[tuple[bytes, str, str]] | None = None,
+        provider_binding_id: str = "",
+        conversation_id: str = "",
+        parent_message_id: str = "",
+        retain_conversation: bool = False,
     ) -> dict[str, Any]:
         payload = {
             "prompt": prompt,
@@ -164,6 +179,10 @@ class ImageTaskService:
             "quality": quality,
             "response_format": "url",
             "base_url": base_url,
+            "provider_binding_id": provider_binding_id,
+            "conversation_id": conversation_id,
+            "parent_message_id": parent_message_id,
+            "retain_conversation": retain_conversation,
         }
         return self._submit(identity, client_task_id=client_task_id, mode="edit", payload=payload)
 
@@ -224,6 +243,10 @@ class ImageTaskService:
                 "created_at": now,
                 "updated_at": now,
                 "created_ts": time.time(),
+                "provider_binding_id": _clean(payload.get("provider_binding_id")),
+                "conversation_id": _clean(payload.get("conversation_id")),
+                "parent_message_id": _clean(payload.get("parent_message_id")),
+                "binding_status": "bound" if payload.get("provider_binding_id") else "unbound",
             }
             self._tasks[key] = task
             self._save_locked()
@@ -263,6 +286,9 @@ class ImageTaskService:
                 raise RuntimeError("image task returned streaming result unexpectedly")
             data = result.get("data")
             account_email = _clean(result.get("_account_email") or result.get("account_email"))
+            provider_binding_id = _clean(result.get("_provider_binding_id"))
+            conversation_id = _clean(result.get("_conversation_id"))
+            parent_message_id = _clean(result.get("_parent_message_id"))
             if not isinstance(data, list) or not data:
                 upstream = _clean(result.get("message"))
                 if upstream:
@@ -275,7 +301,20 @@ class ImageTaskService:
                 raise error
             usage = result.get("usage")
             duration_ms = int((time.time() - started) * 1000)
-            self._update_task(key, status=TASK_STATUS_SUCCESS, data=data, usage=usage, error="", duration_ms=duration_ms)
+            if bool(provider_binding_id) != bool(conversation_id) or bool(provider_binding_id) != bool(parent_message_id):
+                raise RuntimeError("bound image result is missing authoritative conversation state")
+            self._update_task(
+                key,
+                status=TASK_STATUS_SUCCESS,
+                data=data,
+                usage=usage,
+                error="",
+                duration_ms=duration_ms,
+                provider_binding_id=provider_binding_id,
+                conversation_id=conversation_id,
+                parent_message_id=parent_message_id,
+                binding_status="bound" if provider_binding_id else "unbound",
+            )
             self._log_call(
                 identity,
                 mode,
@@ -290,10 +329,31 @@ class ImageTaskService:
             error_message = str(exc) or "image task failed"
             account_email = _clean(getattr(exc, "account_email", ""))
             conversation_id = _clean(getattr(exc, "conversation_id", ""))
+            provider_binding_id = _clean(getattr(exc, "provider_binding_id", ""))
+            parent_message_id = _clean(getattr(exc, "parent_message_id", ""))
+            error_code = _clean(getattr(exc, "code", ""))
             duration_ms = int((time.time() - started) * 1000)
             self._update_task(key, status=TASK_STATUS_ERROR, error=error_message, data=[],
                               duration_ms=duration_ms,
-                              **({"conversation_id": conversation_id} if conversation_id else {}))
+                              **({"provider_binding_id": provider_binding_id} if provider_binding_id else {}),
+                              **({"conversation_id": conversation_id} if conversation_id else {}),
+                              **({"parent_message_id": parent_message_id} if parent_message_id else {}),
+                              **(
+                                  {
+                                      "binding_status": (
+                                          "bound"
+                                          if conversation_id and parent_message_id
+                                          else (
+                                              "unknown"
+                                              if error_code == "CONVERSATION_OUTCOME_UNKNOWN"
+                                              else "unavailable"
+                                          )
+                                      )
+                                  }
+                                  if provider_binding_id
+                                  else {}
+                              ),
+                              **({"error_code": error_code} if error_code else {}))
             self._log_call(
                 identity,
                 mode,
@@ -391,6 +451,11 @@ class ImageTaskService:
                 "updated_ts": item.get("updated_ts"),
                 "started_ts": item.get("started_ts"),
                 "duration_ms": item.get("duration_ms"),
+                "provider_binding_id": _clean(item.get("provider_binding_id")),
+                "conversation_id": _clean(item.get("conversation_id")),
+                "parent_message_id": _clean(item.get("parent_message_id")),
+                "binding_status": _clean(item.get("binding_status"), "unbound"),
+                "error_code": _clean(item.get("error_code")),
             }
             data = item.get("data")
             if isinstance(data, list):
@@ -416,6 +481,9 @@ class ImageTaskService:
             if task.get("status") in UNFINISHED_STATUSES:
                 task["status"] = TASK_STATUS_ERROR
                 task["error"] = "服务已重启，未完成的图片任务已中断"
+                task["error_code"] = "CONVERSATION_OUTCOME_UNKNOWN"
+                if task.get("provider_binding_id"):
+                    task["binding_status"] = "unknown"
                 task["updated_at"] = _now_iso()
                 changed = True
         return changed

--- a/services/image_task_service.py
+++ b/services/image_task_service.py
@@ -74,7 +74,13 @@ def _public_task(task: dict[str, Any]) -> dict[str, Any]:
     }
     if task.get("conversation_id"):
         item["conversation_id"] = task.get("conversation_id")
-    for field in ("provider_binding_id", "parent_message_id", "binding_status", "error_code"):
+    for field in (
+        "provider_binding_id",
+        "provider_account_identity",
+        "parent_message_id",
+        "binding_status",
+        "error_code",
+    ):
         if task.get(field):
             item[field] = task.get(field)
     if task.get("data") is not None:
@@ -133,6 +139,8 @@ class ImageTaskService:
         quality: str = "auto",
         base_url: str = "",
         provider_binding_id: str = "",
+        provider_account_identity: str = "",
+        client_conversation_id: str = "",
         conversation_id: str = "",
         parent_message_id: str = "",
         retain_conversation: bool = False,
@@ -146,6 +154,8 @@ class ImageTaskService:
             "response_format": "url",
             "base_url": base_url,
             "provider_binding_id": provider_binding_id,
+            "provider_account_identity": provider_account_identity,
+            "client_conversation_id": client_conversation_id,
             "conversation_id": conversation_id,
             "parent_message_id": parent_message_id,
             "retain_conversation": retain_conversation,
@@ -165,6 +175,8 @@ class ImageTaskService:
         images: list[tuple[bytes, str, str]] | None = None,
         masks: list[tuple[bytes, str, str]] | None = None,
         provider_binding_id: str = "",
+        provider_account_identity: str = "",
+        client_conversation_id: str = "",
         conversation_id: str = "",
         parent_message_id: str = "",
         retain_conversation: bool = False,
@@ -180,6 +192,8 @@ class ImageTaskService:
             "response_format": "url",
             "base_url": base_url,
             "provider_binding_id": provider_binding_id,
+            "provider_account_identity": provider_account_identity,
+            "client_conversation_id": client_conversation_id,
             "conversation_id": conversation_id,
             "parent_message_id": parent_message_id,
             "retain_conversation": retain_conversation,
@@ -244,6 +258,7 @@ class ImageTaskService:
                 "updated_at": now,
                 "created_ts": time.time(),
                 "provider_binding_id": _clean(payload.get("provider_binding_id")),
+                "provider_account_identity": _clean(payload.get("provider_account_identity")),
                 "conversation_id": _clean(payload.get("conversation_id")),
                 "parent_message_id": _clean(payload.get("parent_message_id")),
                 "binding_status": "bound" if payload.get("provider_binding_id") else "unbound",
@@ -287,6 +302,7 @@ class ImageTaskService:
             data = result.get("data")
             account_email = _clean(result.get("_account_email") or result.get("account_email"))
             provider_binding_id = _clean(result.get("_provider_binding_id"))
+            provider_account_identity = _clean(result.get("_provider_account_identity"))
             conversation_id = _clean(result.get("_conversation_id"))
             parent_message_id = _clean(result.get("_parent_message_id"))
             if not isinstance(data, list) or not data:
@@ -301,7 +317,11 @@ class ImageTaskService:
                 raise error
             usage = result.get("usage")
             duration_ms = int((time.time() - started) * 1000)
-            if bool(provider_binding_id) != bool(conversation_id) or bool(provider_binding_id) != bool(parent_message_id):
+            if (
+                bool(provider_binding_id) != bool(provider_account_identity)
+                or bool(provider_binding_id) != bool(conversation_id)
+                or bool(provider_binding_id) != bool(parent_message_id)
+            ):
                 raise RuntimeError("bound image result is missing authoritative conversation state")
             self._update_task(
                 key,
@@ -311,6 +331,7 @@ class ImageTaskService:
                 error="",
                 duration_ms=duration_ms,
                 provider_binding_id=provider_binding_id,
+                provider_account_identity=provider_account_identity,
                 conversation_id=conversation_id,
                 parent_message_id=parent_message_id,
                 binding_status="bound" if provider_binding_id else "unbound",
@@ -330,12 +351,14 @@ class ImageTaskService:
             account_email = _clean(getattr(exc, "account_email", ""))
             conversation_id = _clean(getattr(exc, "conversation_id", ""))
             provider_binding_id = _clean(getattr(exc, "provider_binding_id", ""))
+            provider_account_identity = _clean(getattr(exc, "provider_account_identity", ""))
             parent_message_id = _clean(getattr(exc, "parent_message_id", ""))
             error_code = _clean(getattr(exc, "code", ""))
             duration_ms = int((time.time() - started) * 1000)
             self._update_task(key, status=TASK_STATUS_ERROR, error=error_message, data=[],
                               duration_ms=duration_ms,
                               **({"provider_binding_id": provider_binding_id} if provider_binding_id else {}),
+                              **({"provider_account_identity": provider_account_identity} if provider_account_identity else {}),
                               **({"conversation_id": conversation_id} if conversation_id else {}),
                               **({"parent_message_id": parent_message_id} if parent_message_id else {}),
                               **(
@@ -452,6 +475,7 @@ class ImageTaskService:
                 "started_ts": item.get("started_ts"),
                 "duration_ms": item.get("duration_ms"),
                 "provider_binding_id": _clean(item.get("provider_binding_id")),
+                "provider_account_identity": _clean(item.get("provider_account_identity")),
                 "conversation_id": _clean(item.get("conversation_id")),
                 "parent_message_id": _clean(item.get("parent_message_id")),
                 "binding_status": _clean(item.get("binding_status"), "unbound"),

--- a/services/openai_backend_api.py
+++ b/services/openai_backend_api.py
@@ -524,13 +524,15 @@ class OpenAIBackendAPI:
             model: str,
             timezone: str,
             thinking_effort: str = "",
+            conversation_id: str = "",
+            parent_message_id: str = "",
     ) -> Dict[str, Any]:
         """把标准 messages 构造成 web 对话请求体。"""
         payload = {
             "action": "next",
             "messages": self._api_messages_to_conversation_messages(messages),
             "model": model,
-            "parent_message_id": new_uuid(),
+            "parent_message_id": parent_message_id or new_uuid(),
             "conversation_mode": {"kind": "primary_assistant"},
             "conversation_origin": None,
             "force_paragen": False,
@@ -559,6 +561,12 @@ class OpenAIBackendAPI:
         normalized_effort = self._normalize_thinking_effort(thinking_effort or config.default_thinking_effort)
         if normalized_effort:
             payload["thinking_effort"] = normalized_effort
+        if conversation_id:
+            if not parent_message_id:
+                raise RuntimeError("conversation continuation requires parent_message_id")
+            payload["conversation_id"] = conversation_id
+        elif parent_message_id:
+            raise RuntimeError("parent_message_id requires conversation_id")
         return payload
 
     def _image_model_settings(self, model: str) -> tuple[str, str]:
@@ -861,14 +869,21 @@ class OpenAIBackendAPI:
             retry_after = int(retry_after_header) if str(retry_after_header or "").isdigit() else None
             raise UpstreamHTTPError(path, error.code, body, retry_after=retry_after) from error
 
-    def _prepare_image_conversation(self, prompt: str, requirements: ChatRequirements, model: str) -> str:
+    def _prepare_image_conversation(
+            self,
+            prompt: str,
+            requirements: ChatRequirements,
+            model: str,
+            conversation_id: str = "",
+            parent_message_id: str = "",
+    ) -> str:
         """为图片生成准备 conduit token。"""
         path = "/backend-api/f/conversation/prepare"
         upstream_model, thinking_effort = self._image_model_settings(model)
         payload = {
             "action": "next",
             "fork_from_shared_post": False,
-            "parent_message_id": new_uuid(),
+            "parent_message_id": parent_message_id or new_uuid(),
             "model": upstream_model,
             "client_prepare_state": "success",
             "timezone_offset_min": -480,
@@ -886,6 +901,12 @@ class OpenAIBackendAPI:
         }
         if thinking_effort:
             payload["thinking_effort"] = thinking_effort
+        if conversation_id:
+            if not parent_message_id:
+                raise RuntimeError("conversation continuation requires parent_message_id")
+            payload["conversation_id"] = conversation_id
+        elif parent_message_id:
+            raise RuntimeError("parent_message_id requires conversation_id")
         response = self.session.post(
             self.base_url + path,
             headers=self._image_headers(path, requirements),
@@ -970,7 +991,9 @@ class OpenAIBackendAPI:
         }
 
     def _start_image_generation(self, prompt: str, requirements: ChatRequirements, conduit_token: str, model: str,
-                                references: Optional[list[Dict[str, Any]]] = None) -> requests.Response:
+                                references: Optional[list[Dict[str, Any]]] = None,
+                                conversation_id: str = "",
+                                parent_message_id: str = "") -> requests.Response:
         """启动图片生成或编辑的 SSE 请求。"""
         upstream_model, thinking_effort = self._image_model_settings(model)
         references = references or []
@@ -1009,7 +1032,7 @@ class OpenAIBackendAPI:
                 "content": content,
                 "metadata": metadata,
             }],
-            "parent_message_id": new_uuid(),
+            "parent_message_id": parent_message_id or new_uuid(),
             "model": upstream_model,
             "client_prepare_state": "sent",
             "timezone_offset_min": -480,
@@ -1034,6 +1057,12 @@ class OpenAIBackendAPI:
         }
         if thinking_effort:
             payload["thinking_effort"] = thinking_effort
+        if conversation_id:
+            if not parent_message_id:
+                raise RuntimeError("conversation continuation requires parent_message_id")
+            payload["conversation_id"] = conversation_id
+        elif parent_message_id:
+            raise RuntimeError("parent_message_id requires conversation_id")
         path = "/backend-api/f/conversation"
         response = self.session.post(
             self.base_url + path,
@@ -1052,6 +1081,13 @@ class OpenAIBackendAPI:
                                     timeout=60)
         ensure_ok(response, path)
         return response.json()
+
+    def get_conversation_parent_message_id(self, conversation_id: str) -> str:
+        document = self._get_conversation(conversation_id)
+        parent_message_id = str(document.get("current_node") or "").strip()
+        if not parent_message_id:
+            raise RuntimeError("upstream conversation has no authoritative current_node")
+        return parent_message_id
 
     def delete_conversation(self, conversation_id: str) -> Dict[str, Any]:
         """删除本地对话记录。"""
@@ -2563,17 +2599,32 @@ class OpenAIBackendAPI:
             images: Optional[list[str]] = None,
             system_hints: Optional[list[str]] = None,
             thinking_effort: str = "",
+            conversation_id: str = "",
+            parent_message_id: str = "",
     ) -> Iterator[str]:
         system_hints = system_hints or []
         if "picture_v2" in system_hints:
-            yield from self._stream_picture_conversation(prompt, model, images or [])
+            yield from self._stream_picture_conversation(
+                prompt,
+                model,
+                images or [],
+                conversation_id=conversation_id,
+                parent_message_id=parent_message_id,
+            )
             return
 
         normalized = messages or [{"role": "user", "content": prompt}]
         self._bootstrap()
         requirements = self._get_chat_requirements()
         path, timezone = self._chat_target()
-        payload = self._conversation_payload(normalized, model, timezone, thinking_effort=thinking_effort)
+        payload = self._conversation_payload(
+            normalized,
+            model,
+            timezone,
+            thinking_effort=thinking_effort,
+            conversation_id=conversation_id,
+            parent_message_id=parent_message_id,
+        )
         response = self.session.post(
             self.base_url + path,
             headers=self._conversation_headers(path, requirements),
@@ -2600,6 +2651,8 @@ class OpenAIBackendAPI:
             prompt: str,
             model: str,
             images: list[str],
+            conversation_id: str = "",
+            parent_message_id: str = "",
     ) -> Iterator[str]:
         if not self.access_token:
             raise RuntimeError("access_token is required for image endpoints")
@@ -2610,9 +2663,23 @@ class OpenAIBackendAPI:
         self._report_progress("getting_token")
         requirements = self._get_chat_requirements()
         self._report_progress("preparing_conversation")
-        conduit_token = self._prepare_image_conversation(prompt, requirements, model)
+        conduit_token = self._prepare_image_conversation(
+            prompt,
+            requirements,
+            model,
+            conversation_id=conversation_id,
+            parent_message_id=parent_message_id,
+        )
         self._report_progress("starting_generation")
-        response = self._start_image_generation(prompt, requirements, conduit_token, model, references)
+        response = self._start_image_generation(
+            prompt,
+            requirements,
+            conduit_token,
+            model,
+            references,
+            conversation_id=conversation_id,
+            parent_message_id=parent_message_id,
+        )
         self._report_progress("generating")
         yield from self._iter_sse_payloads_capped(response, float(config.image_poll_timeout_secs))
 

--- a/services/protocol/conversation.py
+++ b/services/protocol/conversation.py
@@ -37,6 +37,7 @@ class ImageGenerationError(Exception):
         account_email: str = "",
         conversation_id: str = "",
         provider_binding_id: str = "",
+        provider_account_identity: str = "",
         parent_message_id: str = "",
     ) -> None:
         super().__init__(message)
@@ -47,6 +48,7 @@ class ImageGenerationError(Exception):
         self.account_email = account_email
         self.conversation_id = conversation_id
         self.provider_binding_id = provider_binding_id
+        self.provider_account_identity = provider_account_identity
         self.parent_message_id = parent_message_id
 
     def to_openai_error(self) -> dict[str, Any]:
@@ -312,6 +314,8 @@ class ConversationRequest:
     message_as_error: bool = False
     progress_callback: Any = None  # Callable[[str], None] | None
     provider_binding_id: str = ""
+    provider_account_identity: str = ""
+    client_conversation_id: str = ""
     conversation_id: str = ""
     parent_message_id: str = ""
     retain_conversation: bool = False
@@ -342,6 +346,7 @@ class ImageOutput:
     account_email: str = ""
     conversation_id: str = ""
     provider_binding_id: str = ""
+    provider_account_identity: str = ""
     parent_message_id: str = ""
 
     def to_chunk(self) -> dict[str, Any]:
@@ -361,6 +366,8 @@ class ImageOutput:
             chunk["_conversation_id"] = self.conversation_id
         if self.provider_binding_id:
             chunk["_provider_binding_id"] = self.provider_binding_id
+        if self.provider_account_identity:
+            chunk["_provider_account_identity"] = self.provider_account_identity
         if self.parent_message_id:
             chunk["_parent_message_id"] = self.parent_message_id
         if self.kind == "message":
@@ -1332,24 +1339,46 @@ def _generate_bound_single_image(
             conversation_id=request.conversation_id,
             parent_message_id=request.parent_message_id,
         )
+    if not request.client_conversation_id:
+        raise ImageGenerationError(
+            "client_conversation_id is required for retained conversation binding",
+            code="CONVERSATION_BINDING_CONTRACT_INVALID",
+            provider_binding_id=request.provider_binding_id,
+            provider_account_identity=request.provider_account_identity,
+            conversation_id=request.conversation_id,
+            parent_message_id=request.parent_message_id,
+        )
     token = ""
     binding_id = request.provider_binding_id
+    account_identity = request.provider_account_identity
     try:
         if binding_id:
+            authoritative_identity = account_service.get_bound_account_identity(binding_id)
+            if not account_identity or authoritative_identity != account_identity:
+                raise ImageGenerationError(
+                    "provider account identity changed",
+                    code="CONVERSATION_BINDING_MISMATCH",
+                    provider_binding_id=binding_id,
+                    provider_account_identity=account_identity,
+                    conversation_id=request.conversation_id,
+                    parent_message_id=request.parent_message_id,
+                )
             token = account_service.acquire_bound_image_access_token(
                 binding_id,
                 image_model=request.model,
             )
         else:
-            binding_id, token = account_service.create_conversation_binding(
+            binding_id, account_identity, token = account_service.create_conversation_binding(
                 image_model=request.model,
             )
             request.provider_binding_id = binding_id
+            request.provider_account_identity = account_identity
     except RuntimeError as exc:
         raise ImageGenerationError(
             str(exc) or "conversation binding unavailable",
             code="CONVERSATION_BINDING_UNAVAILABLE",
             provider_binding_id=binding_id,
+            provider_account_identity=account_identity,
             conversation_id=request.conversation_id,
             parent_message_id=request.parent_message_id,
         ) from exc
@@ -1360,7 +1389,7 @@ def _generate_bound_single_image(
     outputs: list[ImageOutput] = []
     last_conversation_id = request.conversation_id
     try:
-        with account_service.conversation_binding_lock(binding_id):
+        with account_service.conversation_binding_lock(binding_id, request.client_conversation_id):
             backend = OpenAIBackendAPI(access_token=token)
             if request.progress_callback:
                 backend.progress_callback = request.progress_callback
@@ -1369,6 +1398,7 @@ def _generate_bound_single_image(
                     last_conversation_id = output.conversation_id or last_conversation_id
                     output.account_email = output.account_email or account_email
                     output.provider_binding_id = binding_id
+                    output.provider_account_identity = account_identity
                     if output.kind == "message" and request.message_as_error:
                         raise ImageGenerationError(
                             output.text or "Image generation was rejected by upstream policy.",
@@ -1406,6 +1436,7 @@ def _generate_bound_single_image(
                 next_parent_message_id = backend.get_conversation_parent_message_id(last_conversation_id)
                 for output in outputs:
                     output.provider_binding_id = binding_id
+                    output.provider_account_identity = account_identity
                     output.conversation_id = last_conversation_id
                     output.parent_message_id = next_parent_message_id
                 account_service.mark_image_result(token, True)
@@ -1421,6 +1452,7 @@ def _generate_bound_single_image(
                         pass
                 if isinstance(exc, ImageGenerationError):
                     exc.provider_binding_id = binding_id
+                    exc.provider_account_identity = account_identity
                     exc.conversation_id = conversation_id
                     exc.parent_message_id = parent_message_id
                     raise
@@ -1429,6 +1461,7 @@ def _generate_bound_single_image(
                     code="CONVERSATION_OUTCOME_UNKNOWN" if conversation_id else "CONVERSATION_BINDING_UNAVAILABLE",
                     account_email=account_email,
                     provider_binding_id=binding_id,
+                    provider_account_identity=account_identity,
                     conversation_id=conversation_id,
                     parent_message_id=parent_message_id,
                 ) from exc
@@ -1778,6 +1811,7 @@ def collect_image_outputs(outputs: Iterable[ImageOutput]) -> dict[str, Any]:
     progress_parts: list[str] = []
     account_email = ""
     provider_binding_id = ""
+    provider_account_identity = ""
     conversation_id = ""
     parent_message_id = ""
     for output in outputs:
@@ -1785,6 +1819,7 @@ def collect_image_outputs(outputs: Iterable[ImageOutput]) -> dict[str, Any]:
         if output.account_email and not account_email:
             account_email = output.account_email
         provider_binding_id = output.provider_binding_id or provider_binding_id
+        provider_account_identity = output.provider_account_identity or provider_account_identity
         conversation_id = output.conversation_id or conversation_id
         parent_message_id = output.parent_message_id or parent_message_id
         if output.kind == "progress" and output.text:
@@ -1803,6 +1838,8 @@ def collect_image_outputs(outputs: Iterable[ImageOutput]) -> dict[str, Any]:
         result["_account_email"] = account_email
     if provider_binding_id:
         result["_provider_binding_id"] = provider_binding_id
+    if provider_account_identity:
+        result["_provider_account_identity"] = provider_account_identity
     if conversation_id:
         result["_conversation_id"] = conversation_id
     if parent_message_id:

--- a/services/protocol/conversation.py
+++ b/services/protocol/conversation.py
@@ -36,6 +36,8 @@ class ImageGenerationError(Exception):
         param: str | None = None,
         account_email: str = "",
         conversation_id: str = "",
+        provider_binding_id: str = "",
+        parent_message_id: str = "",
     ) -> None:
         super().__init__(message)
         self.status_code = status_code
@@ -44,6 +46,8 @@ class ImageGenerationError(Exception):
         self.param = param
         self.account_email = account_email
         self.conversation_id = conversation_id
+        self.provider_binding_id = provider_binding_id
+        self.parent_message_id = parent_message_id
 
     def to_openai_error(self) -> dict[str, Any]:
         error_dict = {
@@ -307,6 +311,10 @@ class ConversationRequest:
     base_url: str | None = None
     message_as_error: bool = False
     progress_callback: Any = None  # Callable[[str], None] | None
+    provider_binding_id: str = ""
+    conversation_id: str = ""
+    parent_message_id: str = ""
+    retain_conversation: bool = False
 
 
 @dataclass
@@ -333,6 +341,8 @@ class ImageOutput:
     data: list[dict[str, Any]] = field(default_factory=list)
     account_email: str = ""
     conversation_id: str = ""
+    provider_binding_id: str = ""
+    parent_message_id: str = ""
 
     def to_chunk(self) -> dict[str, Any]:
         chunk: dict[str, Any] = {
@@ -349,6 +359,10 @@ class ImageOutput:
             chunk["_account_email"] = self.account_email
         if self.conversation_id:
             chunk["_conversation_id"] = self.conversation_id
+        if self.provider_binding_id:
+            chunk["_provider_binding_id"] = self.provider_binding_id
+        if self.parent_message_id:
+            chunk["_parent_message_id"] = self.parent_message_id
         if self.kind == "message":
             chunk.update({
                 "object": "image.generation.message",
@@ -689,6 +703,8 @@ def conversation_events(
     size: str | None = None,
     quality: str = "auto",
     thinking_effort: str = "",
+    conversation_id: str = "",
+    parent_message_id: str = "",
 ) -> Iterator[dict[str, Any]]:
     normalized = normalize_messages(messages or ([{"role": "user", "content": prompt}] if prompt else []))
     image_model = is_supported_image_model(model)
@@ -702,6 +718,8 @@ def conversation_events(
         images=images if image_model else None,
         system_hints=["picture_v2"] if image_model else None,
         thinking_effort=thinking_effort if not image_model else "",
+        conversation_id=conversation_id,
+        parent_message_id=parent_message_id,
     )
     yield from iter_conversation_payloads(payloads, history_text, history_messages)
 
@@ -815,7 +833,10 @@ def _remove_image_conversation_later(
         conversation_id: str,
         *,
         success: bool,
+        retain_conversation: bool = False,
 ) -> None:
+    if retain_conversation:
+        return
     if not conversation_id:
         return
     if not (config.image_remove_conversation_always or (success and config.image_remove_conversation_after_result)):
@@ -849,6 +870,8 @@ def stream_image_outputs(
             images=request.images or [],
             size=request.size,
             quality=request.quality,
+            conversation_id=request.conversation_id,
+            parent_message_id=request.parent_message_id,
     ):
         last = event
         if event.get("type") == "conversation.delta":
@@ -1287,6 +1310,134 @@ def stream_codex_image_outputs(
     raise ImageGenerationError("No image result found in response")
 
 
+def _generate_bound_single_image(
+        request: ConversationRequest,
+        index: int,
+        total: int,
+) -> list[ImageOutput]:
+    """Run one durable conversation step without account or conversation failover."""
+    if is_codex_image_model(request.model):
+        raise ImageGenerationError(
+            "conversation binding is not supported for the selected image model",
+            code="CONVERSATION_BINDING_UNSUPPORTED",
+            provider_binding_id=request.provider_binding_id,
+            conversation_id=request.conversation_id,
+            parent_message_id=request.parent_message_id,
+        )
+    if bool(request.conversation_id) != bool(request.parent_message_id):
+        raise ImageGenerationError(
+            "conversation continuation requires conversation_id and parent_message_id",
+            code="CONVERSATION_BINDING_CONTRACT_INVALID",
+            provider_binding_id=request.provider_binding_id,
+            conversation_id=request.conversation_id,
+            parent_message_id=request.parent_message_id,
+        )
+    token = ""
+    binding_id = request.provider_binding_id
+    try:
+        if binding_id:
+            token = account_service.acquire_bound_image_access_token(
+                binding_id,
+                image_model=request.model,
+            )
+        else:
+            binding_id, token = account_service.create_conversation_binding(
+                image_model=request.model,
+            )
+            request.provider_binding_id = binding_id
+    except RuntimeError as exc:
+        raise ImageGenerationError(
+            str(exc) or "conversation binding unavailable",
+            code="CONVERSATION_BINDING_UNAVAILABLE",
+            provider_binding_id=binding_id,
+            conversation_id=request.conversation_id,
+            parent_message_id=request.parent_message_id,
+        ) from exc
+
+    account = account_service.get_account(token) or {}
+    account_email = str(account.get("email") or "").strip()
+    backend: OpenAIBackendAPI | None = None
+    outputs: list[ImageOutput] = []
+    last_conversation_id = request.conversation_id
+    try:
+        with account_service.conversation_binding_lock(binding_id):
+            backend = OpenAIBackendAPI(access_token=token)
+            if request.progress_callback:
+                backend.progress_callback = request.progress_callback
+            try:
+                for output in stream_image_outputs(backend, request, index, total):
+                    last_conversation_id = output.conversation_id or last_conversation_id
+                    output.account_email = output.account_email or account_email
+                    output.provider_binding_id = binding_id
+                    if output.kind == "message" and request.message_as_error:
+                        raise ImageGenerationError(
+                            output.text or "Image generation was rejected by upstream policy.",
+                            status_code=400,
+                            error_type="invalid_request_error",
+                            code="content_policy_violation",
+                            account_email=account_email,
+                            provider_binding_id=binding_id,
+                            conversation_id=last_conversation_id,
+                        )
+                    outputs.append(output)
+                if not last_conversation_id:
+                    raise ImageGenerationError(
+                        "upstream response has no conversation_id",
+                        code="CONVERSATION_OUTCOME_UNKNOWN",
+                        account_email=account_email,
+                        provider_binding_id=binding_id,
+                    )
+                if request.conversation_id and last_conversation_id != request.conversation_id:
+                    raise ImageGenerationError(
+                        "upstream conversation identity changed",
+                        code="CONVERSATION_BINDING_MISMATCH",
+                        account_email=account_email,
+                        provider_binding_id=binding_id,
+                        conversation_id=last_conversation_id,
+                    )
+                if not any(output.kind == "result" for output in outputs):
+                    raise ImageGenerationError(
+                        "upstream completed without generating images",
+                        code="no_image_generated",
+                        account_email=account_email,
+                        provider_binding_id=binding_id,
+                        conversation_id=last_conversation_id,
+                    )
+                next_parent_message_id = backend.get_conversation_parent_message_id(last_conversation_id)
+                for output in outputs:
+                    output.provider_binding_id = binding_id
+                    output.conversation_id = last_conversation_id
+                    output.parent_message_id = next_parent_message_id
+                account_service.mark_image_result(token, True)
+                return outputs
+            except Exception as exc:
+                account_service.mark_image_result(token, False)
+                conversation_id = str(getattr(exc, "conversation_id", "") or last_conversation_id)
+                parent_message_id = str(getattr(exc, "parent_message_id", "") or "")
+                if conversation_id and backend is not None and not parent_message_id:
+                    try:
+                        parent_message_id = backend.get_conversation_parent_message_id(conversation_id)
+                    except Exception:
+                        pass
+                if isinstance(exc, ImageGenerationError):
+                    exc.provider_binding_id = binding_id
+                    exc.conversation_id = conversation_id
+                    exc.parent_message_id = parent_message_id
+                    raise
+                raise ImageGenerationError(
+                    image_stream_error_message(str(exc)),
+                    code="CONVERSATION_OUTCOME_UNKNOWN" if conversation_id else "CONVERSATION_BINDING_UNAVAILABLE",
+                    account_email=account_email,
+                    provider_binding_id=binding_id,
+                    conversation_id=conversation_id,
+                    parent_message_id=parent_message_id,
+                ) from exc
+    finally:
+        if backend is not None:
+            backend.close()
+        account_service.release_image_slot(token)
+
+
 def _generate_single_image(
         request: ConversationRequest,
         index: int,
@@ -1297,6 +1448,9 @@ def _generate_single_image(
     该函数在独立线程中运行，每个线程使用不同的账号，
     实现并行生图，避免串行超时阻塞。
     """
+    if request.retain_conversation:
+        return _generate_bound_single_image(request, index, total)
+
     # 模型返回文本而非图片的最大重试次数
     MAX_TEXT_REPLY_RETRIES = 3
     # TLS 连接错误最大重试次数
@@ -1623,10 +1777,16 @@ def collect_image_outputs(outputs: Iterable[ImageOutput]) -> dict[str, Any]:
     message = ""
     progress_parts: list[str] = []
     account_email = ""
+    provider_binding_id = ""
+    conversation_id = ""
+    parent_message_id = ""
     for output in outputs:
         created = created or output.created
         if output.account_email and not account_email:
             account_email = output.account_email
+        provider_binding_id = output.provider_binding_id or provider_binding_id
+        conversation_id = output.conversation_id or conversation_id
+        parent_message_id = output.parent_message_id or parent_message_id
         if output.kind == "progress" and output.text:
             progress_parts.append(output.text)
         elif output.kind == "message":
@@ -1641,4 +1801,10 @@ def collect_image_outputs(outputs: Iterable[ImageOutput]) -> dict[str, Any]:
             result["message"] = text
     if account_email:
         result["_account_email"] = account_email
+    if provider_binding_id:
+        result["_provider_binding_id"] = provider_binding_id
+    if conversation_id:
+        result["_conversation_id"] = conversation_id
+    if parent_message_id:
+        result["_parent_message_id"] = parent_message_id
     return result

--- a/services/protocol/openai_v1_image_edit.py
+++ b/services/protocol/openai_v1_image_edit.py
@@ -75,6 +75,8 @@ def handle(body: dict[str, Any]) -> dict[str, Any] | Iterator[dict[str, Any]]:
         message_as_error=True,
         progress_callback=progress_callback,
         provider_binding_id=str(body.get("provider_binding_id") or ""),
+        provider_account_identity=str(body.get("provider_account_identity") or ""),
+        client_conversation_id=str(body.get("client_conversation_id") or ""),
         conversation_id=str(body.get("conversation_id") or ""),
         parent_message_id=str(body.get("parent_message_id") or ""),
         retain_conversation=bool(body.get("retain_conversation")),

--- a/services/protocol/openai_v1_image_edit.py
+++ b/services/protocol/openai_v1_image_edit.py
@@ -74,6 +74,10 @@ def handle(body: dict[str, Any]) -> dict[str, Any] | Iterator[dict[str, Any]]:
         images=encoded_images,
         message_as_error=True,
         progress_callback=progress_callback,
+        provider_binding_id=str(body.get("provider_binding_id") or ""),
+        conversation_id=str(body.get("conversation_id") or ""),
+        parent_message_id=str(body.get("parent_message_id") or ""),
+        retain_conversation=bool(body.get("retain_conversation")),
     ))
     if body.get("stream"):
         return stream_image_chunks(outputs)

--- a/services/protocol/openai_v1_image_generations.py
+++ b/services/protocol/openai_v1_image_generations.py
@@ -31,6 +31,10 @@ def handle(body: dict[str, Any]) -> dict[str, Any] | Iterator[dict[str, Any]]:
         base_url=base_url,
         message_as_error=True,
         progress_callback=progress_callback,
+        provider_binding_id=str(body.get("provider_binding_id") or ""),
+        conversation_id=str(body.get("conversation_id") or ""),
+        parent_message_id=str(body.get("parent_message_id") or ""),
+        retain_conversation=bool(body.get("retain_conversation")),
     ))
     if body.get("stream"):
         return stream_image_chunks(outputs)

--- a/services/protocol/openai_v1_image_generations.py
+++ b/services/protocol/openai_v1_image_generations.py
@@ -32,6 +32,8 @@ def handle(body: dict[str, Any]) -> dict[str, Any] | Iterator[dict[str, Any]]:
         message_as_error=True,
         progress_callback=progress_callback,
         provider_binding_id=str(body.get("provider_binding_id") or ""),
+        provider_account_identity=str(body.get("provider_account_identity") or ""),
+        client_conversation_id=str(body.get("client_conversation_id") or ""),
         conversation_id=str(body.get("conversation_id") or ""),
         parent_message_id=str(body.get("parent_message_id") or ""),
         retain_conversation=bool(body.get("retain_conversation")),

--- a/test/test_account_image_capabilities.py
+++ b/test/test_account_image_capabilities.py
@@ -30,7 +30,7 @@ class AccountCapabilityTests(unittest.TestCase):
                 lambda access_token, event="fetch_remote_info": service.get_account(access_token)
             )
 
-            binding_id, first_token = service.create_conversation_binding(
+            binding_id, account_identity, first_token = service.create_conversation_binding(
                 image_model="gpt-image-2"
             )
             service.release_image_slot(first_token)
@@ -42,6 +42,7 @@ class AccountCapabilityTests(unittest.TestCase):
 
             self.assertTrue(binding_id.startswith("cb_"))
             self.assertEqual(bound_token, first_token)
+            self.assertEqual(service.get_bound_account_identity(binding_id), account_identity)
             service.update_account(first_token, {"status": "异常", "quota": 0})
             with self.assertRaisesRegex(RuntimeError, "conversation binding unavailable"):
                 service.acquire_bound_image_access_token(
@@ -59,11 +60,11 @@ class AccountCapabilityTests(unittest.TestCase):
                 lambda access_token, event="fetch_remote_info": service.get_account(access_token)
             )
 
-            first_binding, first_token = service.create_conversation_binding(
+            first_binding, _, first_token = service.create_conversation_binding(
                 image_model="gpt-image-2"
             )
             service.release_image_slot(first_token)
-            second_binding, second_token = service.create_conversation_binding(
+            second_binding, _, second_token = service.create_conversation_binding(
                 image_model="gpt-image-2"
             )
             service.release_image_slot(second_token)

--- a/test/test_account_image_capabilities.py
+++ b/test/test_account_image_capabilities.py
@@ -17,6 +17,64 @@ from utils.helper import anonymize_token, split_image_model
 
 
 class AccountCapabilityTests(unittest.TestCase):
+    def test_conversation_binding_pins_one_account_and_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            service = AccountService(JSONStorageBackend(Path(tmp_dir) / "accounts.json"))
+            service.add_account_items(
+                [
+                    {"access_token": "token-a", "type": "Pro", "status": "正常", "quota": 3},
+                    {"access_token": "token-b", "type": "Pro", "status": "正常", "quota": 3},
+                ]
+            )
+            service.fetch_remote_info = (
+                lambda access_token, event="fetch_remote_info": service.get_account(access_token)
+            )
+
+            binding_id, first_token = service.create_conversation_binding(
+                image_model="gpt-image-2"
+            )
+            service.release_image_slot(first_token)
+            bound_token = service.acquire_bound_image_access_token(
+                binding_id,
+                image_model="gpt-image-2",
+            )
+            service.release_image_slot(bound_token)
+
+            self.assertTrue(binding_id.startswith("cb_"))
+            self.assertEqual(bound_token, first_token)
+            service.update_account(first_token, {"status": "异常", "quota": 0})
+            with self.assertRaisesRegex(RuntimeError, "conversation binding unavailable"):
+                service.acquire_bound_image_access_token(
+                    binding_id,
+                    image_model="gpt-image-2",
+                )
+
+    def test_separate_conversations_get_distinct_bindings_on_the_same_account(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            service = AccountService(JSONStorageBackend(Path(tmp_dir) / "accounts.json"))
+            service.add_account_items(
+                [{"access_token": "token-a", "type": "Pro", "status": "正常", "quota": 3}]
+            )
+            service.fetch_remote_info = (
+                lambda access_token, event="fetch_remote_info": service.get_account(access_token)
+            )
+
+            first_binding, first_token = service.create_conversation_binding(
+                image_model="gpt-image-2"
+            )
+            service.release_image_slot(first_token)
+            second_binding, second_token = service.create_conversation_binding(
+                image_model="gpt-image-2"
+            )
+            service.release_image_slot(second_token)
+
+            self.assertNotEqual(first_binding, second_binding)
+            self.assertEqual(first_token, second_token)
+            self.assertIsNot(
+                service.conversation_binding_lock(first_binding),
+                service.conversation_binding_lock(second_binding),
+            )
+
     def test_image_accounts_require_positive_quota(self) -> None:
         self.assertFalse(
             AccountService._is_image_account_available(

--- a/test/test_conversation_continuation.py
+++ b/test/test_conversation_continuation.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import unittest
+from contextlib import nullcontext
+from unittest import mock
+
+from services.openai_backend_api import OpenAIBackendAPI
+from services.conversation_binding_service import ConversationBindingService
+from services.protocol.conversation import (
+    ConversationRequest,
+    ImageGenerationError,
+    ImageOutput,
+    _generate_bound_single_image,
+)
+
+
+class ConversationContinuationPayloadTests(unittest.TestCase):
+    def test_continuation_sends_exact_conversation_and_parent(self) -> None:
+        backend = object.__new__(OpenAIBackendAPI)
+
+        payload = backend._conversation_payload(
+            [{"role": "user", "content": "continue"}],
+            "auto",
+            "UTC",
+            conversation_id="conversation-1",
+            parent_message_id="message-1",
+        )
+
+        self.assertEqual(payload["conversation_id"], "conversation-1")
+        self.assertEqual(payload["parent_message_id"], "message-1")
+
+    def test_partial_continuation_cursor_fails_closed(self) -> None:
+        backend = object.__new__(OpenAIBackendAPI)
+
+        with self.assertRaisesRegex(RuntimeError, "requires parent_message_id"):
+            backend._conversation_payload(
+                [{"role": "user", "content": "continue"}],
+                "auto",
+                "UTC",
+                conversation_id="conversation-1",
+            )
+
+    def test_bound_image_uses_exact_account_and_advances_parent(self) -> None:
+        request = ConversationRequest(
+            model="gpt-image-2",
+            prompt="continue",
+            provider_binding_id="cb-account-a",
+            conversation_id="conversation-1",
+            parent_message_id="message-1",
+            retain_conversation=True,
+        )
+
+        class FakeBackend:
+            def __init__(self, access_token: str) -> None:
+                self.access_token = access_token
+                self.progress_callback = None
+
+            def get_conversation_parent_message_id(self, conversation_id: str) -> str:
+                self.test_case.assertEqual(conversation_id, "conversation-1")
+                return "message-2"
+
+            def close(self) -> None:
+                pass
+
+        FakeBackend.test_case = self
+        output = ImageOutput(
+            kind="result",
+            model="gpt-image-2",
+            index=1,
+            total=1,
+            data=[{"url": "image.png"}],
+            conversation_id="conversation-1",
+        )
+        with (
+            mock.patch(
+                "services.protocol.conversation.account_service.acquire_bound_image_access_token",
+                return_value="token-a",
+            ) as acquire,
+            mock.patch(
+                "services.protocol.conversation.account_service.get_available_access_token",
+                side_effect=AssertionError("bound image must not round-robin"),
+            ),
+            mock.patch(
+                "services.protocol.conversation.account_service.get_account",
+                return_value={"email": "a@example.test"},
+            ),
+            mock.patch(
+                "services.protocol.conversation.account_service.conversation_binding_lock",
+                return_value=nullcontext(),
+            ),
+            mock.patch("services.protocol.conversation.account_service.mark_image_result"),
+            mock.patch("services.protocol.conversation.account_service.release_image_slot"),
+            mock.patch("services.protocol.conversation.OpenAIBackendAPI", FakeBackend),
+            mock.patch(
+                "services.protocol.conversation.stream_image_outputs",
+                return_value=iter([output]),
+            ),
+        ):
+            result = _generate_bound_single_image(request, 1, 1)
+
+        acquire.assert_called_once_with("cb-account-a", image_model="gpt-image-2")
+        self.assertEqual(result[0].provider_binding_id, "cb-account-a")
+        self.assertEqual(result[0].conversation_id, "conversation-1")
+        self.assertEqual(result[0].parent_message_id, "message-2")
+
+    def test_unavailable_bound_account_fails_without_fallback(self) -> None:
+        request = ConversationRequest(
+            model="gpt-image-2",
+            provider_binding_id="cb-account-a",
+            conversation_id="conversation-1",
+            parent_message_id="message-1",
+            retain_conversation=True,
+        )
+        with (
+            mock.patch(
+                "services.protocol.conversation.account_service.acquire_bound_image_access_token",
+                side_effect=RuntimeError("conversation binding unavailable"),
+            ),
+            mock.patch(
+                "services.protocol.conversation.account_service.get_available_access_token",
+                side_effect=AssertionError("must not fall back"),
+            ),
+        ):
+            with self.assertRaises(ImageGenerationError) as captured:
+                _generate_bound_single_image(request, 1, 1)
+
+        self.assertEqual(captured.exception.code, "CONVERSATION_BINDING_UNAVAILABLE")
+
+    def test_text_binding_is_created_once_then_reused(self) -> None:
+        service = ConversationBindingService()
+
+        class FakeBackend:
+            def __init__(self, access_token: str) -> None:
+                self.access_token = access_token
+
+            def get_conversation_parent_message_id(self, conversation_id: str) -> str:
+                return "message-2" if conversation_id == "conversation-1" else ""
+
+            def close(self) -> None:
+                pass
+
+        events = [
+            {
+                "type": "conversation.delta",
+                "delta": "ok",
+                "conversation_id": "conversation-1",
+            }
+        ]
+        with (
+            mock.patch(
+                "services.conversation_binding_service.account_service.create_conversation_binding",
+                return_value=("cb-account-a", "token-a"),
+            ) as create_binding,
+            mock.patch(
+                "services.conversation_binding_service.account_service.release_image_slot"
+            ),
+            mock.patch(
+                "services.conversation_binding_service.account_service.get_bound_text_access_token",
+                return_value="token-a",
+            ) as bound_token,
+            mock.patch(
+                "services.conversation_binding_service.account_service.conversation_binding_lock",
+                return_value=nullcontext(),
+            ),
+            mock.patch("services.conversation_binding_service.account_service.mark_text_used"),
+            mock.patch("services.conversation_binding_service.OpenAIBackendAPI", FakeBackend),
+            mock.patch(
+                "services.conversation_binding_service.conversation_events",
+                side_effect=(iter(events), iter(events)),
+            ) as conversation_events,
+        ):
+            first = service.complete_text(
+                {"messages": [{"role": "user", "content": "first"}]}
+            )
+            second = service.complete_text(
+                {
+                    "messages": [{"role": "user", "content": "second"}],
+                    "provider_binding_id": first["provider_binding_id"],
+                    "conversation_id": first["conversation_id"],
+                    "parent_message_id": first["parent_message_id"],
+                }
+            )
+
+        create_binding.assert_called_once()
+        self.assertEqual(bound_token.call_count, 2)
+        self.assertEqual(first["provider_binding_id"], "cb-account-a")
+        self.assertEqual(second["provider_binding_id"], "cb-account-a")
+        self.assertEqual(second["conversation_id"], "conversation-1")
+        self.assertEqual(second["parent_message_id"], "message-2")
+        second_call = conversation_events.call_args_list[1].kwargs
+        self.assertEqual(second_call["conversation_id"], "conversation-1")
+        self.assertEqual(second_call["parent_message_id"], "message-2")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_conversation_continuation.py
+++ b/test/test_conversation_continuation.py
@@ -5,7 +5,7 @@ from contextlib import nullcontext
 from unittest import mock
 
 from services.openai_backend_api import OpenAIBackendAPI
-from services.conversation_binding_service import ConversationBindingService
+from services.conversation_binding_service import ConversationBindingError, ConversationBindingService
 from services.protocol.conversation import (
     ConversationRequest,
     ImageGenerationError,
@@ -45,6 +45,8 @@ class ConversationContinuationPayloadTests(unittest.TestCase):
             model="gpt-image-2",
             prompt="continue",
             provider_binding_id="cb-account-a",
+            provider_account_identity="account-opaque-a",
+            client_conversation_id="workbench-conversation-1",
             conversation_id="conversation-1",
             parent_message_id="message-1",
             retain_conversation=True,
@@ -77,6 +79,10 @@ class ConversationContinuationPayloadTests(unittest.TestCase):
                 return_value="token-a",
             ) as acquire,
             mock.patch(
+                "services.protocol.conversation.account_service.get_bound_account_identity",
+                return_value="account-opaque-a",
+            ),
+            mock.patch(
                 "services.protocol.conversation.account_service.get_available_access_token",
                 side_effect=AssertionError("bound image must not round-robin"),
             ),
@@ -99,6 +105,7 @@ class ConversationContinuationPayloadTests(unittest.TestCase):
             result = _generate_bound_single_image(request, 1, 1)
 
         acquire.assert_called_once_with("cb-account-a", image_model="gpt-image-2")
+        self.assertEqual(result[0].provider_account_identity, "account-opaque-a")
         self.assertEqual(result[0].provider_binding_id, "cb-account-a")
         self.assertEqual(result[0].conversation_id, "conversation-1")
         self.assertEqual(result[0].parent_message_id, "message-2")
@@ -107,6 +114,8 @@ class ConversationContinuationPayloadTests(unittest.TestCase):
         request = ConversationRequest(
             model="gpt-image-2",
             provider_binding_id="cb-account-a",
+            provider_account_identity="account-opaque-a",
+            client_conversation_id="workbench-conversation-1",
             conversation_id="conversation-1",
             parent_message_id="message-1",
             retain_conversation=True,
@@ -149,7 +158,7 @@ class ConversationContinuationPayloadTests(unittest.TestCase):
         with (
             mock.patch(
                 "services.conversation_binding_service.account_service.create_conversation_binding",
-                return_value=("cb-account-a", "token-a"),
+                return_value=("cb-account-a", "account-opaque-a", "token-a"),
             ) as create_binding,
             mock.patch(
                 "services.conversation_binding_service.account_service.release_image_slot"
@@ -158,6 +167,10 @@ class ConversationContinuationPayloadTests(unittest.TestCase):
                 "services.conversation_binding_service.account_service.get_bound_text_access_token",
                 return_value="token-a",
             ) as bound_token,
+            mock.patch(
+                "services.conversation_binding_service.account_service.get_bound_account_identity",
+                return_value="account-opaque-a",
+            ),
             mock.patch(
                 "services.conversation_binding_service.account_service.conversation_binding_lock",
                 return_value=nullcontext(),
@@ -170,12 +183,17 @@ class ConversationContinuationPayloadTests(unittest.TestCase):
             ) as conversation_events,
         ):
             first = service.complete_text(
-                {"messages": [{"role": "user", "content": "first"}]}
+                {
+                    "messages": [{"role": "user", "content": "first"}],
+                    "client_conversation_id": "workbench-conversation-1",
+                }
             )
             second = service.complete_text(
                 {
                     "messages": [{"role": "user", "content": "second"}],
                     "provider_binding_id": first["provider_binding_id"],
+                    "provider_account_identity": first["provider_account_identity"],
+                    "client_conversation_id": "workbench-conversation-1",
                     "conversation_id": first["conversation_id"],
                     "parent_message_id": first["parent_message_id"],
                 }
@@ -184,12 +202,136 @@ class ConversationContinuationPayloadTests(unittest.TestCase):
         create_binding.assert_called_once()
         self.assertEqual(bound_token.call_count, 2)
         self.assertEqual(first["provider_binding_id"], "cb-account-a")
+        self.assertEqual(first["provider_account_identity"], "account-opaque-a")
         self.assertEqual(second["provider_binding_id"], "cb-account-a")
         self.assertEqual(second["conversation_id"], "conversation-1")
         self.assertEqual(second["parent_message_id"], "message-2")
         second_call = conversation_events.call_args_list[1].kwargs
         self.assertEqual(second_call["conversation_id"], "conversation-1")
         self.assertEqual(second_call["parent_message_id"], "message-2")
+
+    def test_project_binding_can_create_independent_conversations_on_same_account(self) -> None:
+        service = ConversationBindingService()
+
+        class FakeBackend:
+            def __init__(self, access_token: str) -> None:
+                self.access_token = access_token
+
+            def get_conversation_parent_message_id(self, conversation_id: str) -> str:
+                return "message-1"
+
+            def close(self) -> None:
+                pass
+
+        events = [{"type": "conversation.delta", "delta": "ok", "conversation_id": "conversation-2"}]
+        with (
+            mock.patch(
+                "services.conversation_binding_service.account_service.create_conversation_binding",
+                side_effect=AssertionError("project binding must not be recreated"),
+            ),
+            mock.patch(
+                "services.conversation_binding_service.account_service.get_bound_account_identity",
+                return_value="account-opaque-a",
+            ),
+            mock.patch(
+                "services.conversation_binding_service.account_service.get_bound_text_access_token",
+                return_value="token-a",
+            ),
+            mock.patch(
+                "services.conversation_binding_service.account_service.conversation_binding_lock",
+                return_value=nullcontext(),
+            ) as binding_lock,
+            mock.patch("services.conversation_binding_service.account_service.mark_text_used"),
+            mock.patch("services.conversation_binding_service.OpenAIBackendAPI", FakeBackend),
+            mock.patch(
+                "services.conversation_binding_service.conversation_events",
+                return_value=iter(events),
+            ),
+        ):
+            result = service.complete_text(
+                {
+                    "messages": [{"role": "user", "content": "new conversation"}],
+                    "provider_binding_id": "cb-account-a",
+                    "provider_account_identity": "account-opaque-a",
+                    "client_conversation_id": "workbench-conversation-2",
+                }
+            )
+
+        binding_lock.assert_called_once_with("cb-account-a", "workbench-conversation-2")
+        self.assertEqual(result["conversation_id"], "conversation-2")
+        self.assertEqual(result["provider_account_identity"], "account-opaque-a")
+
+    def test_provider_account_identity_mismatch_fails_closed(self) -> None:
+        service = ConversationBindingService()
+        with mock.patch(
+            "services.conversation_binding_service.account_service.get_bound_account_identity",
+            return_value="account-opaque-a",
+        ):
+            with self.assertRaises(ConversationBindingError) as captured:
+                service.complete_text(
+                    {
+                        "messages": [{"role": "user", "content": "continue"}],
+                        "provider_binding_id": "cb-account-a",
+                        "provider_account_identity": "account-opaque-b",
+                        "client_conversation_id": "workbench-conversation-1",
+                        "conversation_id": "conversation-1",
+                        "parent_message_id": "message-1",
+                    }
+                )
+
+        self.assertEqual(captured.exception.code, "CONVERSATION_BINDING_MISMATCH")
+
+    def test_initial_unknown_returns_new_account_binding_for_authoritative_storage(self) -> None:
+        service = ConversationBindingService()
+
+        class FakeBackend:
+            def __init__(self, access_token: str) -> None:
+                self.access_token = access_token
+
+            def get_conversation_parent_message_id(self, conversation_id: str) -> str:
+                return "message-1"
+
+            def close(self) -> None:
+                pass
+
+        with (
+            mock.patch(
+                "services.conversation_binding_service.account_service.create_conversation_binding",
+                return_value=("cb-account-a", "account-opaque-a", "token-a"),
+            ),
+            mock.patch(
+                "services.conversation_binding_service.account_service.release_image_slot"
+            ),
+            mock.patch(
+                "services.conversation_binding_service.account_service.get_bound_text_access_token",
+                return_value="token-a",
+            ),
+            mock.patch(
+                "services.conversation_binding_service.account_service.conversation_binding_lock",
+                return_value=nullcontext(),
+            ),
+            mock.patch("services.conversation_binding_service.OpenAIBackendAPI", FakeBackend),
+            mock.patch(
+                "services.conversation_binding_service.conversation_events",
+                return_value=iter(
+                    [{"type": "conversation.done", "conversation_id": "conversation-1"}]
+                ),
+            ),
+        ):
+            with self.assertRaises(ConversationBindingError) as captured:
+                service.complete_text(
+                    {
+                        "messages": [{"role": "user", "content": "first"}],
+                        "client_conversation_id": "workbench-conversation-1",
+                    }
+                )
+
+        self.assertEqual(captured.exception.code, "CONVERSATION_OUTCOME_UNKNOWN")
+        self.assertEqual(captured.exception.provider_binding_id, "cb-account-a")
+        self.assertEqual(
+            captured.exception.provider_account_identity, "account-opaque-a"
+        )
+        self.assertEqual(captured.exception.conversation_id, "conversation-1")
 
 
 if __name__ == "__main__":

--- a/test/test_image_remove_conversation.py
+++ b/test/test_image_remove_conversation.py
@@ -49,6 +49,17 @@ class RemoveImageConversationGateTests(unittest.TestCase):
         _remove_image_conversation_later(backend, "", success=False)
         self.assertFalse(backend.called.wait(0.2))
 
+    def test_retained_workbench_conversation_is_never_removed(self) -> None:
+        config.data = dict(self._saved, image_remove_conversation_always=True)
+        backend = FakeBackend()
+        _remove_image_conversation_later(
+            backend,
+            "conv-1",
+            success=True,
+            retain_conversation=True,
+        )
+        self.assertFalse(backend.called.wait(0.2))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_image_task_service.py
+++ b/test/test_image_task_service.py
@@ -26,6 +26,43 @@ def wait_for_task(service: ImageTaskService, identity: dict[str, object], task_i
 
 
 class ImageTaskServiceTests(unittest.TestCase):
+    def test_image_task_preserves_conversation_continuation_contract(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            captured = {}
+
+            def handler(payload):
+                captured.update(payload)
+                return {
+                    "data": [{"url": "http://example.test/image.png"}],
+                    "_provider_binding_id": "cb_account_a",
+                    "_conversation_id": "conversation-1",
+                    "_parent_message_id": "message-2",
+                }
+
+            service = self.make_service(Path(tmp_dir) / "image_tasks.json", handler)
+            service.submit_generation(
+                OWNER,
+                client_task_id="bound-task",
+                prompt="continue",
+                model="gpt-image-2",
+                size=None,
+                base_url="http://local.test",
+                provider_binding_id="cb_account_a",
+                conversation_id="conversation-1",
+                parent_message_id="message-1",
+                retain_conversation=True,
+            )
+
+            task = wait_for_task(service, OWNER, "bound-task", "success")
+
+            self.assertEqual(captured["provider_binding_id"], "cb_account_a")
+            self.assertEqual(captured["conversation_id"], "conversation-1")
+            self.assertEqual(captured["parent_message_id"], "message-1")
+            self.assertTrue(captured["retain_conversation"])
+            self.assertEqual(task["provider_binding_id"], "cb_account_a")
+            self.assertEqual(task["conversation_id"], "conversation-1")
+            self.assertEqual(task["parent_message_id"], "message-2")
+
     def make_service(self, path: Path, handler=None) -> ImageTaskService:
         return ImageTaskService(
             path,
@@ -143,6 +180,12 @@ class ImageTaskServiceTests(unittest.TestCase):
 
             self.assertEqual([item["status"] for item in result["items"]], ["error", "error"])
             self.assertTrue(all("已中断" in item.get("error", "") for item in result["items"]))
+            self.assertTrue(
+                all(
+                    item.get("error_code") == "CONVERSATION_OUTCOME_UNKNOWN"
+                    for item in result["items"]
+                )
+            )
 
 
 if __name__ == "__main__":

--- a/test/test_image_task_service.py
+++ b/test/test_image_task_service.py
@@ -35,6 +35,7 @@ class ImageTaskServiceTests(unittest.TestCase):
                 return {
                     "data": [{"url": "http://example.test/image.png"}],
                     "_provider_binding_id": "cb_account_a",
+                    "_provider_account_identity": "account_opaque_a",
                     "_conversation_id": "conversation-1",
                     "_parent_message_id": "message-2",
                 }
@@ -48,6 +49,8 @@ class ImageTaskServiceTests(unittest.TestCase):
                 size=None,
                 base_url="http://local.test",
                 provider_binding_id="cb_account_a",
+                provider_account_identity="account_opaque_a",
+                client_conversation_id="workbench-conversation-1",
                 conversation_id="conversation-1",
                 parent_message_id="message-1",
                 retain_conversation=True,
@@ -56,10 +59,13 @@ class ImageTaskServiceTests(unittest.TestCase):
             task = wait_for_task(service, OWNER, "bound-task", "success")
 
             self.assertEqual(captured["provider_binding_id"], "cb_account_a")
+            self.assertEqual(captured["provider_account_identity"], "account_opaque_a")
+            self.assertEqual(captured["client_conversation_id"], "workbench-conversation-1")
             self.assertEqual(captured["conversation_id"], "conversation-1")
             self.assertEqual(captured["parent_message_id"], "message-1")
             self.assertTrue(captured["retain_conversation"])
             self.assertEqual(task["provider_binding_id"], "cb_account_a")
+            self.assertEqual(task["provider_account_identity"], "account_opaque_a")
             self.assertEqual(task["conversation_id"], "conversation-1")
             self.assertEqual(task["parent_message_id"], "message-2")
 


### PR DESCRIPTION
## Scope

Provider-side continuation and stable-account contract paired with Content Generation Binding P0. No deployment or provider write is performed by this PR.

## Exact candidate

- Head: `6039bdb07e0204b463cf1ff089914348312a4829`
- Upstream: `basketikun/chatgpt2api`
- Paired Content candidate: `sunnywang666/cross-border-workbench@603d75e8bc2643b1a7476882c7deaf68e9df4d18`

## Contract under review

- Validate the fixed opaque account identity; do not round-robin on mismatch/unavailable.
- Continue the bound upstream conversation with authoritative parent readback.
- Serialize parent advancement per bound Content conversation while allowing different conversations to proceed independently.
- Retain Workbench-bound upstream conversations after successful image generation/edit.
- Preserve deterministic task readback and UNKNOWN no-blind-replay semantics.
