### PR TITLE
fix(image): retry image download on transient upstream failures

### DIFF
--- a/services/openai_backend_api.py
+++ b/services/openai_backend_api.py
@@ -2546,13 +2546,37 @@ class OpenAIBackendAPI:
                 sediment_ids.extend(item for item in polled_sediment_ids if item and item not in sediment_ids)
         return self._resolve_image_urls(conversation_id, file_ids, sediment_ids)
 
+    # 图片下载失败时的重试间隔（秒），长度即最大重试次数
+    IMAGE_DOWNLOAD_RETRY_DELAYS = (1.0, 2.0)
+
+    def _download_image_with_retry(self, url: str) -> bytes:
+        """下载单张图片，失败时按固定间隔重试，重试用尽后抛出最后一次异常。"""
+        attempts = len(self.IMAGE_DOWNLOAD_RETRY_DELAYS) + 1
+        for attempt in range(1, attempts + 1):
+            try:
+                response = self.session.get(url, timeout=120)
+                ensure_ok(response, "image_download")
+                return response.content
+            except Exception as exc:
+                if attempt >= attempts:
+                    raise
+                delay = self.IMAGE_DOWNLOAD_RETRY_DELAYS[attempt - 1]
+                logger.warning({
+                    "event": "image_download_retry",
+                    "attempt": attempt,
+                    "max_attempts": attempts,
+                    "delay_secs": delay,
+                    "error": repr(exc)[:300],
+                })
+                time.sleep(delay)
+        raise RuntimeError("unreachable")
+
     def download_image_bytes(self, urls: list[str]) -> list[bytes]:
         images = []
         for url in urls:
-            response = self.session.get(url, timeout=120)
-            ensure_ok(response, "image_download")
-            if response.content not in images:
-                images.append(response.content)
+            content = self._download_image_with_retry(url)
+            if content not in images:
+                images.append(content)
         return images
 
     def stream_conversation(

--- a/test/test_image_download_retry.py
+++ b/test/test_image_download_retry.py
@@ -1,0 +1,85 @@
+import unittest
+from unittest import mock
+
+from services.openai_backend_api import OpenAIBackendAPI
+from utils.helper import UpstreamHTTPError
+
+
+class FakeResponse:
+    """模拟 curl_cffi 响应，只提供 ensure_ok 和下载逻辑用到的字段。"""
+
+    def __init__(self, status_code: int, content: bytes = b"", text: str = "") -> None:
+        self.status_code = status_code
+        self.content = content
+        self.text = text
+        self.headers: dict[str, str] = {}
+
+    def json(self):
+        raise ValueError("not json")
+
+
+class FakeSession:
+    """按预设序列依次返回响应或抛出异常，并记录调用次数。"""
+
+    def __init__(self, outcomes) -> None:
+        self.outcomes = list(outcomes)
+        self.calls = 0
+
+    def get(self, url, timeout=None):
+        self.calls += 1
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+def _backend(outcomes) -> OpenAIBackendAPI:
+    backend = OpenAIBackendAPI.__new__(OpenAIBackendAPI)
+    backend.session = FakeSession(outcomes)
+    return backend
+
+
+class ImageDownloadRetryTest(unittest.TestCase):
+    def setUp(self) -> None:
+        patcher = mock.patch("services.openai_backend_api.time.sleep")
+        self.sleep = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_success_first_try_no_retry(self) -> None:
+        backend = _backend([FakeResponse(200, b"img")])
+        self.assertEqual(backend.download_image_bytes(["u"]), [b"img"])
+        self.assertEqual(backend.session.calls, 1)
+        self.sleep.assert_not_called()
+
+    def test_503_then_success(self) -> None:
+        backend = _backend([FakeResponse(503, text="upstream connect error"), FakeResponse(200, b"img")])
+        self.assertEqual(backend.download_image_bytes(["u"]), [b"img"])
+        self.assertEqual(backend.session.calls, 2)
+        self.sleep.assert_called_once_with(1.0)
+
+    def test_connection_error_then_success(self) -> None:
+        backend = _backend([ConnectionError("curl: (7) Connection refused"), FakeResponse(200, b"img")])
+        self.assertEqual(backend.download_image_bytes(["u"]), [b"img"])
+        self.assertEqual(backend.session.calls, 2)
+
+    def test_exhausted_raises_last_error_with_backoff(self) -> None:
+        backend = _backend([
+            FakeResponse(503, text="first"),
+            FakeResponse(502, text="second"),
+            FakeResponse(503, text="third"),
+        ])
+        with self.assertRaises(UpstreamHTTPError) as ctx:
+            backend.download_image_bytes(["u"])
+        self.assertEqual(ctx.exception.status_code, 503)
+        self.assertEqual(ctx.exception.body, "third")
+        self.assertEqual(backend.session.calls, 3)
+        self.assertEqual([c.args[0] for c in self.sleep.call_args_list], [1.0, 2.0])
+
+    def test_dedup_and_multiple_urls(self) -> None:
+        backend = _backend([FakeResponse(200, b"a"), FakeResponse(503), FakeResponse(200, b"a"), FakeResponse(200, b"b")])
+        self.assertEqual(backend.download_image_bytes(["u1", "u2", "u3"]), [b"a", b"b"])
+        self.assertEqual(backend.session.calls, 4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Retry image byte downloads in `download_image_bytes` up to 2 times with 1s/2s backoff on any failure (non-2xx or connection error), instead of failing the whole request on a single GET
- Motivation: in production the image was already generated and its download URL resolved, but the final GET hit a transient 503 from the upstream edge (`upstream connect error or disconnect/reset before headers ... Connection refused`), wasting the generation and the account quota. The outer generation-level retries only match TLS/timeout/token error text, and would regenerate from scratch anyway
- Re-raise the last error unchanged after retries are exhausted, so existing error messages and call logs stay the same
- Log an `image_download_retry` warning per attempt to make the frequency of such hiccups observable
- Add unit tests covering first-try success, 503/connection error followed by success, exhausted retries with backoff, and multi-URL dedup

🤖 Generated with [Claude Code](https://claude.com/claude-code)