### PR TITLE
feat(image): add gpt-image-2.5 image generation support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
++ [新增] 新增 `gpt-image-2.5` / `codex-gpt-image-2.5` 生图模型适配：官网链路别名 `gpt-image-2.5` 支持独立配置上游模型名（留空跟随 `gpt-image-2` 设置）；Codex 链路别名（含 `plus` / `team` / `pro` 前缀）工具模型默认 `gpt-image-2.5-flare`、可切换 `gpt-image-2.5-sunburst`，质量档新增 `xhigh` / `max` 支持。
+
 ## 1.8.0 - 2026-07-28
 
 + [新增] 新增默认请求上游模型名称和默认思考强度配置，支持在设置页面修改，并可通过模型名的 `-standard`、`-extended`、`-max` 后缀覆盖思考强度。

--- a/README.md
+++ b/README.md
@@ -119,18 +119,21 @@ environment:
 - 兼容 `POST /v1/images/edits` 图片编辑接口
 - 兼容面向图片场景的 `POST /v1/chat/completions`
 - 兼容面向图片场景的 `POST /v1/responses`
-- `GET /v1/models` 返回 `gpt-image-2`、`codex-gpt-image-2`、`auto`、`gpt-5`、`gpt-5-1`、`gpt-5-2`、`gpt-5-3`、`gpt-5-3-mini`、
+- `GET /v1/models` 返回 `gpt-image-2`、`gpt-image-2.5`、`codex-gpt-image-2`、`codex-gpt-image-2.5`、`auto`、`gpt-5`、`gpt-5-1`、`gpt-5-2`、`gpt-5-3`、`gpt-5-3-mini`、
   `gpt-5-mini`
 - 支持通过 `n` 返回多张生成结果
 - 支持生成可编辑 PPT 文件
 - 支持生成可编辑 PSD 文件
 - 支持 Codex 中的画图接口逆向，仅 `Plus` / `Team` / `Pro` 订阅可用，模型别名为 `codex-gpt-image-2`，如有需要可自行在其他场景映射回
   `gpt-image-2`，用于和官网画图区分；也就意味着同一账号会同时有官网和 Codex 两份生图额度
+- 支持 ChatGPT Images 2.5：官网画图链路的别名为 `gpt-image-2.5`（上游模型名可在设置页单独配置，留空跟随 `gpt-image-2` 设置）；
+  Codex 链路的别名为 `codex-gpt-image-2.5`（同样支持 `plus` / `team` / `pro` 前缀），工具模型默认 `gpt-image-2.5-flare`、
+  可在设置页切换为 `gpt-image-2.5-sunburst`，质量档额外支持 `xhigh` / `max`
 
 ### 在线画图功能
 
 - 内置在线画图工作台，支持生成、图片编辑与多图组图编辑
-- 支持 `gpt-image-2`、`codex-gpt-image-2`、`auto`、`gpt-5`、`gpt-5-1`、`gpt-5-2`、`gpt-5-3`、`gpt-5-3-mini`、`gpt-5-mini` 模型选择
+- 支持 `gpt-image-2`、`gpt-image-2.5`、`codex-gpt-image-2`、`codex-gpt-image-2.5`、`auto`、`gpt-5`、`gpt-5-1`、`gpt-5-2`、`gpt-5-3`、`gpt-5-3-mini`、`gpt-5-mini` 模型选择
 - 编辑模式支持参考图上传
 - 前端支持多图生成交互
 - 本地保存图片会话历史，支持回看、删除和清空
@@ -196,7 +199,7 @@ curl http://localhost:8000/v1/models \
 
 | 字段   | 说明                                                                                                         |
 |:-----|:-----------------------------------------------------------------------------------------------------------|
-| 返回模型 | `gpt-image-2`、`codex-gpt-image-2`、`auto`、`gpt-5`、`gpt-5-1`、`gpt-5-2`、`gpt-5-3`、`gpt-5-3-mini`、`gpt-5-mini` |
+| 返回模型 | `gpt-image-2`、`gpt-image-2.5`、`codex-gpt-image-2`、`codex-gpt-image-2.5`、`auto`、`gpt-5`、`gpt-5-1`、`gpt-5-2`、`gpt-5-3`、`gpt-5-3-mini`、`gpt-5-mini` |
 | 接入场景 | 可接入 Cherry Studio、New API 等上游或客户端                                                                          |
 
 <br>
@@ -227,7 +230,7 @@ curl http://localhost:8000/v1/images/generations \
 
 | 字段                | 说明                                                 |
 |:------------------|:---------------------------------------------------|
-| `model`           | 图片模型，当前可用值以 `/v1/models` 返回结果为准，推荐使用 `gpt-image-2` |
+| `model`           | 图片模型，当前可用值以 `/v1/models` 返回结果为准，推荐使用 `gpt-image-2`；`gpt-image-2.5` / `codex-gpt-image-2.5` 对应 ChatGPT Images 2.5 |
 | `prompt`          | 图片生成提示词                                            |
 | `n`               | 生成数量，当前后端限制为 `1-4`                                 |
 | `response_format` | 当前请求模型中包含该字段，默认值为 `b64_json`                       |
@@ -272,7 +275,7 @@ curl http://localhost:8000/v1/images/edits \
 
 | 字段          | 说明                                            |
 |:------------|:----------------------------------------------|
-| `model`     | 图片模型， `gpt-image-2`                           |
+| `model`     | 图片模型， `gpt-image-2`（`gpt-image-2.5` / `codex-gpt-image-2.5` 对应 ChatGPT Images 2.5） |
 | `prompt`    | 图片编辑提示词                                       |
 | `n`         | 生成数量，当前后端限制为 `1-4`                            |
 | `image`     | 需要编辑的图片文件，使用 multipart/form-data 上传           |

--- a/docs/feature-status.en.md
+++ b/docs/feature-status.en.md
@@ -8,7 +8,7 @@
 | OpenAI 兼容 `POST /v1/images/edits` | ✅  | 已支持，可上传图片进行编辑。 |
 | 面向图片工作流的 `POST /v1/chat/completions` | ✅  | 已支持图片相关请求。 |
 | 面向图片工作流的 `POST /v1/responses` | ✅  | 已支持图片生成工具调用。 |
-| `GET /v1/models` 接口 | ✅  | 当前返回 `gpt-image-2`、`codex-gpt-image-2`、`auto`、`gpt-5`、`gpt-5-1`、`gpt-5-2`、`gpt-5-3`、`gpt-5-3-mini`、`gpt-5-mini`。 |
+| `GET /v1/models` 接口 | ✅  | 当前返回 `gpt-image-2`、`gpt-image-2.5`、`codex-gpt-image-2`、`codex-gpt-image-2.5`、`auto`、`gpt-5`、`gpt-5-1`、`gpt-5-2`、`gpt-5-3`、`gpt-5-3-mini`、`gpt-5-mini`。 |
 | 同时生成多张图片 | ✅  | 已支持，后端与前端都可进行多图生成。 |
 | 图片并行生成 | ✅  | 多张图片使用独立线程和账号同时生成，可通过 `image_parallel_generation` 配置关闭。 |
 | 图片生成进度追踪 | ✅  | 任务显示当前步骤（上传/预热/获取token/生成中等），支持耗时统计。 |
@@ -18,6 +18,7 @@
 | 前端图片懒加载与滚动优化 | ✅  | LazyImage 懒加载、会话切换滚动位置保存与恢复、bfcache 页面恢复同步。 |
 | 前端图片输入 / 参考图交互 | ✅  | 已支持参考图上传、预览、移除和编辑模式工作流。 |
 | Codex 画图接口逆向 | ✅  | 已支持，仅 `Plus` / `Team` / `Pro` 订阅可用，模型别名为 `codex-gpt-image-2`；如有需要可自行在其他场景映射回 `gpt-image-2`。这是 Codex 逆向链路，用于和官网画图区分，同一账号通常会同时支持官网和 Codex 两份生图额度。 |
+| ChatGPT Images 2.5 生图适配 | ✅  | 官网画图链路别名 `gpt-image-2.5`（上游模型名可在设置页单独配置，留空跟随 `gpt-image-2` 设置）；Codex 链路别名 `codex-gpt-image-2.5`（支持 `plus` / `team` / `pro` 前缀），`image_generation` 工具模型默认 `gpt-image-2.5-flare`，设置页可切换 `gpt-image-2.5-sunburst`，质量档额外支持 `xhigh` / `max`。 |
 | Cherry Studio 接入 | ✅  | 已支持作为绘图接口接入 Cherry Studio。 |
 | New API 接入 | ✅  | 已支持接入 New API。 |
 | 账号池管理 | ✅  | 已支持列表、筛选、批量操作、导出、手动编辑、刷新和删除。 |

--- a/services/config.py
+++ b/services/config.py
@@ -514,6 +514,18 @@ class ConfigStore:
         return str(self.data.get("default_upstream_model_name") or "gpt-5-5").strip()
 
     @property
+    def default_upstream_model_name_25(self) -> str:
+        """gpt-image-2.5 使用的上游模型名称，留空时跟随 default_upstream_model_name。"""
+        return str(self.data.get("default_upstream_model_name_25") or "").strip()
+
+    @property
+    def codex_image_model_25_name(self) -> str:
+        """Codex 链路中 gpt-image-2.5 对应的 image_generation 工具模型名。"""
+        value = str(self.data.get("codex_image_model_25_name") or "gpt-image-2.5-flare").strip().lower()
+        allowed = {"gpt-image-2.5-flare", "gpt-image-2.5-sunburst"}
+        return value if value in allowed else "gpt-image-2.5-flare"
+
+    @property
     def default_thinking_effort(self) -> str:
         value = str(self.data.get("default_thinking_effort") or "auto").strip().lower()
         return value if value in {"auto", "standard", "extended", "max"} else "auto"
@@ -579,6 +591,8 @@ class ConfigStore:
         data["ai_review"] = self.ai_review
         data["global_system_prompt"] = self.global_system_prompt
         data["default_upstream_model_name"] = self.default_upstream_model_name
+        data["default_upstream_model_name_25"] = self.default_upstream_model_name_25
+        data["codex_image_model_25_name"] = self.codex_image_model_25_name
         data["default_thinking_effort"] = self.default_thinking_effort
         data["backup"] = self.get_backup_settings()
         data["image_storage"] = self.get_image_storage_settings()

--- a/services/openai_backend_api.py
+++ b/services/openai_backend_api.py
@@ -69,6 +69,10 @@ DEFAULT_CLIENT_VERSION = "prod-a194cd50d4416d3c0b47c740f206b12ce60f5887"
 DEFAULT_CLIENT_BUILD_NUMBER = "6708908"
 DEFAULT_POW_SCRIPT = "https://chatgpt.com/backend-api/sentinel/sdk.js"
 CODEX_IMAGE_MODEL = "codex-gpt-image-2"
+CODEX_IMAGE_MODEL_25 = "codex-gpt-image-2.5"
+CODEX_IMAGE_MODEL_25_TOOL_NAMES = {"gpt-image-2.5-flare", "gpt-image-2.5-sunburst"}
+CODEX_IMAGE_QUALITY_TIERS = {"auto", "low", "medium", "high"}
+CODEX_IMAGE_25_QUALITY_TIERS = CODEX_IMAGE_QUALITY_TIERS | {"xhigh", "max"}
 CODEX_RESPONSES_MODEL = "gpt-5.5"
 SEARCH_MODEL = "gpt-5-5"
 SEARCH_TIMEOUT_SECS = 300.0
@@ -129,6 +133,23 @@ def _is_content_policy_error(error_msg: str) -> bool:
         return False
     msg_lower = error_msg.lower()
     return any(keyword in msg_lower for keyword in _CONTENT_POLICY_KEYWORDS)
+
+
+def normalize_codex_image_quality(image_model: str, quality: str) -> str:
+    """按 Codex image_generation 工具模型规范化质量档。
+
+    - 2.5 系列工具模型（flare / sunburst）支持 auto/low/medium/high/xhigh/max。
+    - 其余工具模型（如 gpt-image-2）只支持 auto/low/medium/high：
+      xhigh/max 收敛为 high，未知档位保持原值透传（不改变既有行为）。
+    """
+    value = str(quality or "auto").strip().lower() or "auto"
+    allowed = CODEX_IMAGE_25_QUALITY_TIERS if image_model in CODEX_IMAGE_MODEL_25_TOOL_NAMES else CODEX_IMAGE_QUALITY_TIERS
+    if value in allowed:
+        return value
+    if value not in CODEX_IMAGE_25_QUALITY_TIERS:
+        return value
+    # xhigh / max 仅在 2.5 系列有效
+    return "high"
 
 
 @dataclass
@@ -568,7 +589,9 @@ class OpenAIBackendAPI:
             return "auto", ""
         if base_model == "gpt-image-2":
             upstream_model = config.default_upstream_model_name
-        elif base_model == CODEX_IMAGE_MODEL:
+        elif base_model == "gpt-image-2.5":
+            upstream_model = config.default_upstream_model_name_25 or config.default_upstream_model_name
+        elif base_model in {CODEX_IMAGE_MODEL, CODEX_IMAGE_MODEL_25}:
             upstream_model = base_model
         else:
             return "auto", ""
@@ -778,6 +801,7 @@ class OpenAIBackendAPI:
             images: list[str] | None = None,
             size: str | None = None,
             quality: str = "auto",
+            image_model: str = "gpt-image-2",
     ) -> Iterator[Dict[str, Any]]:
         if not self.access_token:
             raise RuntimeError("access_token is required for codex image endpoints")
@@ -790,10 +814,10 @@ class OpenAIBackendAPI:
             "input": self._codex_image_input(prompt, images or []),
             "tools": [{
                 "type": "image_generation",
-                "model": "gpt-image-2",
+                "model": str(image_model or "gpt-image-2"),
                 "action": "edit" if images else "generate",
                 "size": str(size or "1024x1024"),
-                "quality": str(quality or "auto"),
+                "quality": normalize_codex_image_quality(str(image_model or "gpt-image-2"), quality),
                 "output_format": "png",
             }],
             "tool_choice": {"type": "image_generation"},

--- a/services/protocol/conversation.py
+++ b/services/protocol/conversation.py
@@ -16,6 +16,7 @@ from services.config import config
 from services.image_storage_service import image_storage_service
 from services.openai_backend_api import ImageContentPolicyError, ImagePollTimeoutError, OpenAIBackendAPI
 from utils.helper import (
+    CODEX_IMAGE_MODEL_25,
     IMAGE_MODELS,
     extract_image_from_message_content,
     is_codex_image_model,
@@ -1260,6 +1261,14 @@ def _codex_response_images(value: Any) -> list[str]:
     return []
 
 
+def codex_image_tool_model(model: object) -> str:
+    """把本地图片模型名映射为 Codex image_generation 工具模型名。"""
+    _, base_model = split_image_model(model)
+    if base_model == CODEX_IMAGE_MODEL_25:
+        return config.codex_image_model_25_name
+    return "gpt-image-2"
+
+
 def stream_codex_image_outputs(
         backend: OpenAIBackendAPI,
         request: ConversationRequest,
@@ -1271,6 +1280,7 @@ def stream_codex_image_outputs(
         images=request.images or [],
         size=request.size,
         quality=request.quality,
+        image_model=codex_image_tool_model(request.model),
     )))
     if not images:
         raise ImageGenerationError("No image result found in response")

--- a/services/protocol/openai_v1_models.py
+++ b/services/protocol/openai_v1_models.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from services.account_service import account_service
 from services.model_service import model_catalog_service
-from utils.helper import CODEX_IMAGE_MODEL
+from utils.helper import CODEX_IMAGE_MODEL, CODEX_IMAGE_MODEL_25
 
 
 def list_models() -> dict[str, Any]:
@@ -30,14 +30,16 @@ def list_models() -> dict[str, Any]:
 
     if web_image_accounts:
         dynamic_models.add("gpt-image-2")
-    if codex_types & {"Plus", "Team", "Pro"}:
-        dynamic_models.add(CODEX_IMAGE_MODEL)
-    if "Plus" in codex_types:
-        dynamic_models.add(f"plus-{CODEX_IMAGE_MODEL}")
-    if "Team" in codex_types:
-        dynamic_models.add(f"team-{CODEX_IMAGE_MODEL}")
-    if "Pro" in codex_types:
-        dynamic_models.add(f"pro-{CODEX_IMAGE_MODEL}")
+        dynamic_models.add("gpt-image-2.5")
+    for codex_model in (CODEX_IMAGE_MODEL, CODEX_IMAGE_MODEL_25):
+        if codex_types & {"Plus", "Team", "Pro"}:
+            dynamic_models.add(codex_model)
+        if "Plus" in codex_types:
+            dynamic_models.add(f"plus-{codex_model}")
+        if "Team" in codex_types:
+            dynamic_models.add(f"team-{codex_model}")
+        if "Pro" in codex_types:
+            dynamic_models.add(f"pro-{codex_model}")
 
     for model in sorted(dynamic_models):
         if model not in seen:

--- a/test/test_account_image_capabilities.py
+++ b/test/test_account_image_capabilities.py
@@ -70,10 +70,15 @@ class AccountCapabilityTests(unittest.TestCase):
 
     def test_split_image_model_supports_plan_type_prefix(self) -> None:
         self.assertEqual(split_image_model("gpt-image-2"), (None, "gpt-image-2"))
+        self.assertEqual(split_image_model("gpt-image-2.5"), (None, "gpt-image-2.5"))
         self.assertEqual(split_image_model("plus-codex-gpt-image-2"), ("plus", "codex-gpt-image-2"))
         self.assertEqual(split_image_model("team-codex-gpt-image-2"), ("team", "codex-gpt-image-2"))
         self.assertEqual(split_image_model("pro-codex-gpt-image-2"), ("pro", "codex-gpt-image-2"))
+        self.assertEqual(split_image_model("plus-codex-gpt-image-2.5"), ("plus", "codex-gpt-image-2.5"))
+        self.assertEqual(split_image_model("team-codex-gpt-image-2.5"), ("team", "codex-gpt-image-2.5"))
+        self.assertEqual(split_image_model("pro-codex-gpt-image-2.5"), ("pro", "codex-gpt-image-2.5"))
         self.assertEqual(split_image_model("plus-gpt-image-2"), (None, None))
+        self.assertEqual(split_image_model("plus-gpt-image-2.5"), (None, None))
         self.assertEqual(split_image_model("unknown-image-model"), (None, None))
 
     def test_get_available_access_token_filters_by_plan_type(self) -> None:

--- a/test/test_image_model_25.py
+++ b/test/test_image_model_25.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import os
+import unittest
+from unittest import mock
+
+os.environ.setdefault("CHATGPT2API_AUTH_KEY", "test-auth")
+
+import services.openai_backend_api as openai_backend_api
+import services.protocol.conversation as conversation_module
+from services.openai_backend_api import OpenAIBackendAPI, normalize_codex_image_quality
+from services.protocol.conversation import codex_image_tool_model
+from utils.helper import is_codex_image_model, is_supported_image_model
+
+
+class FakeImageConfig:
+    def __init__(
+        self,
+        default: str = "gpt-5-5",
+        default_25: str = "",
+        codex_25: str = "gpt-image-2.5-flare",
+        thinking: str = "auto",
+    ) -> None:
+        self.default_upstream_model_name = default
+        self.default_upstream_model_name_25 = default_25
+        self.codex_image_model_25_name = codex_25
+        self.default_thinking_effort = thinking
+
+
+class ImageModel25SettingTests(unittest.TestCase):
+    def test_image_model_settings_for_gpt_image_2_5_uses_dedicated_upstream_model(self) -> None:
+        with mock.patch.object(
+            openai_backend_api,
+            "config",
+            FakeImageConfig(default_25="gpt-5.6-luna-extended"),
+        ):
+            backend = OpenAIBackendAPI()
+            self.assertEqual(
+                backend._image_model_settings("gpt-image-2.5"),
+                ("gpt-5.6-luna", "extended"),
+            )
+
+    def test_image_model_settings_for_gpt_image_2_5_falls_back_to_default(self) -> None:
+        with mock.patch.object(openai_backend_api, "config", FakeImageConfig(default_25="")):
+            backend = OpenAIBackendAPI()
+            self.assertEqual(
+                backend._image_model_settings("gpt-image-2.5"),
+                ("gpt-5-5", ""),
+            )
+
+    def test_image_model_settings_keeps_existing_mappings(self) -> None:
+        with mock.patch.object(openai_backend_api, "config", FakeImageConfig()):
+            backend = OpenAIBackendAPI()
+            self.assertEqual(backend._image_model_settings("gpt-image-2"), ("gpt-5-5", ""))
+            self.assertEqual(
+                backend._image_model_settings("codex-gpt-image-2"),
+                ("codex-gpt-image-2", ""),
+            )
+            self.assertEqual(
+                backend._image_model_settings("codex-gpt-image-2.5"),
+                ("codex-gpt-image-2.5", ""),
+            )
+            self.assertEqual(backend._image_model_settings("unknown-model"), ("auto", ""))
+
+
+class CodexImageQualityTests(unittest.TestCase):
+    def test_quality_tiers_for_legacy_tool_model(self) -> None:
+        self.assertEqual(normalize_codex_image_quality("gpt-image-2", "auto"), "auto")
+        self.assertEqual(normalize_codex_image_quality("gpt-image-2", "high"), "high")
+        self.assertEqual(normalize_codex_image_quality("gpt-image-2", "xhigh"), "high")
+        self.assertEqual(normalize_codex_image_quality("gpt-image-2", "max"), "high")
+        # 未识别档位保持透传，不改变既有行为
+        self.assertEqual(normalize_codex_image_quality("gpt-image-2", "hd"), "hd")
+        self.assertEqual(normalize_codex_image_quality("gpt-image-2", ""), "auto")
+
+    def test_quality_tiers_for_25_tool_models(self) -> None:
+        for tool_model in ("gpt-image-2.5-flare", "gpt-image-2.5-sunburst"):
+            self.assertEqual(normalize_codex_image_quality(tool_model, "xhigh"), "xhigh")
+            self.assertEqual(normalize_codex_image_quality(tool_model, "max"), "max")
+            self.assertEqual(normalize_codex_image_quality(tool_model, "high"), "high")
+            self.assertEqual(normalize_codex_image_quality(tool_model, ""), "auto")
+
+
+class CodexImageToolModelTests(unittest.TestCase):
+    def test_codex_image_tool_model_maps_25_alias_to_configured_tool_model(self) -> None:
+        with mock.patch.object(
+            conversation_module,
+            "config",
+            FakeImageConfig(codex_25="gpt-image-2.5-sunburst"),
+        ):
+            self.assertEqual(codex_image_tool_model("codex-gpt-image-2.5"), "gpt-image-2.5-sunburst")
+            self.assertEqual(codex_image_tool_model("plus-codex-gpt-image-2.5"), "gpt-image-2.5-sunburst")
+
+    def test_codex_image_tool_model_keeps_default_for_other_models(self) -> None:
+        with mock.patch.object(conversation_module, "config", FakeImageConfig()):
+            self.assertEqual(codex_image_tool_model("codex-gpt-image-2"), "gpt-image-2")
+            self.assertEqual(codex_image_tool_model("gpt-image-2.5"), "gpt-image-2")
+            self.assertEqual(codex_image_tool_model("gpt-image-2"), "gpt-image-2")
+
+
+class ImageModel25HelperTests(unittest.TestCase):
+    def test_new_models_are_supported_and_classified(self) -> None:
+        self.assertTrue(is_supported_image_model("gpt-image-2.5"))
+        self.assertTrue(is_supported_image_model("codex-gpt-image-2.5"))
+        self.assertTrue(is_codex_image_model("codex-gpt-image-2"))
+        self.assertTrue(is_codex_image_model("codex-gpt-image-2.5"))
+        self.assertTrue(is_codex_image_model("pro-codex-gpt-image-2.5"))
+        self.assertFalse(is_codex_image_model("gpt-image-2.5"))
+        self.assertFalse(is_codex_image_model("gpt-image-2"))
+        self.assertFalse(is_supported_image_model("unknown-image-model"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_v1_models.py
+++ b/test/test_v1_models.py
@@ -35,10 +35,15 @@ class ModelListTests(unittest.TestCase):
 
         ids = {item["id"] for item in result["data"]}
         self.assertIn("gpt-image-2", ids)
+        self.assertIn("gpt-image-2.5", ids)
         self.assertIn("codex-gpt-image-2", ids)
+        self.assertIn("codex-gpt-image-2.5", ids)
         self.assertIn("team-codex-gpt-image-2", ids)
+        self.assertIn("team-codex-gpt-image-2.5", ids)
         self.assertNotIn("plus-codex-gpt-image-2", ids)
+        self.assertNotIn("plus-codex-gpt-image-2.5", ids)
         self.assertNotIn("pro-codex-gpt-image-2", ids)
+        self.assertNotIn("pro-codex-gpt-image-2.5", ids)
 
     def test_list_models_does_not_return_codex_models_for_web_plus_accounts(self):
         with (
@@ -59,7 +64,9 @@ class ModelListTests(unittest.TestCase):
 
         ids = {item["id"] for item in result["data"]}
         self.assertIn("gpt-image-2", ids)
+        self.assertIn("gpt-image-2.5", ids)
         self.assertNotIn("codex-gpt-image-2", ids)
+        self.assertNotIn("codex-gpt-image-2.5", ids)
         self.assertNotIn("plus-codex-gpt-image-2", ids)
 
     def test_list_models_function(self):

--- a/utils/helper.py
+++ b/utils/helper.py
@@ -14,12 +14,15 @@ from fastapi import HTTPException
 from services.proxy_service import proxy_settings
 from utils.log import logger
 
-BASE_IMAGE_MODELS = {"gpt-image-2", "codex-gpt-image-2"}
+BASE_IMAGE_MODELS = {"gpt-image-2", "gpt-image-2.5", "codex-gpt-image-2", "codex-gpt-image-2.5"}
 IMAGE_MODEL_PLAN_TYPES = ("plus", "team", "pro")
 CODEX_IMAGE_MODEL = "codex-gpt-image-2"
+CODEX_IMAGE_MODEL_25 = "codex-gpt-image-2.5"
+CODEX_IMAGE_BASE_MODELS = {CODEX_IMAGE_MODEL, CODEX_IMAGE_MODEL_25}
 PREFIXED_CODEX_IMAGE_MODELS = {
-    f"{plan_type}-{CODEX_IMAGE_MODEL}"
+    f"{plan_type}-{codex_model}"
     for plan_type in IMAGE_MODEL_PLAN_TYPES
+    for codex_model in CODEX_IMAGE_BASE_MODELS
 }
 IMAGE_MODELS = BASE_IMAGE_MODELS | PREFIXED_CODEX_IMAGE_MODELS
 PUBLIC_IMAGE_MODELS = BASE_IMAGE_MODELS | PREFIXED_CODEX_IMAGE_MODELS
@@ -116,7 +119,7 @@ def split_image_model(model: object) -> tuple[str | None, str | None]:
         prefix = f"{plan_type}-"
         if normalized.startswith(prefix):
             base_model = normalized[len(prefix):]
-            if base_model == CODEX_IMAGE_MODEL:
+            if base_model in CODEX_IMAGE_BASE_MODELS:
                 return plan_type, base_model
     return None, None
 
@@ -128,7 +131,7 @@ def is_supported_image_model(model: object) -> bool:
 
 def is_codex_image_model(model: object) -> bool:
     _, base_model = split_image_model(model)
-    return base_model == CODEX_IMAGE_MODEL
+    return base_model in CODEX_IMAGE_BASE_MODELS
 
 
 def is_image_chat_request(body: dict[str, object]) -> bool:

--- a/web/src/app/settings/components/api-docs-card.tsx
+++ b/web/src/app/settings/components/api-docs-card.tsx
@@ -215,7 +215,7 @@ const docs: ApiDoc[] = [
   },
 ];
 
-const usableModels = ["gpt-image-2", "codex-gpt-image-2", "auto", "gpt-5", "gpt-5-1", "gpt-5-2", "gpt-5-3", "gpt-5-3-mini", "gpt-5-mini"];
+const usableModels = ["gpt-image-2", "gpt-image-2.5", "codex-gpt-image-2", "codex-gpt-image-2.5", "auto", "gpt-5", "gpt-5-1", "gpt-5-2", "gpt-5-3", "gpt-5-3-mini", "gpt-5-mini"];
 
 function ParamTable({ rows }: { rows: ParamRow[] }) {
   return (

--- a/web/src/app/settings/components/config-card.tsx
+++ b/web/src/app/settings/components/config-card.tsx
@@ -39,6 +39,8 @@ export function ConfigCard() {
   const setBaseUrl = useSettingsStore((state) => state.setBaseUrl);
   const setGlobalSystemPrompt = useSettingsStore((state) => state.setGlobalSystemPrompt);
   const setDefaultUpstreamModelName = useSettingsStore((state) => state.setDefaultUpstreamModelName);
+  const setDefaultUpstreamModelName25 = useSettingsStore((state) => state.setDefaultUpstreamModelName25);
+  const setCodexImageModel25Name = useSettingsStore((state) => state.setCodexImageModel25Name);
   const setDefaultThinkingEffort = useSettingsStore((state) => state.setDefaultThinkingEffort);
   const setSensitiveWordsText = useSettingsStore((state) => state.setSensitiveWordsText);
   const setAIReviewField = useSettingsStore((state) => state.setAIReviewField);
@@ -158,6 +160,34 @@ export function ConfigCard() {
               className="h-10 rounded-xl border-stone-200 bg-white"
             />
             <p className="text-xs text-stone-500">gpt-image-2 发起图片请求时使用的上游模型名称，默认 gpt-5-5。</p>
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm text-stone-700">gpt-image-2.5 上游模型名称</label>
+            <Input
+              value={String(config?.default_upstream_model_name_25 || "")}
+              onChange={(event) => setDefaultUpstreamModelName25(event.target.value)}
+              placeholder="gpt-5-5"
+              className="h-10 rounded-xl border-stone-200 bg-white"
+            />
+            <p className="text-xs text-stone-500">
+              gpt-image-2.5 发起图片请求时使用的上游模型名称，留空则跟随上方 gpt-image-2 设置。
+            </p>
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm text-stone-700">Codex 图片 2.5 工具模型</label>
+            <Select
+              value={String(config?.codex_image_model_25_name || "gpt-image-2.5-flare")}
+              onValueChange={(value) => setCodexImageModel25Name(value)}
+            >
+              <SelectTrigger className="h-10 rounded-xl border-stone-200 bg-white">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="gpt-image-2.5-flare">gpt-image-2.5-flare（默认）</SelectItem>
+                <SelectItem value="gpt-image-2.5-sunburst">gpt-image-2.5-sunburst</SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-stone-500">codex-gpt-image-2.5 调用 Codex 生图工具时使用的模型，默认 gpt-image-2.5-flare。</p>
           </div>
           <div className="space-y-2">
             <label className="text-sm text-stone-700">默认思考强度</label>

--- a/web/src/app/settings/store.ts
+++ b/web/src/app/settings/store.ts
@@ -186,6 +186,8 @@ function normalizeConfig(config: SettingsConfig): SettingsConfig {
     base_url: typeof config.base_url === "string" ? config.base_url : "",
     global_system_prompt: String(config.global_system_prompt || ""),
     default_upstream_model_name: String(config.default_upstream_model_name || "gpt-5-5"),
+    default_upstream_model_name_25: String(config.default_upstream_model_name_25 || ""),
+    codex_image_model_25_name: String(config.codex_image_model_25_name || "gpt-image-2.5-flare"),
     default_thinking_effort: defaultThinkingEffort,
     sensitive_words: Array.isArray(config.sensitive_words) ? config.sensitive_words : [],
     ai_review: {
@@ -309,6 +311,8 @@ type SettingsStore = {
   setBaseUrl: (value: string) => void;
   setGlobalSystemPrompt: (value: string) => void;
   setDefaultUpstreamModelName: (value: string) => void;
+  setDefaultUpstreamModelName25: (value: string) => void;
+  setCodexImageModel25Name: (value: string) => void;
   setDefaultThinkingEffort: (value: "auto" | "standard" | "extended" | "max") => void;
   setSensitiveWordsText: (value: string) => void;
   setAIReviewField: (key: "enabled" | "base_url" | "api_key" | "model" | "prompt", value: string | boolean) => void;
@@ -436,6 +440,8 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
         base_url: String(config.base_url || "").trim(),
         global_system_prompt: String(config.global_system_prompt || "").trim(),
         default_upstream_model_name: String(config.default_upstream_model_name || "gpt-5-5").trim() || "gpt-5-5",
+        default_upstream_model_name_25: String(config.default_upstream_model_name_25 || "").trim(),
+        codex_image_model_25_name: String(config.codex_image_model_25_name || "gpt-image-2.5-flare").trim() || "gpt-image-2.5-flare",
         default_thinking_effort: ["standard", "extended", "max"].includes(String(config.default_thinking_effort))
           ? config.default_thinking_effort
           : "auto",
@@ -614,6 +620,14 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
 
   setDefaultUpstreamModelName: (value) => {
     set((state) => state.config ? { config: { ...state.config, default_upstream_model_name: value } } : {});
+  },
+
+  setDefaultUpstreamModelName25: (value) => {
+    set((state) => state.config ? { config: { ...state.config, default_upstream_model_name_25: value } } : {});
+  },
+
+  setCodexImageModel25Name: (value) => {
+    set((state) => state.config ? { config: { ...state.config, codex_image_model_25_name: value } } : {});
   },
 
   setDefaultThinkingEffort: (value) => {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -156,6 +156,8 @@ export type SettingsConfig = {
   base_url?: string;
   global_system_prompt?: string;
   default_upstream_model_name?: string;
+  default_upstream_model_name_25?: string;
+  codex_image_model_25_name?: string;
   default_thinking_effort?: "auto" | "standard" | "extended" | "max";
   sensitive_words?: string[];
   ai_review?: {


### PR DESCRIPTION
## 变更内容

- 新增官网画图链路别名 `gpt-image-2.5`：沿 `picture_v2` 官网画图管线，上游模型名可独立配置（`default_upstream_model_name_25`），留空时跟随 `gpt-image-2` 的 `default_upstream_model_name` 设置。
- 新增 Codex 链路别名 `codex-gpt-image-2.5`（支持 `plus` / `team` / `pro` 前缀）：Codex `image_generation` 工具模型默认 `gpt-image-2.5-flare`，设置页可切换为 `gpt-image-2.5-sunburst`。
- Codex 质量档扩展：2.5 系列工具模型支持 `xhigh` / `max`；切回 `gpt-image-2` 时 `xhigh` / `max` 自动收敛为 `high`，未知档位保持透传（不改变既有行为）。
- `/v1/models` 按账号类型输出 `gpt-image-2.5` 与 `codex-gpt-image-2.5`（含计划前缀）。
- 设置页新增「gpt-image-2.5 上游模型名称」「Codex 图片 2.5 工具模型」两个可编辑配置项。
- 文档（README / feature-status / CHANGELOG）与单元测试同步更新。

## 兼容性

- 所有入口默认模型仍为 `gpt-image-2`，完全向后兼容。
- 新增可选配置键 `default_upstream_model_name_25`、`codex_image_model_25_name`（config.json 不强制写入，代码层有默认值，缺省时行为与原版一致）。

## 验证

- 单元测试：`test/test_image_model_25.py`（新增）+ `test_account_image_capabilities.py`、`test_v1_models.py`、`test_image_tokens.py` 共 26 项通过。
- 本地启动实测：`/v1/images/generations`、`/v1/chat/completions`、`/v1/responses` 对两个 2.5 别名的路由分流正确（web 链路与 Codex 链路各自匹配账号池）；设置页读写配置回环正常；前端 `next build` 与 `tsc --noEmit` 通过。
- 真实出图效果已由本机账号实测，测试截图见（评论区 / 描述附图）。